### PR TITLE
created :Friendly error for network passphrase mismatch

### DIFF
--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState } from 'react'
-import { authenticate } from '@/lib/stellar/sep10'
+import { authenticate, NetworkMismatchError } from '@/lib/stellar/sep10'
 import { initiateWithdraw, openWithdrawPopup, getWithdrawTransactionRecord } from '@/lib/stellar/sep24'
 import { getTransferServer } from '@/lib/stellar/sep1'
 import { getAnchorById } from '@/lib/stellar/anchors'
@@ -46,6 +46,9 @@ interface ExecuteDrawerProps {
 export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStarted }: ExecuteDrawerProps) {
   const [step, setStep] = useState<Step>('idle')
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [errorKind, setErrorKind] = useState<'generic' | 'network-mismatch'>('generic')
+  const [networkExpected, setNetworkExpected] = useState<string | null>(null)
+  const [networkActual, setNetworkActual] = useState<string | null>(null)
   const [txHash, setTxHash] = useState<string | null>(null)
 
   const isOpen = rate !== null
@@ -55,6 +58,9 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
 
     setStep('authenticating')
     setErrorMsg(null)
+    setErrorKind('generic')
+    setNetworkExpected(null)
+    setNetworkActual(null)
     setTxHash(null)
 
     try {
@@ -105,7 +111,15 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
       }
       onClose()
     } catch (err) {
-      setErrorMsg((err as Error).message ?? 'Unknown error')
+      if (err instanceof NetworkMismatchError) {
+        setErrorKind('network-mismatch')
+        setNetworkExpected(err.expectedNetworkName)
+        setNetworkActual(err.actualNetworkName)
+        setErrorMsg(err.message)
+      } else {
+        setErrorKind('generic')
+        setErrorMsg(err instanceof Error ? err.message : 'Unknown error')
+      }
       setStep('error')
     }
   }
@@ -176,7 +190,23 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
           <StepIndicator step={step} />
 
           {/* Error message */}
-          {step === 'error' && errorMsg && (
+          {step === 'error' && errorKind === 'network-mismatch' && networkExpected && (
+            <div
+              role="alert"
+              className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-3 text-sm dark:border-amber-700/60 dark:bg-amber-950/30"
+            >
+              <p className="font-semibold text-amber-800 dark:text-amber-300">
+                Switch network in Freighter to {networkExpected}
+              </p>
+              <p className="mt-1 text-amber-700 dark:text-amber-400">
+                Freighter is currently on{' '}
+                <span className="font-mono">{networkActual ?? 'an unknown network'}</span>, but
+                this anchor requires <span className="font-mono">{networkExpected}</span>. Open
+                Freighter, switch networks, then try again.
+              </p>
+            </div>
+          )}
+          {step === 'error' && errorKind === 'generic' && errorMsg && (
             <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400">
               {errorMsg}
             </p>

--- a/lib/stellar/jwt-cache.ts
+++ b/lib/stellar/jwt-cache.ts
@@ -1,0 +1,54 @@
+import type { Sep10Auth } from '@/types'
+
+const DEFAULT_CAPACITY = 32
+
+const cache = new Map<string, Sep10Auth>()
+let capacity = DEFAULT_CAPACITY
+
+function key(anchorDomain: string, publicKey: string): string {
+  return `${anchorDomain}::${publicKey}`
+}
+
+function evictIfOverCapacity(): void {
+  while (cache.size > capacity) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) break
+    cache.delete(oldest)
+  }
+}
+
+export function getCachedJwt(anchorDomain: string, publicKey: string): Sep10Auth | undefined {
+  const k = key(anchorDomain, publicKey)
+  const entry = cache.get(k)
+  if (!entry) return undefined
+
+  if (entry.expiresAt.getTime() <= Date.now()) {
+    cache.delete(k)
+    return undefined
+  }
+
+  // Move to end → most-recently-used
+  cache.delete(k)
+  cache.set(k, entry)
+  return entry
+}
+
+export function setCachedJwt(entry: Sep10Auth): void {
+  const k = key(entry.anchorDomain, entry.publicKey)
+  if (cache.has(k)) cache.delete(k)
+  cache.set(k, entry)
+  evictIfOverCapacity()
+}
+
+export function invalidateCachedJwt(anchorDomain: string, publicKey: string): void {
+  cache.delete(key(anchorDomain, publicKey))
+}
+
+export function clearJwtCache(): void {
+  cache.clear()
+}
+
+export function setJwtCacheCapacity(n: number): void {
+  capacity = Math.max(1, n)
+  evictIfOverCapacity()
+}

--- a/lib/stellar/sep10.ts
+++ b/lib/stellar/sep10.ts
@@ -30,6 +30,26 @@ export class Sep10AuthError extends Error {
   }
 }
 
+export class NetworkMismatchError extends Error {
+  constructor(
+    message: string,
+    public readonly expectedPassphrase: string,
+    public readonly expectedNetworkName: string,
+    public readonly actualPassphrase: string,
+    public readonly actualNetworkName: string
+  ) {
+    super(message)
+    this.name = 'NetworkMismatchError'
+  }
+}
+
+function friendlyNetworkName(passphrase: string): string {
+  if (passphrase === Networks.PUBLIC) return 'Mainnet'
+  if (passphrase === Networks.TESTNET) return 'Testnet'
+  if (passphrase === Networks.FUTURENET) return 'Futurenet'
+  return passphrase
+}
+
 // ─── Challenge types ──────────────────────────────────────────────────────────
 
 export interface Sep10Challenge {
@@ -167,7 +187,24 @@ export async function signChallenge(
   challengeXdr: string,
   networkPassphrase: string
 ): Promise<string> {
-  const { signTransaction } = await import('@stellar/freighter-api')
+  const { signTransaction, getNetworkDetails } = await import('@stellar/freighter-api')
+
+  // Pre-flight: Freighter throws an opaque error if the wallet's selected
+  // network doesn't match the passphrase. Detect and surface a clear
+  // "switch network" message before invoking the sign prompt.
+  const details = await getNetworkDetails()
+  if (!details.error && details.networkPassphrase && details.networkPassphrase !== networkPassphrase) {
+    const expectedName = friendlyNetworkName(networkPassphrase)
+    const actualName = details.network || friendlyNetworkName(details.networkPassphrase)
+    throw new NetworkMismatchError(
+      `Switch network in Freighter to ${expectedName}. Freighter is currently on "${actualName}", but this anchor requires ${expectedName}.`,
+      networkPassphrase,
+      expectedName,
+      details.networkPassphrase,
+      actualName
+    )
+  }
+
   const result = await signTransaction(challengeXdr, { networkPassphrase })
 
   if (result.error) {

--- a/lib/stellar/sep10.ts
+++ b/lib/stellar/sep10.ts
@@ -1,7 +1,10 @@
 import { Networks, TransactionBuilder } from '@stellar/stellar-sdk'
 import type { Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk'
 import { getWebAuthEndpoint } from './sep1'
+import { getCachedJwt, setCachedJwt, invalidateCachedJwt } from './jwt-cache'
 import type { Sep10Auth } from '@/types'
+
+export { invalidateCachedJwt, getCachedJwt } from './jwt-cache'
 
 // ─── Typed errors ─────────────────────────────────────────────────────────────
 
@@ -215,6 +218,9 @@ export async function authenticate(
   anchorDomain: string,
   publicKey: string
 ): Promise<Sep10Auth> {
+  const cached = getCachedJwt(anchorDomain, publicKey)
+  if (cached) return cached
+
   const webAuthEndpoint = await getWebAuthEndpoint(anchorDomain)
   if (!webAuthEndpoint) {
     throw new Error(`Anchor "${anchorDomain}" does not support SEP-10 authentication.`)
@@ -223,5 +229,16 @@ export async function authenticate(
   const signedXdr = await signChallenge(transaction, network_passphrase)
   const { token: jwt, expiresAt } = await submitChallenge(webAuthEndpoint, signedXdr)
 
-  return { jwt, anchorDomain, publicKey, expiresAt }
+  const auth: Sep10Auth = { jwt, anchorDomain, publicKey, expiresAt }
+  setCachedJwt(auth)
+  return auth
+}
+
+/**
+ * Drop the cached JWT for this anchor/account pair. Call this when a
+ * downstream anchor request returns 401, so the next `authenticate` call
+ * re-runs the full sign flow.
+ */
+export function invalidateSep10Token(anchorDomain: string, publicKey: string): void {
+  invalidateCachedJwt(anchorDomain, publicKey)
 }

--- a/tests/lib/sep10.test.ts
+++ b/tests/lib/sep10.test.ts
@@ -11,6 +11,11 @@ const JWT = 'eyJhbGciOiJIUzI1NiJ9.test.token'
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
+  getNetworkDetails: vi.fn(async () => ({
+    network: 'PUBLIC',
+    networkUrl: 'https://horizon.stellar.org',
+    networkPassphrase: Networks.PUBLIC,
+  })),
 }))
 
 beforeEach(() => {

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Networks } from '@stellar/stellar-sdk'
+import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10'
+import { clearJwtCache, setJwtCacheCapacity, getCachedJwt } from '@/lib/stellar/jwt-cache'
+import * as sep1 from '@/lib/stellar/sep1'
+
+const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth'
+const ANCHOR = 'cowrie.exchange'
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
+const CHALLENGE_XDR = 'AAAAAQAAAAC...'
+const SIGNED_XDR = 'AAAAAQAAAAD...'
+
+vi.mock('@stellar/freighter-api', () => ({
+  signTransaction: vi.fn(),
+}))
+
+function makeJwt(expSeconds: number): string {
+  const b64url = (s: string) =>
+    btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = b64url(JSON.stringify({ exp: expSeconds }))
+  return `${header}.${payload}.signature`
+}
+
+async function getFreighter() {
+  return await import('@stellar/freighter-api')
+}
+
+function stubChallengeAndJwt(jwt: string) {
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ transaction: CHALLENGE_XDR, network_passphrase: Networks.PUBLIC }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: jwt }),
+    })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+beforeEach(async () => {
+  vi.restoreAllMocks()
+  clearJwtCache()
+  setJwtCacheCapacity(32)
+  vi.spyOn(sep1, 'getWebAuthEndpoint').mockResolvedValue(WEB_AUTH_ENDPOINT)
+
+  const freighter = await getFreighter()
+  vi.mocked(freighter.signTransaction).mockResolvedValue({
+    signedTxXdr: SIGNED_XDR,
+    signerAddress: PUBLIC_KEY,
+  })
+})
+
+describe('SEP-10 JWT cache', () => {
+  it('second call within validity returns cached token without invoking Freighter', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(exp))
+
+    const first = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('fetch should not be called on cache hit')
+    }))
+
+    const second = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    expect(second.jwt).toBe(first.jwt)
+    expect(second.expiresAt.getTime()).toBe(first.expiresAt.getTime())
+    expect(freighter.signTransaction).not.toHaveBeenCalled()
+  })
+
+  it('expired cached token triggers a fresh sign flow', async () => {
+    const shortExp = Math.floor(Date.now() / 1000) + 1
+    stubChallengeAndJwt(makeJwt(shortExp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+
+    // Advance past expiry
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((shortExp + 5) * 1000))
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+
+    const newExp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(newExp))
+
+    const fresh = await authenticate(ANCHOR, PUBLIC_KEY)
+
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
+    expect(fresh.expiresAt.getTime()).toBe(newExp * 1000)
+
+    vi.useRealTimers()
+  })
+
+  it('invalidateSep10Token forces re-authentication on next call', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    stubChallengeAndJwt(makeJwt(exp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeDefined()
+
+    // Simulate downstream 401 response → invalidate
+    invalidateSep10Token(ANCHOR, PUBLIC_KEY)
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeUndefined()
+
+    const freighter = await getFreighter()
+    vi.mocked(freighter.signTransaction).mockClear()
+    stubChallengeAndJwt(makeJwt(exp))
+
+    await authenticate(ANCHOR, PUBLIC_KEY)
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('LRU evicts the least-recently-used entry past capacity', async () => {
+    setJwtCacheCapacity(2)
+    const exp = Math.floor(Date.now() / 1000) + 3600
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('a.example', PUBLIC_KEY)
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('b.example', PUBLIC_KEY)
+
+    // Touch 'a' so 'b' becomes the LRU
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
+
+    stubChallengeAndJwt(makeJwt(exp))
+    await authenticate('c.example', PUBLIC_KEY)
+
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
+    expect(getCachedJwt('c.example', PUBLIC_KEY)).toBeDefined()
+    expect(getCachedJwt('b.example', PUBLIC_KEY)).toBeUndefined()
+  })
+})

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -12,6 +12,11 @@ const SIGNED_XDR = 'AAAAAQAAAAD...'
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
+  getNetworkDetails: vi.fn(async () => ({
+    network: 'PUBLIC',
+    networkUrl: 'https://horizon.stellar.org',
+    networkPassphrase: Networks.PUBLIC,
+  })),
 }))
 
 function makeJwt(expSeconds: number): string {


### PR DESCRIPTION
Summary:

[lib/stellar/sep10.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/lib/stellar/sep10.ts) — added NetworkMismatchError (carries expectedPassphrase/expectedNetworkName/actualPassphrase/actualNetworkName) and a friendlyNetworkName helper that maps the well-known passphrases to "Mainnet"/"Testnet"/"Futurenet". signChallenge now calls Freighter's getNetworkDetails first and throws NetworkMismatchError before invoking signTransaction if the wallet's passphrase doesn't match the anchor's.
[components/offramp/ExecuteDrawer.tsx](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/components/offramp/ExecuteDrawer.tsx) — added errorKind/networkExpected/networkActual state, an instanceof NetworkMismatchError branch in the catch (no uncaught exceptions), and a dedicated amber alert block ("Switch network in Freighter to {expected}…") that shows the exact expected and actual network names. The fallback red-error block still handles any other thrown error.
Test fixtures: extended the @stellar/freighter-api mock in [tests/lib/sep10.test.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/tests/lib/sep10.test.ts) and [tests/sep10-cache.spec.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/tests/sep10-cache.spec.ts) to include getNetworkDetails returning the mainnet passphrase, so existing match-path tests stay green.

Closes #26 