### PR TITLE
fix(#17): capability gating in useAnchorRates

### DIFF
--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import type { ApiRatesResponse, RateComparison } from '@/types';
+import type { ApiRatesResponse, RateComparison, AnchorCapabilities } from '@/types';
 
 async function fetcher([, corridorId, amount]: [string, string, string]): Promise<RateComparison> {
   const url = new URL('/api/rates', window.location.origin);
@@ -21,15 +21,23 @@ export interface UseAnchorRatesResult {
   isLoading: boolean;
   error: string | undefined;
   mutate: () => void;
+  source?: 'live' | 'unavailable';
 }
 
 /**
  * Fetches live anchor rates for the given corridor and amount.
  * Refreshes every 30 seconds and revalidates when the tab regains focus.
  */
-export function useAnchorRates(corridorId: string, amount: string): UseAnchorRatesResult {
+export function useAnchorRates(
+  corridorId: string,
+  amount: string,
+  capabilities?: AnchorCapabilities
+): UseAnchorRatesResult {
+  const capable =
+    capabilities === undefined || capabilities.sep24 || capabilities.sep38;
+
   const { data, error, isLoading, mutate } = useSWR<RateComparison, Error>(
-    ['/api/rates', corridorId, amount],
+    capable ? ['/api/rates', corridorId, amount] : null,
     fetcher,
     {
       refreshInterval: 30_000,
@@ -37,6 +45,16 @@ export function useAnchorRates(corridorId: string, amount: string): UseAnchorRat
       dedupingInterval: 5_000,
     }
   );
+
+  if (!capable) {
+    return {
+      rates: undefined,
+      isLoading: false,
+      error: undefined,
+      mutate: () => {},
+      source: 'unavailable',
+    };
+  }
 
   return {
     rates: data,

--- a/tests/capability-gate.spec.ts
+++ b/tests/capability-gate.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { useAnchorRates } from '@/hooks/useAnchorRates';
+import type { AnchorCapabilities, RateComparison } from '@/types';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
+
+const mockCapabilities = (sep24: boolean, sep38: boolean): AnchorCapabilities => ({
+  sep10: true,
+  sep24,
+  sep38,
+  sep12: true,
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('capability gating in useAnchorRates', () => {
+  it('short-circuits when neither sep24 nor sep38 is true', async () => {
+    const fetchSpy = vi.stubGlobal('fetch', vi.fn());
+    const capabilities = mockCapabilities(false, false);
+
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100', capabilities), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.source).toBe('unavailable');
+    expect(result.current.rates).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches when sep24 is true (but sep38 is false)', async () => {
+    const fetchSpy = vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ rates: {} }) }))
+    );
+    const capabilities = mockCapabilities(true, false);
+
+    renderHook(() => useAnchorRates('usdc-ngn', '100', capabilities), { wrapper });
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('fetches when sep38 is true (but sep24 is false)', async () => {
+    const fetchSpy = vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ rates: {} }) }))
+    );
+    const capabilities = mockCapabilities(false, true);
+
+    renderHook(() => useAnchorRates('usdc-ngn', '100', capabilities), { wrapper });
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('fetches when both sep24 and sep38 are true', async () => {
+    const fetchSpy = vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ rates: {} }) }))
+    );
+    const capabilities = mockCapabilities(true, true);
+
+    renderHook(() => useAnchorRates('usdc-ngn', '100', capabilities), { wrapper });
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION


**Title:**
feat: implement capability gating in [useAnchorRates](cci:1://file:///c:/Users/ritik/Desktop/aadvik/stellar-intel/hooks/useAnchorRates.ts:26:0-64:1)

**Description:**
**Closes #17**

This PR implements capability gating in the [useAnchorRates](cci:1://file:///c:/Users/ritik/Desktop/aadvik/stellar-intel/hooks/useAnchorRates.ts:26:0-64:1) hook to prevent unnecessary network requests to anchors that lack support for SEP-24 or SEP-38. 

**Changes:**
- Receives reading of `capabilities: AnchorCapabilities` from the resolved anchor in [useAnchorRates](cci:1://file:///c:/Users/ritik/Desktop/aadvik/stellar-intel/hooks/useAnchorRates.ts:26:0-64:1)
- Short-circuits the hook to return `{ source: 'unavailable' }` if neither `sep24` nor `sep38` is explicitly supported
- Adds tests in [tests/capability-gate.spec.ts](cci:7://file:///c:/Users/ritik/Desktop/aadvik/stellar-intel/tests/capability-gate.spec.ts:0:0-0:0) to ensure zero API requests are made when lacking the capabilities, and covers all capability combinations.