### PR TITLE
feat(offramp): completion celebration UI with localized amount

### DIFF
--- a/app/offramp/page.tsx
+++ b/app/offramp/page.tsx
@@ -104,6 +104,7 @@ export default function OfframpPage() {
           status={withdrawStatus.status}
           amountIn={withdrawStatus.amountIn}
           amountOut={withdrawStatus.amountOut}
+          currencyCode={corridorId.split('-')[1]?.toUpperCase() ?? 'USD'}
           stellarTransactionId={withdrawStatus.stellarTransactionId}
           isLoading={withdrawStatus.isLoading}
           error={withdrawStatus.error}

--- a/components/offramp/StatusTracker.tsx
+++ b/components/offramp/StatusTracker.tsx
@@ -1,11 +1,14 @@
 'use client'
 import type { WithdrawStatusValue } from '@/types'
+import { formatDeliveredAmount } from '@/lib/format'
 
 interface StatusTrackerProps {
   transactionId: string
   status: WithdrawStatusValue | undefined
   amountIn: string | undefined
   amountOut: string | undefined
+  /** ISO 4217 currency code for the destination corridor (e.g. "NGN", "KES"). */
+  currencyCode: string
   stellarTransactionId: string | undefined
   isLoading: boolean
   error: string | undefined
@@ -55,14 +58,22 @@ export function StatusTracker({
   status,
   amountIn,
   amountOut,
+  currencyCode,
   stellarTransactionId,
   isLoading,
   error,
 }: StatusTrackerProps) {
   const isTerminal = status ? TERMINAL.includes(status) : false
+  const isCompleted = status === 'completed'
 
   return (
-    <div className="rounded-xl border border-gray-200 p-5 dark:border-gray-700">
+    <div
+      className={`rounded-xl border p-5 transition-colors ${
+        isCompleted
+          ? 'border-green-200 bg-green-50 dark:border-green-800/40 dark:bg-green-950/20'
+          : 'border-gray-200 dark:border-gray-700'
+      }`}
+    >
       <div className="mb-4 flex items-start justify-between">
         <div>
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Transaction Status</h3>
@@ -75,6 +86,18 @@ export function StatusTracker({
           </span>
         )}
       </div>
+
+      {/* Completion celebration */}
+      {isCompleted && amountOut && (
+        <div className="mb-4 animate-in fade-in slide-in-from-bottom-2 duration-500">
+          <p className="text-xs font-medium uppercase tracking-wide text-green-600 dark:text-green-400">
+            Delivered
+          </p>
+          <p className="mt-0.5 text-3xl font-bold tabular-nums text-green-700 dark:text-green-300">
+            {formatDeliveredAmount(amountOut, currencyCode)}
+          </p>
+        </div>
+      )}
 
       {/* Status badge */}
       <div className="mb-4 flex items-center gap-2">
@@ -91,8 +114,8 @@ export function StatusTracker({
         </p>
       )}
 
-      {/* Amount details */}
-      {(amountIn || amountOut) && (
+      {/* Amount details — hidden when celebration banner is shown */}
+      {(amountIn || amountOut) && !isCompleted && (
         <dl className="mb-4 space-y-1.5 text-sm">
           {amountIn && (
             <div className="flex justify-between">

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats a delivered amount string using Intl.NumberFormat with currency style.
+ * Falls back to `${amount} ${currencyCode}` if the value is not a valid number
+ * or the currency code is unrecognised by the runtime.
+ *
+ * @param amount      Raw amount string from the anchor (e.g. "158000.50")
+ * @param currencyCode ISO 4217 currency code (e.g. "NGN", "KES", "BRL")
+ */
+export function formatDeliveredAmount(amount: string, currencyCode: string): string {
+  const numeric = parseFloat(amount)
+  if (!isFinite(numeric)) return `${amount} ${currencyCode}`
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: currencyCode,
+      maximumFractionDigits: 2,
+    }).format(numeric)
+  } catch {
+    return `${currencyCode} ${numeric.toFixed(2)}`
+  }
+}

--- a/tests/components/StatusTracker.test.tsx
+++ b/tests/components/StatusTracker.test.tsx
@@ -7,6 +7,7 @@ const BASE_PROPS = {
   status: undefined,
   amountIn: undefined,
   amountOut: undefined,
+  currencyCode: 'NGN',
   stellarTransactionId: undefined,
   isLoading: false,
   error: undefined,
@@ -33,17 +34,33 @@ describe('StatusTracker', () => {
     expect(screen.getByText('Awaiting your payment')).toBeInTheDocument()
   })
 
-  it('shows amount in and out when provided', () => {
+  it('shows completion celebration banner with localized amount when completed', () => {
     render(
       <StatusTracker
         {...BASE_PROPS}
         status="completed"
         amountIn="100"
-        amountOut="154840 NGN"
+        amountOut="154840"
+      />
+    )
+    expect(screen.getByText('Delivered')).toBeInTheDocument()
+    // The formatted amount should contain the numeric value
+    expect(screen.getByText(/154,840|154840/)).toBeInTheDocument()
+    // The raw amount detail row should not be shown when completed
+    expect(screen.queryByText('You receive')).not.toBeInTheDocument()
+  })
+
+  it('shows amount details when status is not completed', () => {
+    render(
+      <StatusTracker
+        {...BASE_PROPS}
+        status="pending_external"
+        amountIn="100"
+        amountOut="154840"
       />
     )
     expect(screen.getByText('100 USDC')).toBeInTheDocument()
-    expect(screen.getByText('154840 NGN')).toBeInTheDocument()
+    expect(screen.getByText('You receive')).toBeInTheDocument()
   })
 
   it('shows the error message when error is provided', () => {

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { formatDeliveredAmount } from '@/lib/format'
+
+describe('formatDeliveredAmount', () => {
+  it('formats NGN with currency style', () => {
+    const result = formatDeliveredAmount('158000', 'NGN')
+    expect(result).toContain('158')
+    expect(result).toMatch(/NGN|₦/)
+  })
+
+  it('formats KES with currency style', () => {
+    const result = formatDeliveredAmount('13500.50', 'KES')
+    expect(result).toContain('13')
+    expect(result).toMatch(/KES|KSh/)
+  })
+
+  it('formats BRL with currency style', () => {
+    const result = formatDeliveredAmount('520.75', 'BRL')
+    expect(result).toContain('520')
+    expect(result).toMatch(/BRL|R\$/)
+  })
+
+  it('falls back gracefully for a non-numeric string', () => {
+    const result = formatDeliveredAmount('N/A', 'NGN')
+    expect(result).toBe('N/A NGN')
+  })
+
+  it('falls back gracefully for an empty string', () => {
+    const result = formatDeliveredAmount('', 'KES')
+    expect(result).toBe(' KES')
+  })
+
+  it('handles zero correctly', () => {
+    const result = formatDeliveredAmount('0', 'MXN')
+    expect(result).toContain('0')
+    expect(result).toMatch(/MXN|\$/)
+  })
+
+  it('handles large numbers without throwing', () => {
+    expect(() => formatDeliveredAmount('9999999.99', 'NGN')).not.toThrow()
+  })
+})


### PR DESCRIPTION
fixed #50 

feat(offramp): completion celebration UI with localized amountDescription
  
  When a SEP-24 withdrawal reaches `completed` status, the StatusTracker
  now shows a prominent delivery confirmation instead of the plain amount
  detail row.
  
  Changes
  -------
  
  lib/format.ts (new)
    - formatDeliveredAmount(amount, currencyCode): formats a raw anchor
      amount string using Intl.NumberFormat with style: 'currency'.
      Uses undefined locale so the browser picks the user's preferred
      locale automatically. Falls back to "${currencyCode} ${n.toFixed(2)}"
      for unrecognised currency codes or non-numeric input.
  
  components/offramp/StatusTracker.tsx
    - Added required currencyCode: string prop (ISO 4217).
    - On status === 'completed' + amountOut present, renders a celebration
      banner: "Delivered" label + formatted amount in text-3xl font-bold
      with animate-in fade-in slide-in-from-bottom-2 (subtle, no confetti).
    - Card border and background transition to green on completion
      (border-green-200 bg-green-50 / dark:border-green-800/40
      dark:bg-green-950/20) for full dark mode parity.
    - Raw amountIn/amountOut detail rows are hidden when completed;
      the banner replaces them to avoid duplication.
  
  app/offramp/page.tsx
    - Derives currencyCode from corridorId at the call site:
      corridorId.split('-')[1]?.toUpperCase() ?? 'USD'
      e.g. 'usdc-ngn' → 'NGN', 'usdc-brl' → 'BRL'.
    - Passes currencyCode down to StatusTracker.
  
  tests/components/StatusTracker.test.tsx
    - Added currencyCode: 'NGN' to BASE_PROPS.
    - Replaced the single "shows amount in and out" test with:
        · completion banner test: asserts "Delivered" label and formatted
          numeric value are present; asserts "You receive" row is absent.
        · non-completed detail row test: asserts raw rows render for
          in-progress statuses.
  
  tests/lib/format.test.ts (new)
    - Covers: NGN, KES, BRL formatting; non-numeric fallback; empty
      string; zero; large numbers without throwing.
  
  Acceptance criteria met
  -----------------------
    ✓ Intl.NumberFormat with currency style, locale-aware
    ✓ Subtle success animation (animate-in, no confetti)
    ✓ Dark mode parity (green tones in both themes)
    ✓ Values localized per corridor currency