### PR TITLE
fix(config): route all Horizon access through lib/config (#006)

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,7 +1,6 @@
 import type { Country, StellarAsset, Anchor } from '@/types';
 
 export const STELLAR_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'mainnet';
-export const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon.stellar.org';
 export const STELLAR_EXPERT_URL =
   process.env.NEXT_PUBLIC_STELLAR_EXPERT_URL ?? 'https://api.stellar.expert/explorer/public';
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,5 @@
+import { Horizon } from '@stellar/stellar-sdk';
+
 export interface Config {
   stellarNetwork: 'mainnet' | 'testnet' | 'futurenet';
   horizonUrl: string;
@@ -87,3 +89,13 @@ Object.freeze(config);
 export const HORIZON_URL = config.horizonUrl;
 export const USDC_ISSUER = config.usdcIssuer;
 export const NETWORK_PASSPHRASE = NETWORK_PASSPHRASES[config.stellarNetwork];
+
+/**
+ * Returns a typed Horizon.Server instance wired to the configured horizon URL.
+ * All Horizon access must go through this helper — flipping
+ * NEXT_PUBLIC_HORIZON_URL or NEXT_PUBLIC_STELLAR_NETWORK automatically takes
+ * effect for every caller.
+ */
+export function getHorizonServer(): Horizon.Server {
+  return new Horizon.Server(config.horizonUrl);
+}

--- a/lib/stellar/horizon.ts
+++ b/lib/stellar/horizon.ts
@@ -1,16 +1,15 @@
 import {
   Horizon,
   TransactionBuilder,
-  Networks,
   Asset,
   Operation,
   Memo,
   BASE_FEE,
 } from '@stellar/stellar-sdk';
-import { HORIZON_URL } from '@/constants';
+import { config, NETWORK_PASSPHRASE, getHorizonServer } from '@/lib/config';
 import type { SwapRoute, StellarAsset } from '@/types';
 
-export const horizonServer = new Horizon.Server(HORIZON_URL);
+export const horizonServer = getHorizonServer();
 
 const MAX_FEE_STROOPS = 10_000;
 
@@ -67,7 +66,7 @@ export async function buildWithdrawPayment(
 
   const builder = new TransactionBuilder(account, {
     fee,
-    networkPassphrase: Networks.PUBLIC,
+    networkPassphrase: NETWORK_PASSPHRASE,
   }).setTimeout(180);
 
   builder.addOperation(
@@ -104,14 +103,14 @@ export async function signAndSubmitPayment(
   const { signTransaction } = await import('@stellar/freighter-api');
 
   const xdr = transaction.toXDR();
-  const signResult = await signTransaction(xdr, { networkPassphrase: Networks.PUBLIC });
+  const signResult = await signTransaction(xdr, { networkPassphrase: NETWORK_PASSPHRASE });
 
   if (signResult.error) {
     throw new Error('User rejected the payment transaction');
   }
 
   const { TransactionBuilder: TB } = await import('@stellar/stellar-sdk');
-  const signedTx = TB.fromXDR(signResult.signedTxXdr, Networks.PUBLIC);
+  const signedTx = TB.fromXDR(signResult.signedTxXdr, NETWORK_PASSPHRASE);
 
   try {
     return await horizonServer.submitTransaction(signedTx);
@@ -181,7 +180,7 @@ export async function getStrictSendPaths(
   fromAmount: number,
   toAssets: StellarAsset[]
 ): Promise<SwapRoute[]> {
-  const url = new URL(`${HORIZON_URL}/paths/strict-send`);
+  const url = new URL(`${config.horizonUrl}/paths/strict-send`);
   url.searchParams.set('source_amount', fromAmount.toString());
 
   if (fromAsset.issuer) {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { Horizon } from '@stellar/stellar-sdk';
+import { config, getHorizonServer, NETWORK_PASSPHRASE, HORIZON_URL } from '@/lib/config';
+
+describe('getHorizonServer', () => {
+  it('returns a Horizon.Server instance', () => {
+    expect(getHorizonServer()).toBeInstanceOf(Horizon.Server);
+  });
+
+  it('server URL is derived from NEXT_PUBLIC_HORIZON_URL, not a hardcoded literal', () => {
+    const server = getHorizonServer();
+    // Stellar SDK normalises the URL with a trailing slash
+    const normalised = config.horizonUrl.endsWith('/')
+      ? config.horizonUrl
+      : `${config.horizonUrl}/`;
+    expect(server.serverURL.toString()).toBe(normalised);
+  });
+
+  it('each call returns a fresh independent instance', () => {
+    expect(getHorizonServer()).not.toBe(getHorizonServer());
+  });
+});
+
+describe('NETWORK_PASSPHRASE', () => {
+  it('matches the network set in NEXT_PUBLIC_STELLAR_NETWORK', () => {
+    const passphrases: Record<string, string> = {
+      mainnet: 'Public Global Stellar Network ; September 2015',
+      testnet: 'Test SDF Network ; September 2015',
+      futurenet: 'Test SDF Future Network ; October 2022',
+    };
+    expect(NETWORK_PASSPHRASE).toBe(passphrases[config.stellarNetwork]);
+  });
+});
+
+describe('HORIZON_URL named export', () => {
+  it('re-exports config.horizonUrl so all callers share one source', () => {
+    expect(HORIZON_URL).toBe(config.horizonUrl);
+  });
+
+  it('contains no hardcoded fallback — value comes from env', () => {
+    expect(HORIZON_URL).toBe(process.env.NEXT_PUBLIC_HORIZON_URL);
+  });
+});


### PR DESCRIPTION
## Summary

- `getHorizonServer()` added to `lib/config.ts` — single factory returning a typed `Horizon.Server` instance wired to `config.horizonUrl`; all Horizon callers use this
- `lib/stellar/horizon.ts` now imports from `@/lib/config` (not `@/constants`); `horizonServer` is initialised via `getHorizonServer()`; all three `Networks.PUBLIC` literals replaced with `NETWORK_PASSPHRASE`; `getStrictSendPaths` URL uses `config.horizonUrl`
- `constants/index.ts` — `HORIZON_URL` export removed along with its hardcoded `'https://horizon.stellar.org'` fallback; `lib/config` is the single source of truth
- `tests/config.spec.ts` — new spec verifying `getHorizonServer()` returns `Horizon.Server`, URL matches env, each call is a fresh instance, and `NETWORK_PASSPHRASE` tracks the configured network

## Acceptance criteria

- [x] Zero hardcoded `horizon.stellar.org` / `horizon-testnet` literals outside `lib/config.ts`
- [x] Flipping `NEXT_PUBLIC_STELLAR_NETWORK` switches `NETWORK_PASSPHRASE` for all callers (`buildWithdrawPayment`, `signAndSubmitPayment`, `getStrictSendPaths`)
- [x] Flipping `NEXT_PUBLIC_HORIZON_URL` switches the server for all callers (`horizonServer`, `getStrictSendPaths`)
- [x] `getHorizonServer()` is typed, tested, and documented

## Files changed

| File | Change |
|---|---|
| `lib/config.ts` | Add `Horizon` import, add `getHorizonServer()` factory |
| `lib/stellar/horizon.ts` | Swap to `@/lib/config` import; replace 3× `Networks.PUBLIC` + URL literal |
| `constants/index.ts` | Remove `HORIZON_URL` export and hardcoded fallback |
| `tests/config.spec.ts` | New spec — `getHorizonServer`, `NETWORK_PASSPHRASE`, `HORIZON_URL` |

Closes #6