### PR TITLE
fix(input): sanitize and debounce AmountInput — reject invalid values (#007)

### DIFF
--- a/components/ui/AmountInput.tsx
+++ b/components/ui/AmountInput.tsx
@@ -1,4 +1,14 @@
 'use client'
+import { useState, useEffect, useRef } from 'react'
+
+const POSITIVE_DECIMAL_RE = /^\d*\.?\d{0,7}$/
+
+function validate(raw: string): string | null {
+  if (!POSITIVE_DECIMAL_RE.test(raw)) return null
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return raw
+}
 
 interface AmountInputProps {
   value: string
@@ -6,27 +16,47 @@ interface AmountInputProps {
   disabled?: boolean
 }
 
-/**
- * Controlled numeric input for USDC amounts.
- * Rejects negative values and enforces a maximum of 2 decimal places.
- */
 export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const raw = e.target.value
+  const [raw, setRaw] = useState(value)
+  const [error, setError] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-    // Allow empty string for clearing the field
-    if (raw === '') {
-      onChange('')
+  useEffect(() => {
+    setRaw(value)
+    setError(null)
+  }, [value])
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const input = e.target.value
+    setRaw(input)
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    if (input === '') {
+      setError(null)
+      debounceRef.current = setTimeout(() => onChange(''), 250)
       return
     }
 
-    const num = Number(raw)
-    if (num < 0) return
+    if (input.endsWith('.')) {
+      setError(null)
+      return
+    }
 
-    // Enforce max 2 decimal places
-    if (/\.\d{3,}$/.test(raw)) return
+    const validated = validate(input)
+    if (validated === null) {
+      setError('Enter a positive number with up to 7 decimal places')
+      return
+    }
 
-    onChange(raw)
+    setError(null)
+    debounceRef.current = setTimeout(() => onChange(validated), 250)
   }
 
   return (
@@ -36,21 +66,32 @@ export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
       </label>
       <div className="relative">
         <input
-          type="number"
-          min={0}
-          step="0.01"
-          value={value}
+          type="text"
+          inputMode="decimal"
+          value={raw}
           onChange={handleChange}
           disabled={disabled}
-          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 pr-16 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          aria-invalid={error !== null}
+          aria-describedby={error ? 'amount-error' : 'amount-hint'}
+          className={`w-full rounded-lg border px-3 py-2.5 pr-16 text-sm text-gray-900 focus:outline-none focus:ring-2 disabled:opacity-50 dark:text-white ${
+            error
+              ? 'border-red-400 bg-red-50 focus:border-red-500 focus:ring-red-500/20 dark:border-red-700 dark:bg-red-950/20'
+              : 'border-gray-300 bg-white focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-800'
+          }`}
         />
         <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm font-medium text-gray-400">
           USDC
         </span>
       </div>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        Enter the amount of USDC to off-ramp
-      </p>
+      {error ? (
+        <p id="amount-error" role="alert" className="mt-1 text-xs text-red-500">
+          {error}
+        </p>
+      ) : (
+        <p id="amount-hint" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Enter the amount of USDC to off-ramp
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- `AmountInput` switched from `type="number"` (which lets `e`/`E`/`-`/`+` through) to `type="text"` + `inputMode="decimal"`; validates against `/^\d*\.?\d{0,7}$/` + finite + positive; debounces `onChange` at 250 ms via `useRef`; shows a `role="alert"` error paragraph for invalid input; treats trailing `.` as mid-entry (no error, no `onChange`)
- `useAnchorRates` sets SWR key to `null` when amount fails `/^\d+(\.\d{1,7})?$/` or is ≤ 0 — **zero network calls for any malformed string**, regardless of how the hook is called
- New `tests/amount-input.spec.tsx`: 30-entry adversarial corpus via `it.each` (negatives, scientific notation, letters, NaN, Infinity, too many decimals, zero, whitespace, special chars, injection attempts), error alert assertions, debounce timing with fake timers
- `tests/components/AmountInput.test.tsx`: `spinbutton` → `textbox` role fix, fake timer wrapping

## Acceptance criteria

- [x] Property-based test over 30 adversarial strings — none produce a network call
- [x] Error `role="alert"` renders under the input for all invalid entries
- [x] `onChange` is debounced 250 ms and only fires for validated positive decimals
- [x] Hook guard (`null` SWR key) provides a second line of defence independent of the component

## Files changed

| File | Change |
|---|---|
| `components/ui/AmountInput.tsx` | Full rewrite: text input, regex validation, 250 ms debounce, error alert |
| `hooks/useAnchorRates.ts` | `null` SWR key guard for invalid amounts |
| `tests/amount-input.spec.tsx` | New — property corpus + debounce timing tests |
| `tests/components/AmountInput.test.tsx` | Role fix + fake timer wrappers |

Closes #7