### PR TITLE
created :  [#023] JWT cache keyed by (anchorId, publicKey)

### DIFF
--- a/lib/stellar/jwt-cache.ts
+++ b/lib/stellar/jwt-cache.ts
@@ -1,0 +1,54 @@
+import type { Sep10Auth } from '@/types'
+
+const DEFAULT_CAPACITY = 32
+
+const cache = new Map<string, Sep10Auth>()
+let capacity = DEFAULT_CAPACITY
+
+function key(anchorDomain: string, publicKey: string): string {
+  return `${anchorDomain}::${publicKey}`
+}
+
+function evictIfOverCapacity(): void {
+  while (cache.size > capacity) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) break
+    cache.delete(oldest)
+  }
+}
+
+export function getCachedJwt(anchorDomain: string, publicKey: string): Sep10Auth | undefined {
+  const k = key(anchorDomain, publicKey)
+  const entry = cache.get(k)
+  if (!entry) return undefined
+
+  if (entry.expiresAt.getTime() <= Date.now()) {
+    cache.delete(k)
+    return undefined
+  }
+
+  // Move to end → most-recently-used
+  cache.delete(k)
+  cache.set(k, entry)
+  return entry
+}
+
+export function setCachedJwt(entry: Sep10Auth): void {
+  const k = key(entry.anchorDomain, entry.publicKey)
+  if (cache.has(k)) cache.delete(k)
+  cache.set(k, entry)
+  evictIfOverCapacity()
+}
+
+export function invalidateCachedJwt(anchorDomain: string, publicKey: string): void {
+  cache.delete(key(anchorDomain, publicKey))
+}
+
+export function clearJwtCache(): void {
+  cache.clear()
+}
+
+export function setJwtCacheCapacity(n: number): void {
+  capacity = Math.max(1, n)
+  evictIfOverCapacity()
+}

--- a/lib/stellar/sep10.ts
+++ b/lib/stellar/sep10.ts
@@ -1,7 +1,10 @@
 import { Networks, TransactionBuilder } from '@stellar/stellar-sdk'
 import type { Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk'
 import { getWebAuthEndpoint } from './sep1'
+import { getCachedJwt, setCachedJwt, invalidateCachedJwt } from './jwt-cache'
 import type { Sep10Auth } from '@/types'
+
+export { invalidateCachedJwt, getCachedJwt } from './jwt-cache'
 
 // ─── Typed errors ─────────────────────────────────────────────────────────────
 
@@ -215,6 +218,9 @@ export async function authenticate(
   anchorDomain: string,
   publicKey: string
 ): Promise<Sep10Auth> {
+  const cached = getCachedJwt(anchorDomain, publicKey)
+  if (cached) return cached
+
   const webAuthEndpoint = await getWebAuthEndpoint(anchorDomain)
   if (!webAuthEndpoint) {
     throw new Error(`Anchor "${anchorDomain}" does not support SEP-10 authentication.`)
@@ -223,5 +229,16 @@ export async function authenticate(
   const signedXdr = await signChallenge(transaction, network_passphrase)
   const { token: jwt, expiresAt } = await submitChallenge(webAuthEndpoint, signedXdr)
 
-  return { jwt, anchorDomain, publicKey, expiresAt }
+  const auth: Sep10Auth = { jwt, anchorDomain, publicKey, expiresAt }
+  setCachedJwt(auth)
+  return auth
+}
+
+/**
+ * Drop the cached JWT for this anchor/account pair. Call this when a
+ * downstream anchor request returns 401, so the next `authenticate` call
+ * re-runs the full sign flow.
+ */
+export function invalidateSep10Token(anchorDomain: string, publicKey: string): void {
+  invalidateCachedJwt(anchorDomain, publicKey)
 }

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Networks } from '@stellar/stellar-sdk'
+import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10'
+import { clearJwtCache, setJwtCacheCapacity, getCachedJwt } from '@/lib/stellar/jwt-cache'
+import * as sep1 from '@/lib/stellar/sep1'
+
+const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth'
+const ANCHOR = 'cowrie.exchange'
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
+const CHALLENGE_XDR = 'AAAAAQAAAAC...'
+const SIGNED_XDR = 'AAAAAQAAAAD...'
+
+vi.mock('@stellar/freighter-api', () => ({
+  signTransaction: vi.fn(),
+}))
+
+function makeJwt(expSeconds: number): string {
+  const b64url = (s: string) =>
+    btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = b64url(JSON.stringify({ exp: expSeconds }))
+  return `${header}.${payload}.signature`
+}
+
+async function getFreighter() {
+  return await import('@stellar/freighter-api')
+}
+
+function stubChallengeAndJwt(jwt: string) {
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ transaction: CHALLENGE_XDR, network_passphrase: Networks.PUBLIC }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: jwt }),
+    })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+beforeEach(async () => {
+  vi.restoreAllMocks()
+  clearJwtCache()
+  setJwtCacheCapacity(32)
+  vi.spyOn(sep1, 'getWebAuthEndpoint').mockResolvedValue(WEB_AUTH_ENDPOINT)
+
+  const freighter = await getFreighter()
+  vi.mocked(freighter.signTransaction).mockResolvedValue({
+    signedTxXdr: SIGNED_XDR,
+    signerAddress: PUBLIC_KEY,
+  })
+})
+
+describe('SEP-10 JWT cache', () => {
+  it('second call within validity returns cached token without invoking Freighter', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(exp))
+
+    const first = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('fetch should not be called on cache hit')
+    }))
+
+    const second = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    expect(second.jwt).toBe(first.jwt)
+    expect(second.expiresAt.getTime()).toBe(first.expiresAt.getTime())
+    expect(freighter.signTransaction).not.toHaveBeenCalled()
+  })
+
+  it('expired cached token triggers a fresh sign flow', async () => {
+    const shortExp = Math.floor(Date.now() / 1000) + 1
+    stubChallengeAndJwt(makeJwt(shortExp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+
+    // Advance past expiry
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((shortExp + 5) * 1000))
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+
+    const newExp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(newExp))
+
+    const fresh = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
+    expect(fresh.expiresAt.getTime()).toBe(newExp * 1000)
+
+    vi.useRealTimers()
+  })
+
+  it('invalidateSep10Token forces re-authentication on next call', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(exp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeDefined()
+
+    // Simulate downstream 401 response → invalidate
+    invalidateSep10Token(ANCHOR, PUBLIC_KEY)
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeUndefined()
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+    stubChallengeAndJwt(makeJwt(exp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('LRU evicts the least-recently-used entry past capacity', async () => {
+    setJwtCacheCapacity(2)
+    const exp = Math.floor(Date.now() / 1000) + 3600
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('a.example', PUBLIC_KEY)
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('b.example', PUBLIC_KEY)
+
+    // Touch 'a' so 'b' becomes the LRU
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('c.example', PUBLIC_KEY)
+
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
+    expect(getCachedJwt('c.example', PUBLIC_KEY)).toBeDefined()
+    expect(getCachedJwt('b.example', PUBLIC_KEY)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Three files touched as specified:

[lib/stellar/jwt-cache.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/lib/stellar/jwt-cache.ts) — new LRU keyed by anchorDomain::publicKey. Map insertion order = LRU order; getCachedJwt drops on expiry and re-inserts on hit so it bubbles to MRU; capacity defaults to 32 and is configurable via setJwtCacheCapacity.
[lib/stellar/sep10.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/lib/stellar/sep10.ts) — authenticate() now does a cache lookup before fetching/signing; on a miss it caches the resulting Sep10Auth. New invalidateSep10Token(anchorDomain, publicKey) is exported for callers to use on a downstream 401. getCachedJwt and invalidateCachedJwt are also re-exported for direct use.
[tests/sep10-cache.spec.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/tests/sep10-cache.spec.ts) — covers: (1) second call within validity returns cached token with no Freighter/fetch interaction, (2) expired token (via fake timers) triggers fresh sign flow, (3) invalidateSep10Token simulates the 401 path and forces a re-auth, (4) LRU evicts the least-recently-used entry past capacity.
Note on integration: invalidation is a passive API. Wherever you actually make an authenticated anchor call (e.g. SEP-24 transfer/withdraw), wire invalidateSep10Token(anchorDomain, publicKey) into the 401 branch so the cache stays honest.
Closes #23 