### PR TITLE
feat(sep24): GET /fee, GET /info+cache, withdraw typed error, canonical WithdrawStatus (#27 #28 #29 #32)

### DIFF
--- a/components/offramp/StatusTracker.tsx
+++ b/components/offramp/StatusTracker.tsx
@@ -28,9 +28,10 @@ const STATUS_LABELS: Record<WithdrawStatusValue, string> = {
   no_market: 'No market available',
   too_small: 'Amount too small',
   too_large: 'Amount too large',
+  expired: 'Transaction expired',
 }
 
-const TERMINAL: WithdrawStatusValue[] = ['completed', 'refunded', 'error', 'no_market', 'too_small', 'too_large']
+const TERMINAL: WithdrawStatusValue[] = ['completed', 'refunded', 'error', 'no_market', 'too_small', 'too_large', 'expired']
 
 function statusColor(status: WithdrawStatusValue | undefined): string {
   if (!status) return 'text-gray-500'

--- a/hooks/useWithdrawStatus.ts
+++ b/hooks/useWithdrawStatus.ts
@@ -1,9 +1,9 @@
 import useSWR from 'swr'
-import type { WithdrawStatus, WithdrawStatusValue } from '@/types'
+import type { Sep24Transaction, WithdrawStatusValue } from '@/types'
 
 const TERMINAL_STATES: WithdrawStatusValue[] = ['completed', 'error', 'refunded', 'no_market', 'too_small', 'too_large']
 
-async function fetcher([transferServer, transactionId, jwt]: [string, string, string]): Promise<WithdrawStatus> {
+async function fetcher([transferServer, transactionId, jwt]: [string, string, string]): Promise<Sep24Transaction> {
   const res = await fetch(`${transferServer}/transaction?id=${transactionId}`, {
     headers: { Authorization: `Bearer ${jwt}` },
   })
@@ -52,7 +52,7 @@ export function useWithdrawStatus(
       ? ([transferServer, transactionId, jwt] as [string, string, string])
       : null
 
-  const { data, error, isLoading } = useSWR<WithdrawStatus, Error>(key, fetcher, {
+  const { data, error, isLoading } = useSWR<Sep24Transaction, Error>(key, fetcher, {
     refreshInterval: (latestData) => {
       if (!latestData) return 5_000
       return TERMINAL_STATES.includes(latestData.status) ? 0 : 5_000

--- a/lib/stellar/sep24-status-map.ts
+++ b/lib/stellar/sep24-status-map.ts
@@ -1,0 +1,30 @@
+import type { WithdrawStatus, WithdrawStatusValue } from '@/types'
+
+/**
+ * Maps every raw SEP-24 anchor status string to the canonical WithdrawStatus enum.
+ *
+ * The Record type enforces exhaustiveness at compile time: adding a new
+ * WithdrawStatusValue without a corresponding entry here is a type error.
+ */
+export const STATUS_MAP: Record<WithdrawStatusValue, WithdrawStatus> = {
+  incomplete: 'pending_user_action',
+  pending_user_transfer_start: 'pending_user_action',
+  pending_user_transfer_complete: 'pending_user_action',
+  pending_user: 'pending_user_action',
+  pending_anchor: 'pending_anchor',
+  pending_trust: 'pending_anchor',
+  pending_stellar: 'pending_stellar',
+  pending_external: 'pending_external',
+  completed: 'completed',
+  refunded: 'refunded',
+  no_market: 'no_market',
+  expired: 'expired',
+  too_small: 'error',
+  too_large: 'error',
+  error: 'error',
+}
+
+/** Converts a raw anchor status string into the canonical WithdrawStatus. */
+export function mapToCanonical(raw: WithdrawStatusValue): WithdrawStatus {
+  return STATUS_MAP[raw]
+}

--- a/lib/stellar/sep24.ts
+++ b/lib/stellar/sep24.ts
@@ -1,7 +1,7 @@
 import { getTransferServer } from './sep1'
 import { getAnchorsByCorridorId, getCorridorById } from './anchors'
 import { computeTotalReceived } from '@/lib/utils'
-import type { Sep24FeeParams, AnchorRate, RateComparison, Sep24WithdrawRequest, Sep24WithdrawResponse, WithdrawStatus, WithdrawStatusValue } from '@/types'
+import type { Sep24FeeParams, AnchorRate, RateComparison, Sep24WithdrawRequest, Sep24WithdrawResponse, Sep24Transaction, WithdrawStatusValue } from '@/types'
 
 // ─── Transaction polling ──────────────────────────────────────────────────────
 
@@ -43,7 +43,7 @@ export async function getSep24Transaction(
   transferServer: string,
   transactionId: string,
   jwt: string
-): Promise<WithdrawStatus> {
+): Promise<Sep24Transaction> {
   const res = await fetch(`${transferServer}/transaction?id=${transactionId}`, {
     headers: { Authorization: `Bearer ${jwt}` },
   })
@@ -68,6 +68,18 @@ export async function getSep24Transaction(
 
 // ─── Typed errors ─────────────────────────────────────────────────────────────
 
+export class Sep24WithdrawError extends Error {
+  readonly status: number
+  readonly anchorBody: unknown
+
+  constructor(status: number, anchorBody: unknown, transferServer: string) {
+    super(`Withdraw initiation failed: HTTP ${status} from ${transferServer}`)
+    this.name = 'Sep24WithdrawError'
+    this.status = status
+    this.anchorBody = anchorBody
+  }
+}
+
 export class AnchorRateError extends Error {
   readonly anchorId: string
 
@@ -84,6 +96,99 @@ function parseRate(raw: unknown): number {
   if (raw === undefined || raw === null) return 0
   const num = Number(String(raw).replace(/,/g, ''))
   return Number.isFinite(num) ? num : 0
+}
+
+// ─── GET /fee (low-level, takes transferServer directly) ─────────────────────
+
+export type Sep24FeeResult = { ok: true; fee: number } | { ok: false; reason: 'unsupported' }
+
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), ms)
+  try {
+    return await fetch(url, { signal: controller.signal })
+  } finally {
+    clearTimeout(id)
+  }
+}
+
+/**
+ * Fetches the anchor's fee quote directly from a known transfer server.
+ * Uses a 5-second timeout with one automatic retry on network/timeout failure.
+ * Returns { ok: false, reason: 'unsupported' } for 404s without throwing.
+ */
+export async function getSep24Fee(params: {
+  transferServer: string
+  assetCode: string
+  assetIssuer: string
+  amount: string
+  type: string
+}): Promise<Sep24FeeResult> {
+  const url = new URL(`${params.transferServer}/fee`)
+  url.searchParams.set('operation', 'withdraw')
+  url.searchParams.set('asset_code', params.assetCode)
+  url.searchParams.set('asset_issuer', params.assetIssuer)
+  url.searchParams.set('amount', params.amount)
+  url.searchParams.set('type', params.type)
+  const urlStr = url.toString()
+
+  let res: Response
+  try {
+    res = await fetchWithTimeout(urlStr, 5_000)
+  } catch {
+    res = await fetchWithTimeout(urlStr, 5_000)
+  }
+
+  if (res.status === 404) return { ok: false, reason: 'unsupported' }
+  if (!res.ok) throw new Error(`HTTP ${res.status} from ${params.transferServer}/fee`)
+
+  const data = (await res.json()) as Record<string, unknown>
+  const fee = Number(data['fee'])
+  return Number.isFinite(fee) ? { ok: true, fee } : { ok: false, reason: 'unsupported' }
+}
+
+// ─── GET /info (with 5-minute in-memory cache) ────────────────────────────────
+
+export interface Sep24AssetInfo {
+  enabled: boolean
+  min_amount?: number
+  max_amount?: number
+  fee_fixed?: number
+  fee_percent?: number
+  authentication_required?: boolean
+}
+
+export interface Sep24InfoResponse {
+  deposit: Record<string, Sep24AssetInfo>
+  withdraw: Record<string, Sep24AssetInfo>
+  fee: { enabled: boolean; authentication_required?: boolean }
+  transaction: { enabled: boolean; authentication_required?: boolean }
+  transactions: { enabled: boolean; authentication_required?: boolean }
+}
+
+const INFO_CACHE = new Map<string, { data: Sep24InfoResponse; expiresAt: number }>()
+const INFO_CACHE_TTL_MS = 5 * 60 * 1_000
+
+export function _clearInfoCache(): void {
+  INFO_CACHE.clear()
+}
+
+/**
+ * Fetches and parses the anchor's SEP-24 /info response.
+ * Results are cached per transfer server for 5 minutes.
+ */
+export async function getSep24Info(transferServer: string): Promise<Sep24InfoResponse> {
+  const cached = INFO_CACHE.get(transferServer)
+  if (cached && cached.expiresAt > Date.now()) return cached.data
+
+  const res = await fetch(`${transferServer}/info`)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch /info from ${transferServer}: HTTP ${res.status}`)
+  }
+
+  const data = (await res.json()) as Sep24InfoResponse
+  INFO_CACHE.set(transferServer, { data, expiresAt: Date.now() + INFO_CACHE_TTL_MS })
+  return data
 }
 
 // ─── Fee fetching ─────────────────────────────────────────────────────────────
@@ -238,7 +343,8 @@ export async function initiateWithdraw(
   })
 
   if (!res.ok) {
-    throw new Error(`Withdraw initiation failed: HTTP ${res.status} from ${transferServer}`)
+    const body = await res.json().catch(() => null)
+    throw new Sep24WithdrawError(res.status, body, transferServer)
   }
 
   const data = (await res.json()) as Record<string, unknown>

--- a/tests/lib/types.test.ts
+++ b/tests/lib/types.test.ts
@@ -1,23 +1,22 @@
 import { describe, it, expect } from 'vitest'
-import type { WithdrawStatus, AnchorRate } from '@/types'
+import type { Sep24Transaction, AnchorRate } from '@/types'
 
-describe('WithdrawStatus', () => {
-  it('accepts a valid WithdrawStatus object', () => {
-    const status: WithdrawStatus = {
+describe('Sep24Transaction', () => {
+  it('accepts a valid Sep24Transaction object', () => {
+    const status: Sep24Transaction = {
       id: 'txn-123',
       status: 'pending_external',
       amountIn: '100',
       amountOut: '97.50',
       amountFee: '2.50',
       updatedAt: new Date(),
-      stellarTransactionId: undefined,
     }
     expect(status.id).toBe('txn-123')
     expect(status.status).toBe('pending_external')
   })
 
   it('accepts a completed status with a stellar transaction id', () => {
-    const status: WithdrawStatus = {
+    const status: Sep24Transaction = {
       id: 'txn-456',
       status: 'completed',
       updatedAt: new Date(),

--- a/tests/sep24-fee.spec.ts
+++ b/tests/sep24-fee.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getSep24Fee } from '@/lib/stellar/sep24'
+
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+
+const BASE_PARAMS = {
+  transferServer: TRANSFER_SERVER,
+  assetCode: 'USDC',
+  assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  amount: '100',
+  type: 'bank_account',
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── getSep24Fee ──────────────────────────────────────────────────────────────
+
+describe('getSep24Fee', () => {
+  it('returns { ok: true, fee } on a valid anchor response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ fee: 2 }),
+    })))
+
+    const result = await getSep24Fee(BASE_PARAMS)
+    expect(result).toEqual({ ok: true, fee: 2 })
+  })
+
+  it('builds the correct URL with all required query parameters', async () => {
+    let capturedUrl = ''
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      capturedUrl = url
+      return { ok: true, status: 200, json: async () => ({ fee: 1 }) }
+    }))
+
+    await getSep24Fee({ ...BASE_PARAMS, amount: '50', type: 'bank_account' })
+
+    expect(capturedUrl).toContain('operation=withdraw')
+    expect(capturedUrl).toContain('asset_code=USDC')
+    expect(capturedUrl).toContain('amount=50')
+    expect(capturedUrl).toContain('type=bank_account')
+  })
+
+  it('returns { ok: false, reason: "unsupported" } on 404 without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 404,
+    })))
+
+    const result = await getSep24Fee(BASE_PARAMS)
+    expect(result).toEqual({ ok: false, reason: 'unsupported' })
+  })
+
+  it('retries once on network failure and succeeds on second attempt', async () => {
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      calls++
+      if (calls === 1) throw new Error('network error')
+      return { ok: true, status: 200, json: async () => ({ fee: 3 }) }
+    }))
+
+    const result = await getSep24Fee(BASE_PARAMS)
+    expect(calls).toBe(2)
+    expect(result).toEqual({ ok: true, fee: 3 })
+  })
+
+  it('throws after two consecutive network failures', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('network error')
+    }))
+
+    await expect(getSep24Fee(BASE_PARAMS)).rejects.toThrow('network error')
+  })
+
+  it('aborts after 5 seconds and retries a second time', async () => {
+    vi.useFakeTimers()
+    let calls = 0
+
+    vi.stubGlobal('fetch', vi.fn((_url: string, opts: { signal: AbortSignal }) => {
+      calls++
+      return new Promise<Response>((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted')
+          ;(err as NodeJS.ErrnoException).name = 'AbortError'
+          reject(err)
+        })
+      })
+    }))
+
+    const promise = getSep24Fee(BASE_PARAMS)
+    // Run timers and catch rejection concurrently so neither is unhandled
+    await Promise.all([
+      vi.runAllTimersAsync(),
+      expect(promise).rejects.toBeDefined(),
+    ])
+    expect(calls).toBe(2)
+
+    vi.useRealTimers()
+  })
+
+  it('returns { ok: false, reason: "unsupported" } when fee field is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ some_other_field: 'oops' }),
+    })))
+
+    const result = await getSep24Fee(BASE_PARAMS)
+    expect(result).toEqual({ ok: false, reason: 'unsupported' })
+  })
+})

--- a/tests/sep24-info.spec.ts
+++ b/tests/sep24-info.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getSep24Info, _clearInfoCache } from '@/lib/stellar/sep24'
+
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+const TRANSFER_SERVER_B = 'https://anclap.com/sep24'
+
+const MOCK_INFO: ReturnType<typeof buildMockInfo> = buildMockInfo()
+
+function buildMockInfo() {
+  return {
+    deposit: { USDC: { enabled: true, min_amount: 1, max_amount: 10000 } },
+    withdraw: { USDC: { enabled: true, min_amount: 1, max_amount: 10000 } },
+    fee: { enabled: true },
+    transaction: { enabled: true, authentication_required: true },
+    transactions: { enabled: true, authentication_required: true },
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  _clearInfoCache()
+})
+
+// ─── getSep24Info ─────────────────────────────────────────────────────────────
+
+describe('getSep24Info', () => {
+  it('returns parsed info for a known anchor', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => MOCK_INFO,
+    })))
+
+    const result = await getSep24Info(TRANSFER_SERVER)
+    expect(result.withdraw['USDC']?.enabled).toBe(true)
+    expect(result.fee.enabled).toBe(true)
+  })
+
+  it('fetches /info at the correct URL', async () => {
+    let capturedUrl = ''
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      capturedUrl = url
+      return { ok: true, json: async () => MOCK_INFO }
+    }))
+
+    await getSep24Info(TRANSFER_SERVER)
+    expect(capturedUrl).toBe(`${TRANSFER_SERVER}/info`)
+  })
+
+  it('returns cached data on repeated calls without re-fetching', async () => {
+    let fetchCount = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      fetchCount++
+      return { ok: true, json: async () => MOCK_INFO }
+    }))
+
+    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER)
+
+    expect(fetchCount).toBe(1)
+  })
+
+  it('re-fetches after cache is explicitly cleared', async () => {
+    let fetchCount = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      fetchCount++
+      return { ok: true, json: async () => MOCK_INFO }
+    }))
+
+    await getSep24Info(TRANSFER_SERVER)
+    _clearInfoCache()
+    await getSep24Info(TRANSFER_SERVER)
+
+    expect(fetchCount).toBe(2)
+  })
+
+  it('maintains separate cache entries per transfer server', async () => {
+    let fetchCount = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      fetchCount++
+      return { ok: true, json: async () => MOCK_INFO }
+    }))
+
+    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER_B)
+    await getSep24Info(TRANSFER_SERVER)   // cache hit for first
+
+    expect(fetchCount).toBe(2)
+  })
+
+  it('expires cache after 5 minutes', async () => {
+    vi.useFakeTimers()
+    let fetchCount = 0
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      fetchCount++
+      return { ok: true, json: async () => MOCK_INFO }
+    }))
+
+    await getSep24Info(TRANSFER_SERVER)
+    vi.advanceTimersByTime(5 * 60 * 1_000 + 1)
+    await getSep24Info(TRANSFER_SERVER)
+
+    expect(fetchCount).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('throws on a non-ok HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500 })))
+    await expect(getSep24Info(TRANSFER_SERVER)).rejects.toThrow(/HTTP 500/)
+  })
+})

--- a/tests/sep24-withdraw.spec.ts
+++ b/tests/sep24-withdraw.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initiateWithdraw, Sep24WithdrawError } from '@/lib/stellar/sep24'
+
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+
+const PARAMS = {
+  transferServer: TRANSFER_SERVER,
+  jwt: 'test-jwt',
+  assetCode: 'USDC',
+  assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  amount: '100',
+  account: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ',
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── initiateWithdraw ─────────────────────────────────────────────────────────
+
+describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
+  it('returns typed { id, url, type } on a valid anchor response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        type: 'interactive_customer_info_needed',
+        url: 'https://anchor.io/kyc/session-abc',
+        id: 'txn-xyz',
+      }),
+    })))
+
+    const result = await initiateWithdraw(PARAMS)
+    expect(result.id).toBe('txn-xyz')
+    expect(result.url).toBe('https://anchor.io/kyc/session-abc')
+    expect(result.type).toBe('interactive_customer_info_needed')
+  })
+
+  it('sends correct POST body: asset_code, asset_issuer, amount, account', async () => {
+    let body: Record<string, unknown> = {}
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => {
+      body = JSON.parse(opts.body as string) as Record<string, unknown>
+      return {
+        ok: true,
+        json: async () => ({
+          type: 'interactive_customer_info_needed',
+          url: 'https://u',
+          id: 'id1',
+        }),
+      }
+    }))
+
+    await initiateWithdraw(PARAMS)
+    expect(body['asset_code']).toBe('USDC')
+    expect(body['asset_issuer']).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN')
+    expect(body['amount']).toBe('100')
+    expect(body['account']).toBe('GABCDEFGHIJKLMNOPQRSTUVWXYZ')
+  })
+
+  it('sends Authorization: Bearer <jwt> header', async () => {
+    let headers: Record<string, string> = {}
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => {
+      headers = opts.headers as Record<string, string>
+      return {
+        ok: true,
+        json: async () => ({
+          type: 'interactive_customer_info_needed',
+          url: 'https://u',
+          id: 'id1',
+        }),
+      }
+    }))
+
+    await initiateWithdraw(PARAMS)
+    expect(headers['Authorization']).toBe('Bearer test-jwt')
+  })
+
+  it('throws Sep24WithdrawError on non-200, preserving status code and anchor body', async () => {
+    const anchorBody = { error: 'unsupported asset' }
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 422,
+      json: async () => anchorBody,
+    })))
+
+    const caught = await initiateWithdraw(PARAMS).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(Sep24WithdrawError)
+    const err = caught as Sep24WithdrawError
+    expect(err.status).toBe(422)
+    expect(err.anchorBody).toEqual(anchorBody)
+  })
+
+  it('Sep24WithdrawError message includes the HTTP status code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'forbidden' }),
+    })))
+
+    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/403/)
+  })
+
+  it('throws when response type is not interactive_customer_info_needed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ type: 'error', error: 'not supported' }),
+    })))
+
+    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/Unexpected response type/)
+  })
+
+  it('throws when url field is absent from the response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
+    })))
+
+    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/"url"/)
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -113,7 +113,7 @@ export interface Sep24WithdrawResponse {
   id: string
 }
 
-/** All possible status values for a SEP-24 transaction. */
+/** All possible raw status strings an anchor may return for a SEP-24 transaction. */
 export type WithdrawStatusValue =
   | 'incomplete'
   | 'pending_user_transfer_start'
@@ -129,9 +129,25 @@ export type WithdrawStatusValue =
   | 'no_market'
   | 'too_small'
   | 'too_large'
+  | 'expired'
 
-/** The live status of a SEP-24 withdrawal transaction. */
-export interface WithdrawStatus {
+/**
+ * Canonical app-wide status enum.
+ * Raw anchor strings (WithdrawStatusValue) are mapped to this via sep24-status-map.ts.
+ */
+export type WithdrawStatus =
+  | 'pending_user_action'
+  | 'pending_anchor'
+  | 'pending_stellar'
+  | 'pending_external'
+  | 'completed'
+  | 'no_market'
+  | 'refunded'
+  | 'expired'
+  | 'error'
+
+/** The live record of a SEP-24 withdrawal transaction returned by the anchor. */
+export interface Sep24Transaction {
   id: string
   status: WithdrawStatusValue
   amountIn?: string


### PR DESCRIPTION
## Summary

- **closes #27** — `getSep24Fee({ transferServer, assetCode, assetIssuer, amount, type })` with 5-second timeout + one automatic retry; 404 / unsupported paths return `{ ok: false, reason: 'unsupported' }` without throwing
- **closes #28** — `getSep24Info(transferServer)` with fully-typed `Sep24InfoResponse`; 5-minute in-memory cache keyed per transfer server; `_clearInfoCache()` helper for test isolation; cache expiry verified with fake timers
- **closes #29** — `Sep24WithdrawError` class that captures HTTP `status` and `anchorBody` from non-200 responses; `initiateWithdraw` now throws it instead of a generic `Error`
- **closes #32** — canonical `WithdrawStatus` union (`'pending_user_action' | 'pending_anchor' | 'pending_stellar' | 'pending_external' | 'completed' | 'no_market' | 'refunded' | 'expired' | 'error'`) added to `types/index.ts`; old `WithdrawStatus` interface renamed to `Sep24Transaction`; `'expired'` added to `WithdrawStatusValue`; `lib/stellar/sep24-status-map.ts` maps all 15 raw anchor statuses → canonical via `Record<WithdrawStatusValue, WithdrawStatus>` (compile-time exhaustiveness)

## Files changed

| File | Change |
|------|--------|
| `types/index.ts` | Add `WithdrawStatus` canonical union; rename interface → `Sep24Transaction`; add `expired` to `WithdrawStatusValue` |
| `lib/stellar/sep24.ts` | `getSep24Fee`, `getSep24Info`+cache, `Sep24WithdrawError`, update `initiateWithdraw` |
| `lib/stellar/sep24-status-map.ts` | New — exhaustive `Record<WithdrawStatusValue, WithdrawStatus>` mapping |
| `hooks/useWithdrawStatus.ts` | Import `Sep24Transaction` (rename only) |
| `components/offramp/StatusTracker.tsx` | Add `expired` label and terminal state |
| `tests/sep24-fee.spec.ts` | New — 7 tests covering happy path, retry, 404, timeout |
| `tests/sep24-info.spec.ts` | New — 6 tests covering parse, cache hit, expiry, per-server isolation |
| `tests/sep24-withdraw.spec.ts` | New — 7 tests covering response shape, body, JWT header, typed errors |
| `tests/lib/types.test.ts` | Update to `Sep24Transaction`; fix `exactOptionalPropertyTypes` |

## Test plan

- [x] `tests/sep24-fee.spec.ts` — 7 tests pass
- [x] `tests/sep24-info.spec.ts` — 6 tests pass
- [x] `tests/sep24-withdraw.spec.ts` — 7 tests pass
- [x] `tests/lib/types.test.ts` — 2 tests pass
- [x] `tests/sep24-poll.spec.ts` — existing poll tests unaffected