### PR TITLE
add anchor validation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint --fix",
     "typecheck": "tsc --noEmit",
     "type-check": "tsc --noEmit",
+    "validate:anchors": "jiti scripts/validate-anchors.ts",
     "format": "prettier --write \"**/*.{ts,tsx,mjs,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,mjs,json,css,md}\"",
     "test": "vitest run",

--- a/scripts/validate-anchors.ts
+++ b/scripts/validate-anchors.ts
@@ -1,0 +1,271 @@
+/* eslint-disable no-console */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { StellarToml } from '@stellar/stellar-sdk';
+import type { Anchor } from '../types';
+
+const REPORT_PATH = path.resolve(process.cwd(), 'tests/reports/anchor-health.json');
+const STELLAR_TOML_PATH = '/.well-known/stellar.toml';
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 500;
+const DEFAULT_ENV = {
+  NEXT_PUBLIC_STELLAR_NETWORK: 'mainnet',
+  NEXT_PUBLIC_HORIZON_URL: 'https://horizon.stellar.org',
+  NEXT_PUBLIC_USDC_ISSUER: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  NEXT_PUBLIC_APP_NAME: 'Stellar Intel',
+} as const;
+
+type TomlRecord = Record<string, unknown>;
+
+interface AnchorCapabilities {
+  hasTransferServerSep0024: boolean;
+  hasTransferServerSep0006: boolean;
+  hasWebAuthEndpoint: boolean;
+  hasSigningKey: boolean;
+  listsRegisteredAsset: boolean | null;
+}
+
+interface AnchorEndpoints {
+  transferServerSep0024: string | null;
+  transferServerSep0006: string | null;
+  webAuthEndpoint: string | null;
+}
+
+interface AnchorHealth {
+  id: string;
+  name: string;
+  homeDomain: string;
+  tomlUrl: string;
+  status: 'reachable' | 'unreachable';
+  checkedAt: string;
+  responseTimeMs: number;
+  attempts: number;
+  capabilities: AnchorCapabilities;
+  endpoints: AnchorEndpoints;
+  currencies: string[];
+  error: string | null;
+}
+
+interface AnchorHealthReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  summary: {
+    total: number;
+    reachable: number;
+    unreachable: number;
+  };
+  anchors: AnchorHealth[];
+}
+
+function ensureConfigDefaults(): void {
+  for (const [key, value] of Object.entries(DEFAULT_ENV)) {
+    process.env[key] ??= value;
+  }
+}
+
+async function loadAnchors(): Promise<Anchor[]> {
+  ensureConfigDefaults();
+
+  const registry =
+    (await import('../lib/stellar/anchors')) as typeof import('../lib/stellar/anchors');
+  return [...registry.ANCHORS];
+}
+
+function getStringField(toml: TomlRecord, key: string): string | null {
+  const value = toml[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function isRecord(value: unknown): value is TomlRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getCurrencies(toml: TomlRecord): TomlRecord[] {
+  const currencies = toml['CURRENCIES'];
+  return Array.isArray(currencies) ? currencies.filter(isRecord) : [];
+}
+
+function getCurrencyCodes(currencies: TomlRecord[]): string[] {
+  return currencies
+    .map((currency) => currency['code'])
+    .filter((code): code is string => typeof code === 'string' && code.length > 0);
+}
+
+function listsRegisteredAsset(anchor: Anchor, currencies: TomlRecord[]): boolean | null {
+  if (currencies.length === 0) {
+    return null;
+  }
+
+  return currencies.some((currency) => {
+    const code = currency['code'];
+    const issuer = currency['issuer'];
+
+    return code === anchor.assetCode && issuer === anchor.assetIssuer;
+  });
+}
+
+function buildCapabilities(
+  anchor: Anchor,
+  toml: TomlRecord
+): {
+  capabilities: AnchorCapabilities;
+  endpoints: AnchorEndpoints;
+  currencies: string[];
+} {
+  const transferServerSep0024 = getStringField(toml, 'TRANSFER_SERVER_SEP0024');
+  const transferServerSep0006 = getStringField(toml, 'TRANSFER_SERVER');
+  const webAuthEndpoint = getStringField(toml, 'WEB_AUTH_ENDPOINT');
+  const signingKey = getStringField(toml, 'SIGNING_KEY');
+  const currencies = getCurrencies(toml);
+
+  return {
+    capabilities: {
+      hasTransferServerSep0024: transferServerSep0024 !== null,
+      hasTransferServerSep0006: transferServerSep0006 !== null,
+      hasWebAuthEndpoint: webAuthEndpoint !== null,
+      hasSigningKey: signingKey !== null,
+      listsRegisteredAsset: listsRegisteredAsset(anchor, currencies),
+    },
+    endpoints: {
+      transferServerSep0024,
+      transferServerSep0006,
+      webAuthEndpoint,
+    },
+    currencies: getCurrencyCodes(currencies),
+  };
+}
+
+function emptyCapabilities(): {
+  capabilities: AnchorCapabilities;
+  endpoints: AnchorEndpoints;
+  currencies: string[];
+} {
+  return {
+    capabilities: {
+      hasTransferServerSep0024: false,
+      hasTransferServerSep0006: false,
+      hasWebAuthEndpoint: false,
+      hasSigningKey: false,
+      listsRegisteredAsset: null,
+    },
+    endpoints: {
+      transferServerSep0024: null,
+      transferServerSep0006: null,
+      webAuthEndpoint: null,
+    },
+    currencies: [],
+  };
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function resolveTomlWithRetry(
+  domain: string
+): Promise<{ toml: TomlRecord; attempts: number }> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const toml = (await StellarToml.Resolver.resolve(domain)) as TomlRecord;
+      return { toml, attempts: attempt };
+    } catch (error) {
+      lastError = error;
+
+      if (attempt < MAX_ATTEMPTS) {
+        await delay(RETRY_DELAY_MS * attempt);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function validateAnchor(anchor: Anchor): Promise<AnchorHealth> {
+  const startedAt = Date.now();
+  const checkedAt = new Date().toISOString();
+  const tomlUrl = `https://${anchor.homeDomain}${STELLAR_TOML_PATH}`;
+
+  try {
+    const { toml, attempts } = await resolveTomlWithRetry(anchor.homeDomain);
+    const capabilityReport = buildCapabilities(anchor, toml);
+
+    return {
+      id: anchor.id,
+      name: anchor.name,
+      homeDomain: anchor.homeDomain,
+      tomlUrl,
+      status: 'reachable',
+      checkedAt,
+      responseTimeMs: Date.now() - startedAt,
+      attempts,
+      ...capabilityReport,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      id: anchor.id,
+      name: anchor.name,
+      homeDomain: anchor.homeDomain,
+      tomlUrl,
+      status: 'unreachable',
+      checkedAt,
+      responseTimeMs: Date.now() - startedAt,
+      attempts: MAX_ATTEMPTS,
+      ...emptyCapabilities(),
+      error: formatError(error),
+    };
+  }
+}
+
+function buildReport(anchors: AnchorHealth[]): AnchorHealthReport {
+  const unreachable = anchors.filter((anchor) => anchor.status === 'unreachable').length;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      total: anchors.length,
+      reachable: anchors.length - unreachable,
+      unreachable,
+    },
+    anchors,
+  };
+}
+
+async function writeReport(report: AnchorHealthReport): Promise<void> {
+  await mkdir(path.dirname(REPORT_PATH), { recursive: true });
+  await writeFile(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const anchors = await loadAnchors();
+  const results = await Promise.all(anchors.map(validateAnchor));
+  const report = buildReport(results);
+
+  await writeReport(report);
+
+  if (report.summary.unreachable > 0) {
+    console.error(
+      `[validate:anchors] ${report.summary.unreachable}/${report.summary.total} anchor TOML files are unreachable. Report written to ${REPORT_PATH}.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `[validate:anchors] ${report.summary.reachable}/${report.summary.total} anchor TOML files resolved. Report written to ${REPORT_PATH}.`
+  );
+}
+
+void main().catch((error: unknown) => {
+  console.error(`[validate:anchors] ${formatError(error)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #16 
<!--
Thanks for opening a PR!

Before you submit:
  • Conventional Commits title — the PR title is linted (feat / fix / docs /
    refactor / test / chore / ci / perf / build / style / revert, with an
    optional scope and a short description). See .github/workflows/pr-title.yml.
  • One logical change per PR. If you have an unrelated cleanup, split it.
  • Fill in every section below. Delete none of them — leave "N/A" if a
    section genuinely doesn't apply and say *why*.
-->

## Summary

<!--
One or two sentences on **what changed and why**. Lead with the why.
Well-named identifiers already explain the what — don't restate the diff.
-->

## Linked issue

<!--
Every PR must link an issue. Use a closing keyword (Closes / Fixes /
Resolves) so the issue auto-closes on merge. If the work spans multiple
issues, close the primary and reference the others.

If there is genuinely no issue (e.g. typo fix, chore), say so here and
name the reason.
-->

Closes #

## Changes

<!--
A tight bullet list of the material changes. Not a diff summary — a
reader-oriented explanation. Reference files with backticks, reference
symbols with file_path:line_number when it helps.

Example:
  - `lib/stellar/sep10.ts:54` — assert mainnet network passphrase at parse time
  - `components/offramp/ExecuteDrawer.tsx` — propagate `{ transactionId, jwt }`
    to the page on success so `StatusTracker` mounts (fixes #002)
-->

-
-
-

## Testing notes

<!--
What you ran locally, what you added, and what a reviewer should run to
reproduce. At minimum:

  - The name of the new test(s), with file path.
  - The command(s) you ran (`npm run test -- stellar/sep10`, etc).
  - Any manual verification steps — especially if this touches a real
    anchor, a real Stellar transaction, or Freighter.

If you did not add a test, justify it. "Trivial refactor" or "doc-only" are
valid. "Hard to test" is not.
-->

**Automated**
- `npm run typecheck` · ⏳ not run / ✅ green / ❌ failing
- `npm run lint` · ⏳ not run / ✅ green / ❌ failing
- `npm run test` · ⏳ not run / ✅ green / ❌ failing
- `npm run build` · ⏳ not run / ✅ green / ❌ failing

**New / modified tests**
-

**Manual verification** (if applicable)
<!-- e.g. "Connected Freighter on mainnet, executed USDC→NGN for $5 via
MoneyGram testnet deployment, observed StatusTracker reach `completed` in
3m12s. Stellar Expert link: …" -->
-

## Screenshots / recordings

<!--
REQUIRED for any user-visible change. Drop in:
  - Before + After screenshots for UI diffs.
  - A short Loom or a <30s GIF for flow changes (drawer, tracker, drawer-
    to-tracker hoist, split routing visualisation).
  - Relevant terminal output for CLI / API changes.

For pure backend / doc / CI PRs, write "N/A — no user-visible change".
-->

| Before | After |
| --- | --- |
|  |  |

## Checklist

<!--
Every box must be ticked or explicitly "N/A — why". A reviewer will not
merge a PR with an unaddressed box.
-->

**Correctness**
- [ ] The PR title follows Conventional Commits (auto-linted)
- [ ] One logical change; unrelated cleanup was split into a separate PR
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes with **zero new warnings** (we run `--max-warnings 0` in CI)
- [ ] `npm run test` passes; new behaviour has a test
- [ ] `npm run build` passes

**Data integrity**
- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
- [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
- [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
- [ ] If touching SEP-10: network passphrase assertion is intact (mainnet only)
- [ ] If touching SEP-24: the 10s `AbortController` timeout is intact on anchor fetches
- [ ] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop

**Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
- [ ] No new code path holds user keys, user funds, or long-lived anchor JWTs
- [ ] Every signing action is performed by the user's wallet (Freighter today)
- [ ] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`

**Docs**
- [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
- [ ] API / schema change → relevant `docs/*.md` updated in the same PR
- [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
- [ ] Public-facing feature → screenshot added to `docs/showcase/images/` when relevant
- [ ] New env var → `.env.example` + README env table updated

**Release hygiene**
- [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
- [ ] No dependency added without justification in the PR description
- [ ] No breaking change hidden inside a non-breaking commit

## Breaking changes

<!--
If this PR breaks a public API, the MCP surface, an env var contract,
or a shipped UI URL, say so here with:
  - What breaks.
  - Who is affected.
  - The migration path (code snippet or doc link).

Also prefix the PR title with "!" (e.g. `feat!: remove legacy rate endpoint`)
to make the break visible to release tooling.

If none: write "None."
-->

None.

## For reviewers

<!--
Optional. Use this to call out:
  - Areas where you want a careful read ("look at the quote-expiry math").
  - Tradeoffs you considered and rejected ("chose SWR over a manual poll
    because …").
  - Things you explicitly did NOT do in this PR and are leaving for a
    follow-up (link the follow-up issue).
-->

<!--
One last thing: this PR template is part of the product. If any section
above feels wrong or missing, open a PR against `.github/PULL_REQUEST_TEMPLATE.md`
itself — meta-PRs are welcome.
-->
