### PR TITLE
implement real stellar toml resolution

### DIFF
--- a/lib/stellar/sep1.ts
+++ b/lib/stellar/sep1.ts
@@ -2,9 +2,7 @@ import { StellarToml } from '@stellar/stellar-sdk'
 import type { Sep1TomlData } from '@/types'
 import { ANCHORS } from './anchors'
 
-// ─── In-memory cache ──────────────────────────────────────────────────────────
-
-const TTL_MS = 60 * 60 * 1000 // 1 hour
+const TTL_MS = 15 * 60 * 1000 // 15 minutes
 
 interface CacheEntry {
   data: Sep1TomlData
@@ -13,86 +11,134 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>()
 
-// ─── Core resolver ────────────────────────────────────────────────────────────
+function normalizeDomain(domain: string): string {
+  const normalized = domain.trim().toLowerCase()
+
+  if (!normalized) {
+    throw new Error('Anchor domain is required')
+  }
+
+  return normalized
+}
+
+function getString(raw: Record<string, unknown>, key: string): string | null {
+  const value = raw[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getCurrencies(raw: Record<string, unknown>): Sep1TomlData['CURRENCIES'] {
+  const currencies = raw['CURRENCIES']
+  if (!Array.isArray(currencies)) {
+    return []
+  }
+
+  return currencies.flatMap((currency) => {
+    if (!isRecord(currency) || typeof currency['code'] !== 'string') {
+      return []
+    }
+
+    const parsed: Sep1TomlData['CURRENCIES'][number] = {
+      code: currency['code'],
+    }
+
+    if (typeof currency['issuer'] === 'string') {
+      parsed.issuer = currency['issuer']
+    }
+
+    return [parsed]
+  })
+}
+
+function toSep1TomlData(domain: string, raw: Record<string, unknown>): Sep1TomlData {
+  return {
+    domain,
+    TRANSFER_SERVER_SEP0024: getString(raw, 'TRANSFER_SERVER_SEP0024'),
+    ANCHOR_QUOTE_SERVER: getString(raw, 'ANCHOR_QUOTE_SERVER'),
+    WEB_AUTH_ENDPOINT: getString(raw, 'WEB_AUTH_ENDPOINT'),
+    SIGNING_KEY: getString(raw, 'SIGNING_KEY'),
+    NETWORK_PASSPHRASE: getString(raw, 'NETWORK_PASSPHRASE'),
+    CURRENCIES: getCurrencies(raw),
+  }
+}
+
+function requireTomlField(
+  domain: string,
+  toml: Sep1TomlData,
+  field: 'TRANSFER_SERVER_SEP0024' | 'WEB_AUTH_ENDPOINT',
+  protocolName: string
+): string {
+  const value = toml[field]
+
+  if (!value) {
+    throw new Error(
+      `Missing ${field} in stellar.toml for "${domain}". ` +
+        `This anchor does not support ${protocolName}.`
+    )
+  }
+
+  return value
+}
 
 /**
- * Resolves a stellar.toml file for the given domain via SEP-1.
- * Results are cached in memory for 1 hour. Failed resolutions are not cached.
+ * Resolves an anchor stellar.toml file via SEP-1.
+ * Results are cached in memory for 15 minutes. Failed resolutions are not cached.
  */
-export async function resolveToml(domain: string): Promise<Sep1TomlData> {
-  const cached = cache.get(domain)
+export async function resolveAnchor(domain: string): Promise<Sep1TomlData> {
+  const cacheKey = normalizeDomain(domain)
+  const cached = cache.get(cacheKey)
+
   if (cached && cached.expiresAt > Date.now()) {
     return cached.data
   }
 
-  let raw: Record<string, unknown>
   try {
-    raw = await StellarToml.Resolver.resolve(domain)
+    const raw = (await StellarToml.Resolver.resolve(cacheKey)) as Record<string, unknown>
+    const data = toSep1TomlData(cacheKey, raw)
+
+    cache.set(cacheKey, { data, expiresAt: Date.now() + TTL_MS })
+    return data
   } catch (err) {
-    cache.delete(domain)
+    cache.delete(cacheKey)
     throw new Error(
-      `Failed to resolve stellar.toml for "${domain}": ${err instanceof Error ? err.message : String(err)}`
+      `Failed to resolve stellar.toml for "${cacheKey}": ${
+        err instanceof Error ? err.message : String(err)
+      }`
     )
   }
-
-  const transferServer = raw['TRANSFER_SERVER_SEP0024']
-  if (!transferServer || typeof transferServer !== 'string') {
-    cache.delete(domain)
-    throw new Error(
-      `Missing TRANSFER_SERVER_SEP0024 in stellar.toml for "${domain}". ` +
-        `This anchor does not support SEP-24.`
-    )
-  }
-
-  const webAuthEndpoint = raw['WEB_AUTH_ENDPOINT']
-  if (!webAuthEndpoint || typeof webAuthEndpoint !== 'string') {
-    cache.delete(domain)
-    throw new Error(
-      `Missing WEB_AUTH_ENDPOINT in stellar.toml for "${domain}". ` +
-        `This anchor does not support SEP-10 authentication.`
-    )
-  }
-
-  const data: Sep1TomlData = {
-    TRANSFER_SERVER_SEP0024: transferServer,
-    WEB_AUTH_ENDPOINT: webAuthEndpoint,
-    SIGNING_KEY: typeof raw['SIGNING_KEY'] === 'string' ? raw['SIGNING_KEY'] : undefined,
-    CURRENCIES: Array.isArray(raw['CURRENCIES'])
-      ? (raw['CURRENCIES'] as Array<{ code: string; issuer?: string }>)
-      : undefined,
-  }
-
-  cache.set(domain, { data, expiresAt: Date.now() + TTL_MS })
-  return data
 }
 
-// ─── Convenience wrappers ─────────────────────────────────────────────────────
+/** Backwards-compatible name used by older SEP-1 callers. */
+export async function resolveToml(domain: string): Promise<Sep1TomlData> {
+  return resolveAnchor(domain)
+}
 
 /**
  * Returns the SEP-24 transfer server URL for the given anchor domain.
  */
 export async function getTransferServer(domain: string): Promise<string> {
-  const toml = await resolveToml(domain)
-  return toml.TRANSFER_SERVER_SEP0024
+  const toml = await resolveAnchor(domain)
+  return requireTomlField(domain, toml, 'TRANSFER_SERVER_SEP0024', 'SEP-24')
 }
 
 /**
  * Returns the SEP-10 web auth endpoint URL for the given anchor domain.
  */
 export async function getWebAuthEndpoint(domain: string): Promise<string> {
-  const toml = await resolveToml(domain)
-  return toml.WEB_AUTH_ENDPOINT
+  const toml = await resolveAnchor(domain)
+  return requireTomlField(domain, toml, 'WEB_AUTH_ENDPOINT', 'SEP-10 authentication')
 }
-
-// ─── Bulk resolver ────────────────────────────────────────────────────────────
 
 /**
  * Resolves stellar.toml for all known anchors in parallel.
- * Anchors that fail resolution are logged but do not cause the function to throw.
+ * Anchors that fail resolution are skipped.
  */
 export async function resolveAllAnchors(): Promise<Record<string, Sep1TomlData>> {
   const results = await Promise.allSettled(
-    ANCHORS.map((anchor) => resolveToml(anchor.homeDomain).then((data) => ({ anchor, data })))
+    ANCHORS.map((anchor) => resolveAnchor(anchor.homeDomain).then((data) => ({ anchor, data })))
   )
 
   const resolved: Record<string, Sep1TomlData> = {}
@@ -100,15 +146,13 @@ export async function resolveAllAnchors(): Promise<Record<string, Sep1TomlData>>
   for (const result of results) {
     if (result.status === 'fulfilled') {
       resolved[result.value.anchor.id] = result.value.data
-    } else {
-      console.warn('[sep1] resolveAllAnchors failure:', result.reason)
     }
   }
 
   return resolved
 }
 
-/** Exposed for testing only — clears the in-memory TOML cache. */
+/** Exposed for testing only - clears the in-memory TOML cache. */
 export function _clearTomlCache(): void {
   cache.clear()
 }

--- a/tests/lib/sep1.test.ts
+++ b/tests/lib/sep1.test.ts
@@ -1,69 +1,129 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { StellarToml } from '@stellar/stellar-sdk'
-import { resolveToml, getTransferServer, getWebAuthEndpoint, resolveAllAnchors, _clearTomlCache } from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Networks, StellarToml } from '@stellar/stellar-sdk'
+import {
+  resolveAnchor,
+  resolveToml,
+  getTransferServer,
+  getWebAuthEndpoint,
+  resolveAllAnchors,
+  _clearTomlCache,
+} from '@/lib/stellar/sep1'
 
 const VALID_TOML = {
   TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+  ANCHOR_QUOTE_SERVER: 'https://cowrie.exchange/quotes',
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'GABCDEF',
-  CURRENCIES: [{ code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' }],
+  NETWORK_PASSPHRASE: Networks.PUBLIC,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
 }
 
 beforeEach(() => {
   _clearTomlCache()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
-describe('resolveToml', () => {
-  it('returns the correct TRANSFER_SERVER_SEP0024', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+afterEach(() => {
+  vi.useRealTimers()
+})
 
-    const result = await resolveToml('cowrie.exchange')
-    expect(result.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
-  })
+describe('resolveAnchor', () => {
+  it('calls StellarToml.Resolver.resolve and extracts SEP-1 fields', async () => {
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
 
-  it('returns the correct WEB_AUTH_ENDPOINT', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    const result = await resolveAnchor('cowrie.exchange')
 
-    const result = await resolveToml('cowrie.exchange')
-    expect(result.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
-  })
-
-  it('throws when TRANSFER_SERVER_SEP0024 is absent', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
-      WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
-    } as never)
-
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
-      /Missing TRANSFER_SERVER_SEP0024.*"cowrie\.exchange"/
-    )
-  })
-
-  it('throws when WEB_AUTH_ENDPOINT is absent', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
+    expect(result).toEqual({
+      domain: 'cowrie.exchange',
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
-    } as never)
+      ANCHOR_QUOTE_SERVER: 'https://cowrie.exchange/quotes',
+      WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+      SIGNING_KEY: 'GABCDEF',
+      NETWORK_PASSPHRASE: Networks.PUBLIC,
+      CURRENCIES: [
+        { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+      ],
+    })
+  })
 
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
-      /Missing WEB_AUTH_ENDPOINT.*"cowrie\.exchange"/
-    )
+  it('normalizes domain casing for cache keys', async () => {
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+
+    await resolveAnchor(' Cowrie.Exchange ')
+    await resolveAnchor('cowrie.exchange')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
+  })
+
+  it('returns nullable fields when optional TOML values are absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({} as never)
+
+    const result = await resolveAnchor('cowrie.exchange')
+
+    expect(result.TRANSFER_SERVER_SEP0024).toBeNull()
+    expect(result.ANCHOR_QUOTE_SERVER).toBeNull()
+    expect(result.WEB_AUTH_ENDPOINT).toBeNull()
+    expect(result.SIGNING_KEY).toBeNull()
+    expect(result.NETWORK_PASSPHRASE).toBeNull()
+    expect(result.CURRENCIES).toEqual([])
   })
 
   it('throws a descriptive error when the network call fails', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
 
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
+    await expect(resolveAnchor('cowrie.exchange')).rejects.toThrow(
       /Failed to resolve stellar\.toml for "cowrie\.exchange"/
     )
   })
 
-  it('returns the cached result on a second call without re-fetching', async () => {
+  it('returns a cache hit in under 1ms', async () => {
     const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
 
-    await resolveToml('cowrie.exchange')
-    await resolveToml('cowrie.exchange')
+    await resolveAnchor('cowrie.exchange')
 
+    const startedAt = performance.now()
+    const cached = await resolveAnchor('cowrie.exchange')
+    const elapsedMs = performance.now() - startedAt
+
+    expect(cached.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+    expect(elapsedMs).toBeLessThan(1)
     expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes the cached TOML after the 15-minute TTL expires', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const spy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValueOnce(VALID_TOML as never)
+      .mockResolvedValueOnce({
+        ...VALID_TOML,
+        WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/new-auth',
+      } as never)
+
+    await resolveAnchor('cowrie.exchange')
+    vi.setSystemTime(new Date('2026-01-01T00:15:00.001Z'))
+
+    const refreshed = await resolveAnchor('cowrie.exchange')
+
+    expect(refreshed.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/new-auth')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('resolveToml', () => {
+  it('keeps the old resolver name as an alias for resolveAnchor', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+
+    const result = await resolveToml('cowrie.exchange')
+
+    expect(result.ANCHOR_QUOTE_SERVER).toBe('https://cowrie.exchange/quotes')
   })
 })
 
@@ -74,6 +134,16 @@ describe('getTransferServer', () => {
     const url = await getTransferServer('cowrie.exchange')
     expect(url).toBe('https://cowrie.exchange/sep24')
   })
+
+  it('throws when TRANSFER_SERVER_SEP0024 is absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
+      WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+    } as never)
+
+    await expect(getTransferServer('cowrie.exchange')).rejects.toThrow(
+      /Missing TRANSFER_SERVER_SEP0024.*"cowrie\.exchange"/
+    )
+  })
 })
 
 describe('getWebAuthEndpoint', () => {
@@ -82,6 +152,16 @@ describe('getWebAuthEndpoint', () => {
 
     const url = await getWebAuthEndpoint('cowrie.exchange')
     expect(url).toBe('https://cowrie.exchange/auth')
+  })
+
+  it('throws when WEB_AUTH_ENDPOINT is absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
+      TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+    } as never)
+
+    await expect(getWebAuthEndpoint('cowrie.exchange')).rejects.toThrow(
+      /Missing WEB_AUTH_ENDPOINT.*"cowrie\.exchange"/
+    )
   })
 })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -55,13 +55,19 @@ export interface FreighterState {
 
 // ─── SEP-1 ────────────────────────────────────────────────────────────────────
 
-/** Relevant fields from a stellar.toml file resolved via SEP-1. */
-export interface Sep1TomlData {
-  TRANSFER_SERVER_SEP0024: string
-  WEB_AUTH_ENDPOINT: string
-  SIGNING_KEY?: string
-  CURRENCIES?: Array<{ code: string; issuer?: string }>
+/** A normalized stellar.toml response for an anchor resolved via SEP-1. */
+export interface ResolvedAnchorToml {
+  domain: string
+  TRANSFER_SERVER_SEP0024: string | null
+  ANCHOR_QUOTE_SERVER: string | null
+  WEB_AUTH_ENDPOINT: string | null
+  SIGNING_KEY: string | null
+  NETWORK_PASSPHRASE: string | null
+  CURRENCIES: Array<{ code: string; issuer?: string }>
 }
+
+/** Backwards-compatible alias for older SEP-1 callers. */
+export type Sep1TomlData = ResolvedAnchorToml
 
 // ─── SEP-10 ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #011
<!--
Thanks for opening a PR!

Before you submit:
  • Conventional Commits title — the PR title is linted (feat / fix / docs /
    refactor / test / chore / ci / perf / build / style / revert, with an
    optional scope and a short description). See .github/workflows/pr-title.yml.
  • One logical change per PR. If you have an unrelated cleanup, split it.
  • Fill in every section below. Delete none of them — leave "N/A" if a
    section genuinely doesn't apply and say *why*.
-->

## Summary

<!--
One or two sentences on **what changed and why**. Lead with the why.
Well-named identifiers already explain the what — don't restate the diff.
-->

## Linked issue

<!--
Every PR must link an issue. Use a closing keyword (Closes / Fixes /
Resolves) so the issue auto-closes on merge. If the work spans multiple
issues, close the primary and reference the others.

If there is genuinely no issue (e.g. typo fix, chore), say so here and
name the reason.
-->

Closes #

## Changes

<!--
A tight bullet list of the material changes. Not a diff summary — a
reader-oriented explanation. Reference files with backticks, reference
symbols with file_path:line_number when it helps.

Example:
  - `lib/stellar/sep10.ts:54` — assert mainnet network passphrase at parse time
  - `components/offramp/ExecuteDrawer.tsx` — propagate `{ transactionId, jwt }`
    to the page on success so `StatusTracker` mounts (fixes #002)
-->

-
-
-

## Testing notes

<!--
What you ran locally, what you added, and what a reviewer should run to
reproduce. At minimum:

  - The name of the new test(s), with file path.
  - The command(s) you ran (`npm run test -- stellar/sep10`, etc).
  - Any manual verification steps — especially if this touches a real
    anchor, a real Stellar transaction, or Freighter.

If you did not add a test, justify it. "Trivial refactor" or "doc-only" are
valid. "Hard to test" is not.
-->

**Automated**
- `npm run typecheck` · ⏳ not run / ✅ green / ❌ failing
- `npm run lint` · ⏳ not run / ✅ green / ❌ failing
- `npm run test` · ⏳ not run / ✅ green / ❌ failing
- `npm run build` · ⏳ not run / ✅ green / ❌ failing

**New / modified tests**
-

**Manual verification** (if applicable)
<!-- e.g. "Connected Freighter on mainnet, executed USDC→NGN for $5 via
MoneyGram testnet deployment, observed StatusTracker reach `completed` in
3m12s. Stellar Expert link: …" -->
-

## Screenshots / recordings

<!--
REQUIRED for any user-visible change. Drop in:
  - Before + After screenshots for UI diffs.
  - A short Loom or a <30s GIF for flow changes (drawer, tracker, drawer-
    to-tracker hoist, split routing visualisation).
  - Relevant terminal output for CLI / API changes.

For pure backend / doc / CI PRs, write "N/A — no user-visible change".
-->

| Before | After |
| --- | --- |
|  |  |

## Checklist

<!--
Every box must be ticked or explicitly "N/A — why". A reviewer will not
merge a PR with an unaddressed box.
-->

**Correctness**
- [ ] The PR title follows Conventional Commits (auto-linted)
- [ ] One logical change; unrelated cleanup was split into a separate PR
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes with **zero new warnings** (we run `--max-warnings 0` in CI)
- [ ] `npm run test` passes; new behaviour has a test
- [ ] `npm run build` passes

**Data integrity**
- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
- [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
- [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
- [ ] If touching SEP-10: network passphrase assertion is intact (mainnet only)
- [ ] If touching SEP-24: the 10s `AbortController` timeout is intact on anchor fetches
- [ ] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop

**Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
- [ ] No new code path holds user keys, user funds, or long-lived anchor JWTs
- [ ] Every signing action is performed by the user's wallet (Freighter today)
- [ ] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`

**Docs**
- [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
- [ ] API / schema change → relevant `docs/*.md` updated in the same PR
- [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
- [ ] Public-facing feature → screenshot added to `docs/showcase/images/` when relevant
- [ ] New env var → `.env.example` + README env table updated

**Release hygiene**
- [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
- [ ] No dependency added without justification in the PR description
- [ ] No breaking change hidden inside a non-breaking commit

## Breaking changes

<!--
If this PR breaks a public API, the MCP surface, an env var contract,
or a shipped UI URL, say so here with:
  - What breaks.
  - Who is affected.
  - The migration path (code snippet or doc link).

Also prefix the PR title with "!" (e.g. `feat!: remove legacy rate endpoint`)
to make the break visible to release tooling.

If none: write "None."
-->

None.

## For reviewers

<!--
Optional. Use this to call out:
  - Areas where you want a careful read ("look at the quote-expiry math").
  - Tradeoffs you considered and rejected ("chose SWR over a manual poll
    because …").
  - Things you explicitly did NOT do in this PR and are leaving for a
    follow-up (link the follow-up issue).
-->

<!--
One last thing: this PR template is part of the product. If any section
above feels wrong or missing, open a PR against `.github/PULL_REQUEST_TEMPLATE.md`
itself — meta-PRs are welcome.
-->
