### PR TITLE
feat: WalletButton four-state rendering (#40)

### DIFF
--- a/components/ui/WalletButton.tsx
+++ b/components/ui/WalletButton.tsx
@@ -3,17 +3,10 @@ import { useFreighter } from '@/hooks/useFreighter'
 import { truncatePublicKey } from '@/lib/utils'
 import { Button } from './Button'
 
-/**
- * Renders the correct wallet state:
- * - Extension not installed → link to freighter.app
- * - Installed, not connected → Connect Wallet button
- * - Connecting → loading state
- * - Connected → truncated public key + Mainnet badge
- * - Error → error message below the button
- */
 export function WalletButton() {
-  const { isInstalled, isConnected, publicKey, connect, error } = useFreighter()
+  const { isInstalled, isConnected, publicKey, network, connect, error } = useFreighter()
 
+  // State 1: not-detected — Freighter extension is not installed
   if (!isInstalled) {
     return (
       <a
@@ -27,6 +20,7 @@ export function WalletButton() {
     )
   }
 
+  // State 2: disconnected — extension present, wallet not connected
   if (!isConnected) {
     return (
       <div className="flex flex-col items-end gap-1">
@@ -42,21 +36,42 @@ export function WalletButton() {
     )
   }
 
-  return (
-    <div className="flex flex-col items-end gap-1">
-      <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-700 dark:bg-gray-800">
-        <span className="text-sm font-mono text-gray-700 dark:text-gray-300">
-          {publicKey ? truncatePublicKey(publicKey) : '—'}
-        </span>
-        <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-          Mainnet
-        </span>
-      </div>
-      {error && (
-        <p className="text-xs text-red-500" role="alert">
-          {error}
+  // State 3: wrong-network — connected but not on Mainnet
+  if (network !== 'PUBLIC') {
+    return (
+      <div className="flex flex-col items-end gap-1">
+        <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 dark:border-amber-700/50 dark:bg-amber-900/20">
+          <span className="text-sm font-medium text-amber-700 dark:text-amber-400">
+            Wrong network
+          </span>
+          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+            Mainnet required
+          </span>
+        </div>
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          Switch to Mainnet to continue.{' '}
+          <a
+            href="https://freighter.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2"
+          >
+            How to switch
+          </a>
         </p>
-      )}
+      </div>
+    )
+  }
+
+  // State 4: connected — on Mainnet with a valid public key
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-700 dark:bg-gray-800">
+      <span className="font-mono text-sm text-gray-700 dark:text-gray-300">
+        {publicKey ? truncatePublicKey(publicKey) : '—'}
+      </span>
+      <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+        Mainnet
+      </span>
     </div>
   )
 }

--- a/tests/WalletButton.spec.tsx
+++ b/tests/WalletButton.spec.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WalletButton } from '@/components/ui/WalletButton'
+import * as useFreighterModule from '@/hooks/useFreighter'
+
+vi.mock('@/hooks/useFreighter')
+
+const mockUseFreighter = vi.mocked(useFreighterModule.useFreighter)
+
+const base = {
+  isInstalled: false,
+  isConnected: false,
+  publicKey: null,
+  network: null,
+  error: null,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+// ─── State 1: not-detected ────────────────────────────────────────────────────
+
+describe('WalletButton — not-detected state', () => {
+  it('renders "Install Freighter" when the extension is not installed', () => {
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
+    render(<WalletButton />)
+    expect(screen.getByText('Install Freighter')).toBeInTheDocument()
+  })
+
+  it('"Install Freighter" is a link to freighter.app', () => {
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
+    render(<WalletButton />)
+    const link = screen.getByRole('link', { name: 'Install Freighter' })
+    expect(link).toHaveAttribute('href', 'https://freighter.app')
+  })
+
+  it('does not render "Connect Wallet" in not-detected state', () => {
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
+    render(<WalletButton />)
+    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument()
+  })
+})
+
+// ─── State 2: disconnected ────────────────────────────────────────────────────
+
+describe('WalletButton — disconnected state', () => {
+  it('renders "Connect Wallet" when installed but not connected', () => {
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false })
+    render(<WalletButton />)
+    expect(screen.getByText('Connect Wallet')).toBeInTheDocument()
+  })
+
+  it('clicking "Connect Wallet" calls connect()', () => {
+    const connect = vi.fn()
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false, connect })
+    render(<WalletButton />)
+    fireEvent.click(screen.getByText('Connect Wallet'))
+    expect(connect).toHaveBeenCalledOnce()
+  })
+
+  it('shows an error message when the hook exposes one', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: false,
+      error: 'Connection rejected',
+    })
+    render(<WalletButton />)
+    expect(screen.getByText('Connection rejected')).toBeInTheDocument()
+  })
+
+  it('does not render "Install Freighter" in disconnected state', () => {
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false })
+    render(<WalletButton />)
+    expect(screen.queryByText('Install Freighter')).not.toBeInTheDocument()
+  })
+})
+
+// ─── State 3: wrong-network ───────────────────────────────────────────────────
+
+describe('WalletButton — wrong-network state', () => {
+  it('renders "Wrong network" when connected on a non-PUBLIC network', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'TESTNET',
+      publicKey: 'GABCDEF',
+    })
+    render(<WalletButton />)
+    expect(screen.getByText('Wrong network')).toBeInTheDocument()
+  })
+
+  it('shows "Mainnet required" as the target network label', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'TESTNET',
+    })
+    render(<WalletButton />)
+    expect(screen.getByText('Mainnet required')).toBeInTheDocument()
+  })
+
+  it('renders a "How to switch" link', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'FUTURENET',
+    })
+    render(<WalletButton />)
+    expect(screen.getByRole('link', { name: 'How to switch' })).toBeInTheDocument()
+  })
+
+  it('does not render the public key in wrong-network state', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'TESTNET',
+      publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
+    })
+    render(<WalletButton />)
+    expect(screen.queryByText('GABC...6789')).not.toBeInTheDocument()
+  })
+})
+
+// ─── State 4: connected ───────────────────────────────────────────────────────
+
+describe('WalletButton — connected state', () => {
+  it('renders the truncated public key when connected on Mainnet', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'PUBLIC',
+      publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
+    })
+    render(<WalletButton />)
+    expect(screen.getByText('GABC...6789')).toBeInTheDocument()
+  })
+
+  it('renders the "Mainnet" badge', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'PUBLIC',
+      publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
+    })
+    render(<WalletButton />)
+    expect(screen.getByText('Mainnet')).toBeInTheDocument()
+  })
+
+  it('does not render "Wrong network" when correctly connected', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'PUBLIC',
+      publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
+    })
+    render(<WalletButton />)
+    expect(screen.queryByText('Wrong network')).not.toBeInTheDocument()
+  })
+
+  it('does not render "Connect Wallet" when connected', () => {
+    mockUseFreighter.mockReturnValue({
+      ...base,
+      isInstalled: true,
+      isConnected: true,
+      network: 'PUBLIC',
+      publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
+    })
+    render(<WalletButton />)
+    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Refactors `WalletButton` into four explicit render paths: `not-detected`, `disconnected`, `wrong-network`, and `connected`
- The new `wrong-network` state (triggered when `isConnected && network !== 'PUBLIC'`) renders an amber warning card with a "Mainnet required" badge and a "How to switch" link — users can re-orient without leaving the page
- Removes the previous pattern of surfacing wrong-network as a generic error string beneath the connected state

## Test plan

- [ ] `tests/WalletButton.spec.tsx` — 15 tests, one `describe` per state, covering correct copy, link attributes, mutual exclusion between states, and `connect()` callback
- [ ] `npx vitest run tests/WalletButton.spec.tsx tests/components/WalletButton.test.tsx` — all 20 tests pass
- [ ] `npm run typecheck` — no new errors introduced

Closes #40 