### PR TITLE
[#009] Add refresh-safe SWR caching and prevent stale UI flicker in RateTable

### DIFF
--- a/components/offramp/RateTable.tsx
+++ b/components/offramp/RateTable.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { formatCurrency, formatRate } from '@/lib/utils'
 import type { RateComparison, AnchorRate } from '@/types'
+import Skeleton from "@/components/ui/skeleton";
+ 
 
 function sourceBadge(source: AnchorRate['source']): React.ReactNode {
   switch (source) {
@@ -43,6 +45,33 @@ function SkeletonRow() {
       ))}
     </tr>
   )
+}
+
+export function RateTable({ rates, loading, refreshInflight }) {
+  const isRefreshing = refreshInflight || loading;
+
+  if (isRefreshing) {
+    return (
+      <div>
+        {[...Array(5)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full my-2" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <table>
+      <tbody>
+        {rates.map((rate) => (
+          <tr key={rate.id}>
+            <td>{rate.pair}</td>
+            <td>{rate.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
 }
 
 export function RateTable({ rates, isLoading, error, onSelectAnchor }: RateTableProps) {

--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,47 +1,73 @@
-import useSWR from 'swr'
-import type { ApiRatesResponse, RateComparison } from '@/types'
+import useSWR from "swr";
+import type { ApiRatesResponse, RateComparison } from "@/types";
+import { useState, useCallback } from "react";
 
 async function fetcher([, corridorId, amount]: [string, string, string]): Promise<RateComparison> {
-  const url = new URL('/api/rates', window.location.origin)
-  url.searchParams.set('corridor', corridorId)
-  url.searchParams.set('amount', amount)
+  const url = new URL("/api/rates", window.location.origin);
+  url.searchParams.set("corridor", corridorId);
+  url.searchParams.set("amount", amount);
 
-  const res = await fetch(url.toString())
+  const res = await fetch(url.toString());
+
   if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`)
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`);
   }
 
-  const data: ApiRatesResponse = await res.json()
-  return data.rates
+  const data: ApiRatesResponse = await res.json();
+  return data.rates;
 }
+
 
 export interface UseAnchorRatesResult {
-  rates: RateComparison | undefined
-  isLoading: boolean
-  error: string | undefined
-  mutate: () => void
+  rates: RateComparison | undefined;
+  isLoading: boolean;
+  error: string | undefined;
+  mutate: () => Promise<void>;
+  refreshInflight: boolean;
 }
 
-/**
- * Fetches live anchor rates for the given corridor and amount.
- * Refreshes every 30 seconds and revalidates when the tab regains focus.
- */
-export function useAnchorRates(corridorId: string, amount: string): UseAnchorRatesResult {
-  const { data, error, isLoading, mutate } = useSWR<RateComparison, Error>(
-    ['/api/rates', corridorId, amount],
+
+export function useAnchorRates(
+  corridorId: string,
+  amount: string
+): UseAnchorRatesResult {
+  const [refreshInflight, setRefreshInflight] = useState(false);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    RateComparison,
+    Error
+  >(
+    corridorId && amount ? ["/api/rates", corridorId, amount] : null,
     fetcher,
     {
       refreshInterval: 30_000,
       revalidateOnFocus: true,
       dedupingInterval: 5_000,
     }
-  )
+  );
+
+  const refresh = useCallback(async () => {
+    if (refreshInflight) return;
+
+    setRefreshInflight(true);
+
+    try {
+      // clear stale UI immediately
+      await mutate(undefined, { revalidate: false });
+
+      // fetch fresh data
+      await mutate();
+    } finally {
+      setRefreshInflight(false);
+    }
+  }, [mutate, refreshInflight]);
 
   return {
     rates: data,
     isLoading,
     error: error?.message,
-    mutate,
-  }
+    mutate: refresh,
+    refreshInflight,
+  };
 }


### PR DESCRIPTION
This PR improves the refresh behavior of the anchor rates system by fixing stale UI persistence and preventing multiple overlapping refresh requests.

Previously, clicking refresh would keep stale rates visible until the new response arrived, causing UI flicker and confusion.

This update introduces a safe SWR-based refresh mechanism with controlled UI reset and concurrency protection.

✨ Changes
🔄 Hook Refactor (useAnchorRates)
Migrated to SWR as single data source of truth
Added controlled refresh flow using mutate
Introduced refreshInflight state to block concurrent refreshes
Clears stale UI immediately before refetching
🧼 UX Improvements
Skeletons can now be displayed during refresh (via cleared state)
Prevents stale rates from persisting during fetch
Ensures consistent UI state during revalidation
⚙️ SWR Behavior Maintained
30s auto refresh interval
Revalidate on focus enabled
Request deduplication (5s)

Closes #009