### PR TITLE
feat: enhance TOML resolution with capabilities and improve error han…

### DIFF
--- a/lib/stellar/sep1.ts
+++ b/lib/stellar/sep1.ts
@@ -1,5 +1,5 @@
 import { StellarToml } from '@stellar/stellar-sdk'
-import type { Sep1TomlData } from '@/types'
+import type { ResolvedAnchor, Sep1TomlData } from '@/types'
 import { ANCHORS } from './anchors'
 
 // ─── In-memory cache ──────────────────────────────────────────────────────────
@@ -35,31 +35,24 @@ export async function resolveToml(domain: string): Promise<Sep1TomlData> {
     )
   }
 
-  const transferServer = raw['TRANSFER_SERVER_SEP0024']
-  if (!transferServer || typeof transferServer !== 'string') {
-    cache.delete(domain)
-    throw new Error(
-      `Missing TRANSFER_SERVER_SEP0024 in stellar.toml for "${domain}". ` +
-        `This anchor does not support SEP-24.`
-    )
-  }
-
-  const webAuthEndpoint = raw['WEB_AUTH_ENDPOINT']
-  if (!webAuthEndpoint || typeof webAuthEndpoint !== 'string') {
-    cache.delete(domain)
-    throw new Error(
-      `Missing WEB_AUTH_ENDPOINT in stellar.toml for "${domain}". ` +
-        `This anchor does not support SEP-10 authentication.`
-    )
-  }
+  const transferServer = typeof raw['TRANSFER_SERVER_SEP0024'] === 'string' ? raw['TRANSFER_SERVER_SEP0024'] : undefined
+  const webAuthEndpoint = typeof raw['WEB_AUTH_ENDPOINT'] === 'string' ? raw['WEB_AUTH_ENDPOINT'] : undefined
+  const signingKey = typeof raw['SIGNING_KEY'] === 'string' ? raw['SIGNING_KEY'] : undefined
+  const quoteServer = typeof raw['QUOTE_SERVER'] === 'string' ? raw['QUOTE_SERVER'] : undefined
 
   const data: Sep1TomlData = {
     TRANSFER_SERVER_SEP0024: transferServer,
     WEB_AUTH_ENDPOINT: webAuthEndpoint,
-    SIGNING_KEY: typeof raw['SIGNING_KEY'] === 'string' ? raw['SIGNING_KEY'] : undefined,
+    SIGNING_KEY: signingKey,
     CURRENCIES: Array.isArray(raw['CURRENCIES'])
       ? (raw['CURRENCIES'] as Array<{ code: string; issuer?: string }>)
       : undefined,
+    capabilities: {
+      sep10: Boolean(webAuthEndpoint),
+      sep24: Boolean(transferServer),
+      sep38: Boolean(quoteServer),
+      sep12: Boolean(signingKey),
+    },
   }
 
   cache.set(domain, { data, expiresAt: Date.now() + TTL_MS })
@@ -73,6 +66,9 @@ export async function resolveToml(domain: string): Promise<Sep1TomlData> {
  */
 export async function getTransferServer(domain: string): Promise<string> {
   const toml = await resolveToml(domain)
+  if (!toml.TRANSFER_SERVER_SEP0024) {
+    throw new Error(`Anchor "${domain}" does not support SEP-24.`)
+  }
   return toml.TRANSFER_SERVER_SEP0024
 }
 
@@ -81,6 +77,9 @@ export async function getTransferServer(domain: string): Promise<string> {
  */
 export async function getWebAuthEndpoint(domain: string): Promise<string> {
   const toml = await resolveToml(domain)
+  if (!toml.WEB_AUTH_ENDPOINT) {
+    throw new Error(`Anchor "${domain}" does not support SEP-10 authentication.`)
+  }
   return toml.WEB_AUTH_ENDPOINT
 }
 
@@ -90,12 +89,12 @@ export async function getWebAuthEndpoint(domain: string): Promise<string> {
  * Resolves stellar.toml for all known anchors in parallel.
  * Anchors that fail resolution are logged but do not cause the function to throw.
  */
-export async function resolveAllAnchors(): Promise<Record<string, Sep1TomlData>> {
+export async function resolveAllAnchors(): Promise<Record<string, ResolvedAnchor>> {
   const results = await Promise.allSettled(
     ANCHORS.map((anchor) => resolveToml(anchor.homeDomain).then((data) => ({ anchor, data })))
   )
 
-  const resolved: Record<string, Sep1TomlData> = {}
+  const resolved: Record<string, ResolvedAnchor> = {}
 
   for (const result of results) {
     if (result.status === 'fulfilled') {

--- a/tests/lib/sep1.test.ts
+++ b/tests/lib/sep1.test.ts
@@ -29,24 +29,28 @@ describe('resolveToml', () => {
     expect(result.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
   })
 
-  it('throws when TRANSFER_SERVER_SEP0024 is absent', async () => {
+  it('returns sep24 false when TRANSFER_SERVER_SEP0024 is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
     } as never)
 
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
-      /Missing TRANSFER_SERVER_SEP0024.*"cowrie\.exchange"/
-    )
+    const result = await resolveToml('cowrie.exchange')
+
+    expect(result.capabilities.sep24).toBe(false)
+    expect(result.capabilities.sep10).toBe(true)
+    expect(result.TRANSFER_SERVER_SEP0024).toBeUndefined()
   })
 
-  it('throws when WEB_AUTH_ENDPOINT is absent', async () => {
+  it('returns sep10 false when WEB_AUTH_ENDPOINT is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
     } as never)
 
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
-      /Missing WEB_AUTH_ENDPOINT.*"cowrie\.exchange"/
-    )
+    const result = await resolveToml('cowrie.exchange')
+
+    expect(result.capabilities.sep10).toBe(false)
+    expect(result.capabilities.sep24).toBe(true)
+    expect(result.WEB_AUTH_ENDPOINT).toBeUndefined()
   })
 
   it('throws a descriptive error when the network call fails', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -55,13 +55,25 @@ export interface FreighterState {
 
 // ─── SEP-1 ────────────────────────────────────────────────────────────────────
 
+/** Per-anchor protocol capability flags derived from the resolved TOML. */
+export interface AnchorCapabilities {
+  sep10: boolean
+  sep24: boolean
+  sep38: boolean
+  sep12: boolean
+}
+
 /** Relevant fields from a stellar.toml file resolved via SEP-1. */
 export interface Sep1TomlData {
-  TRANSFER_SERVER_SEP0024: string
-  WEB_AUTH_ENDPOINT: string
-  SIGNING_KEY?: string
-  CURRENCIES?: Array<{ code: string; issuer?: string }>
+  TRANSFER_SERVER_SEP0024: string | undefined
+  WEB_AUTH_ENDPOINT: string | undefined
+  SIGNING_KEY: string | undefined
+  CURRENCIES: Array<{ code: string; issuer?: string }> | undefined
+  capabilities: AnchorCapabilities
 }
+
+/** A resolved anchor with protocol capabilities attached. */
+export type ResolvedAnchor = Sep1TomlData
 
 // ─── SEP-10 ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
closes #12

This change updates SEP-1 anchor discovery to compute a typed capability set from resolved `stellar.toml` data instead of throwing immediately when optional SEP fields are missing. It attaches `capabilities` to the resolved anchor shape and lets downstream code filter unsupported anchors gracefully.

 What changed
- index.ts
  - Added `AnchorCapabilities` with `sep10`, `sep24`, `sep38`, `sep12`
  - Extended `Sep1TomlData` to include `capabilities`
  - Added `ResolvedAnchor = Sep1TomlData`

- sep1.ts
  - Changed `resolveToml()` to parse optional `TRANSFER_SERVER_SEP0024`, `WEB_AUTH_ENDPOINT`, `SIGNING_KEY`, and `QUOTE_SERVER`
  - Added capability computation:
    - `sep10` = present `WEB_AUTH_ENDPOINT`
    - `sep24` = present `TRANSFER_SERVER_SEP0024`
    - `sep38` = present `QUOTE_SERVER`
    - `sep12` = present `SIGNING_KEY`
  - Preserved `getTransferServer()` / `getWebAuthEndpoint()` wrappers, but now they throw only when those specific protocols are unavailable
  - `resolveAllAnchors()` now returns `Record<string, ResolvedAnchor>`

- sep1.test.ts
  - Reworked tests to assert capability flags instead of requiring missing fields to throw
  - Added coverage for `sep24: false` when `TRANSFER_SERVER_SEP0024` is absent
  - Added coverage for `sep10: false` when `WEB_AUTH_ENDPOINT` is absent

Why
- Supports the requested behavior: unsupported anchors can be discovered without failing resolution.
- Enables downstream code to skip unsupported anchors instead of crashing.
- Makes protocol support explicit and typed for later SEP-38 / SEP-12 integration.

 Validation
- Updated tests in sep1.test.ts to cover the new capability semantics.
- Local test execution could not complete in the current environment because the workspace Node version is `18.19.1`, while `vitest@4.1.5` / `vite@8.x` require Node `>=20.0.0`.

Files changed
- index.ts
- sep1.ts
- sep1.test.ts