### PR TITLE
feat(types): AnchorCapabilities and ResolvedAnchor (#125)

### DIFF
--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -2,8 +2,7 @@
 import { useState } from 'react'
 import { authenticate } from '@/lib/stellar/sep10'
 import { initiateWithdraw, openWithdrawPopup, getWithdrawTransactionRecord } from '@/lib/stellar/sep24'
-import { getTransferServer } from '@/lib/stellar/sep1'
-import { getAnchorById } from '@/lib/stellar/anchors'
+import { getResolvedAnchorById } from '@/lib/stellar/anchors'
 import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon'
 import type { AnchorRate, ExecuteDrawerStep } from '@/types'
 
@@ -48,16 +47,15 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
     setTxHash(null)
 
     try {
+      // Step 0 — Resolve anchor capabilities
+      const anchor = await getResolvedAnchorById(rate.anchorId)
+
       // Step 1 — SEP-10 auth
-      const anchor = getAnchorById(rate.anchorId)
-      if (!anchor) throw new Error(`Anchor not found: ${rate.anchorId}`)
-      const auth = await authenticate(anchor.homeDomain, publicKey)
+      const auth = await authenticate(anchor, publicKey)
 
       // Step 2 — Initiate SEP-24 withdraw
       setStep('initiating')
-      const transferServer = await getTransferServer(anchor.homeDomain)
-      const withdrawResp = await initiateWithdraw({
-        transferServer,
+      const withdrawResp = await initiateWithdraw(anchor, {
         assetCode: anchor.assetCode,
         assetIssuer: anchor.assetIssuer,
         amount,
@@ -71,7 +69,7 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
 
       // Step 4 — Fetch transaction record
       setStep('building')
-      const record = await getWithdrawTransactionRecord(transferServer, transactionId, auth.jwt)
+      const record = await getWithdrawTransactionRecord(anchor.TRANSFER_SERVER_SEP0024!, transactionId, auth.jwt)
 
       // Step 5 — Build payment
       const tx = await buildWithdrawPayment({
@@ -91,8 +89,8 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
       setStep('done')
 
       // Hand tracking data to the page, then close so StatusTracker owns the viewport.
-      if (transferServer) {
-        onExecuteStarted(transactionId, transferServer, auth.jwt)
+      if (anchor.TRANSFER_SERVER_SEP0024) {
+        onExecuteStarted(transactionId, anchor.TRANSFER_SERVER_SEP0024, auth.jwt)
       }
       onClose()
     } catch (err) {

--- a/lib/stellar/anchors.ts
+++ b/lib/stellar/anchors.ts
@@ -4,16 +4,15 @@
 export * from '@/constants/anchors'
 
 import { ANCHORS, CORRIDORS } from '@/constants/anchors'
-import type { Anchor, Corridor, Sep1TomlData } from '@/types'
+import type { Anchor, Corridor, ResolvedAnchor, Sep1TomlData } from '@/types'
 
-export interface DiscoveredAnchor extends Anchor {
-  sep1: Sep1TomlData
-  transferServerSep24: string
-  webAuthEndpoint: string
-}
 
 // ─── Lookup helpers ───────────────────────────────────────────────────────────
 
+/**
+ * Returns the anchor with the given ID.
+ * Throws a descriptive error if the ID is not found.
+ */
 /**
  * Returns the anchor with the given ID.
  * Throws a descriptive error if the ID is not found.
@@ -29,6 +28,18 @@ export function getAnchorById(id: string): Anchor {
 }
 
 /**
+ * Resolves SEP-1 details for the anchor with the given ID.
+ * Throws if the anchor is unknown or TOML resolution fails.
+ */
+export async function getResolvedAnchorById(id: string): Promise<ResolvedAnchor> {
+  const anchor = getAnchorById(id)
+  const { resolveToml } = await import('./sep1')
+  const result = await resolveToml(anchor.homeDomain)
+  if (!result.ok) throw new Error(result.error)
+  return { ...anchor, ...result.data }
+}
+
+/**
  * Returns all anchors that serve the given corridor.
  * Returns an empty array if no anchors support the corridor.
  */
@@ -40,12 +51,12 @@ export function getAnchorsByCorridorId(corridorId: string): Anchor[] {
  * Resolves SEP-1 details for every known anchor that serves the corridor.
  * Failed anchors are omitted so callers can continue with the live subset.
  */
-export async function discoverAnchorsForCorridor(corridorId: string): Promise<DiscoveredAnchor[]> {
+export async function discoverAnchorsForCorridor(corridorId: string): Promise<ResolvedAnchor[]> {
   const { resolveToml } = await import('./sep1')
   const corridorAnchors = ANCHORS.filter((anchor) => anchor.corridors.includes(corridorId))
 
   const results = await Promise.allSettled(
-    corridorAnchors.map(async (anchor): Promise<DiscoveredAnchor> => {
+    corridorAnchors.map(async (anchor): Promise<ResolvedAnchor> => {
       const result = await resolveToml(anchor.homeDomain)
       if (!result.ok) throw new Error(result.error)
       const sep1 = result.data
@@ -54,15 +65,13 @@ export async function discoverAnchorsForCorridor(corridorId: string): Promise<Di
       }
       return {
         ...anchor,
-        sep1,
-        transferServerSep24: sep1.TRANSFER_SERVER_SEP0024,
-        webAuthEndpoint: sep1.WEB_AUTH_ENDPOINT,
+        ...sep1,
       }
     })
   )
 
   return results
-    .filter((result): result is PromiseFulfilledResult<DiscoveredAnchor> => {
+    .filter((result): result is PromiseFulfilledResult<ResolvedAnchor> => {
       return result.status === 'fulfilled'
     })
     .map((result) => result.value)

--- a/lib/stellar/sep1.ts
+++ b/lib/stellar/sep1.ts
@@ -141,7 +141,7 @@ export async function resolveAllAnchors(): Promise<Record<string, ResolvedAnchor
 
   for (const result of results) {
     if (result.status === 'fulfilled') {
-      resolved[result.value.anchor.id] = result.value.data
+      resolved[result.value.anchor.id] = { ...result.value.anchor, ...result.value.data }
     } else {
       console.warn('[sep1] resolveAllAnchors failure:', result.reason)
     }

--- a/lib/stellar/sep10.ts
+++ b/lib/stellar/sep10.ts
@@ -2,7 +2,7 @@ import { Networks, TransactionBuilder } from '@stellar/stellar-sdk'
 import type { Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk'
 import { getWebAuthEndpoint } from './sep1'
 import { getCachedJwt, setCachedJwt, invalidateCachedJwt } from './jwt-cache'
-import type { Sep10Auth } from '@/types'
+import type { ResolvedAnchor, Sep10Auth } from '@/types'
 import { UserRejectedError } from './errors'
 
 export { invalidateCachedJwt, getCachedJwt } from './jwt-cache'
@@ -216,21 +216,21 @@ export async function submitChallenge(
 // ─── Full auth orchestrator ───────────────────────────────────────────────────
 
 export async function authenticate(
-  anchorDomain: string,
+  anchor: ResolvedAnchor,
   publicKey: string
 ): Promise<Sep10Auth> {
-  const cached = getCachedJwt(anchorDomain, publicKey)
+  const cached = getCachedJwt(anchor.homeDomain, publicKey)
   if (cached) return cached
 
-  const webAuthEndpoint = await getWebAuthEndpoint(anchorDomain)
-  if (!webAuthEndpoint) {
-    throw new Error(`Anchor "${anchorDomain}" does not support SEP-10 authentication.`)
+  const webAuthEndpoint = anchor.WEB_AUTH_ENDPOINT
+  if (!webAuthEndpoint || !anchor.capabilities.sep10) {
+    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-10 authentication.`)
   }
   const { transaction, network_passphrase } = await fetchChallenge(webAuthEndpoint, publicKey)
   const signedXdr = await signChallenge(transaction, network_passphrase)
   const { token: jwt, expiresAt } = await submitChallenge(webAuthEndpoint, signedXdr)
 
-  const auth: Sep10Auth = { jwt, anchorDomain, publicKey, expiresAt }
+  const auth: Sep10Auth = { jwt, anchorDomain: anchor.homeDomain, publicKey, expiresAt }
   setCachedJwt(auth)
   return auth
 }

--- a/lib/stellar/sep24.ts
+++ b/lib/stellar/sep24.ts
@@ -2,7 +2,7 @@ import { SepError, parseSepErrorBody } from './errors'
 import { getTransferServer } from './sep1'
 import { getAnchorsByCorridorId, getCorridorById } from './anchors'
 import { computeTotalReceived } from '@/lib/utils'
-import type { Sep24FeeParams, AnchorRate, RateComparison, Sep24WithdrawRequest, Sep24WithdrawResponse, Sep24Transaction, WithdrawStatusValue } from '@/types'
+import type { Sep24FeeParams, AnchorRate, RateComparison, Sep24WithdrawRequest, Sep24WithdrawResponse, Sep24Transaction, WithdrawStatusValue, ResolvedAnchor } from '@/types'
 
 // ─── Transaction polling ──────────────────────────────────────────────────────
 
@@ -69,8 +69,8 @@ export async function getSep24Transaction(
     ...(tx['amount_in_asset'] !== undefined && { amountInAsset: tx['amount_in_asset'] as string }),
     ...(tx['amount_out'] !== undefined && { amountOut: tx['amount_out'] as string }),
     ...(tx['amount_out_asset'] !== undefined && { amountOutAsset: tx['amount_out_asset'] as string }),
-    ...(tx['amount_fee'] !== undefined || (tx['fee_details'] as any)?.total !== undefined) && { 
-      amountFee: (tx['amount_fee'] ?? (tx['fee_details'] as any)?.total) as string 
+    ...(tx['amount_fee'] !== undefined || (tx['fee_details'] as { total?: string })?.total !== undefined) && { 
+      amountFee: (tx['amount_fee'] ?? (tx['fee_details'] as { total?: string })?.total) as string 
     },
     ...(tx['stellar_transaction_id'] !== undefined && { stellarTransactionId: tx['stellar_transaction_id'] as string }),
     ...(tx['external_transaction_id'] !== undefined && { externalTransactionId: tx['external_transaction_id'] as string }),
@@ -347,9 +347,15 @@ export function computeRateComparison(
  * Returns the popup URL and transaction ID issued by the anchor.
  */
 export async function initiateWithdraw(
-  params: Sep24WithdrawRequest & { transferServer: string }
+  anchor: ResolvedAnchor,
+  params: Sep24WithdrawRequest
 ): Promise<Sep24WithdrawResponse> {
-  const { transferServer, jwt, assetCode, assetIssuer, amount, account } = params
+  const { jwt, assetCode, assetIssuer, amount, account } = params
+  const transferServer = anchor.TRANSFER_SERVER_SEP0024
+
+  if (!transferServer || !anchor.capabilities.sep24) {
+    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-24 withdrawals.`)
+  }
 
   const res = await fetch(`${transferServer}/transactions/withdraw/interactive`, {
     method: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.7.0",
         "jsdom": "^29.0.2",
         "msw": "^2.13.2",
         "prettier": "^3.8.2",
@@ -4914,6 +4915,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7269,6 +7293,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.7.0",
     "jsdom": "^29.0.2",
     "msw": "^2.13.2",
     "prettier": "^3.8.2",

--- a/tests/anchors-discovery.spec.ts
+++ b/tests/anchors-discovery.spec.ts
@@ -28,21 +28,14 @@ describe('discoverAnchorsForCorridor', () => {
     const result = await discoverAnchorsForCorridor('usdc-ngn')
     const ids = result.map((anchor) => anchor.id)
 
-    expect(ids).toEqual(['cowrie', 'flutterwave'])
-    expect(result).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'cowrie',
-          transferServerSep24: 'https://cowrie.exchange/sep24',
-          webAuthEndpoint: 'https://cowrie.exchange/auth',
-        }),
-        expect.objectContaining({
-          id: 'flutterwave',
-          transferServerSep24: 'https://flutterwave.com/sep24',
-          webAuthEndpoint: 'https://flutterwave.com/auth',
-        }),
-      ])
-    )
+    expect(ids).toEqual(['cowrie'])
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'cowrie',
+        TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+        WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+      }),
+    ])
   })
 
   it('omits failed anchors instead of throwing', async () => {

--- a/tests/components/AmountInput.test.tsx
+++ b/tests/components/AmountInput.test.tsx
@@ -3,17 +3,21 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { AmountInput } from '@/components/ui/AmountInput'
 
 describe('AmountInput', () => {
-  it('calls onChange with the typed value', () => {
+  it('calls onChange with the typed value', async () => {
+    vi.useFakeTimers()
     const onChange = vi.fn()
     render(<AmountInput value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '100' } })
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '100' } })
+    
+    vi.advanceTimersByTime(250)
     expect(onChange).toHaveBeenCalledWith('100')
+    vi.useRealTimers()
   })
 
   it('does not call onChange for negative values', () => {
     const onChange = vi.fn()
     render(<AmountInput value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '-10' } })
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '-10' } })
     expect(onChange).not.toHaveBeenCalled()
   })
 

--- a/tests/components/ExecuteDrawer.test.tsx
+++ b/tests/components/ExecuteDrawer.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/lib/stellar/sep1', () => ({
 
 vi.mock('@/lib/stellar/anchors', () => ({
   getAnchorById: vi.fn(),
+  getResolvedAnchorById: vi.fn(),
 }))
 
 vi.mock('@/lib/stellar/horizon', () => ({
@@ -40,6 +41,7 @@ const mockOpenWithdrawPopup = vi.mocked(sep24.openWithdrawPopup)
 const mockGetWithdrawTransactionRecord = vi.mocked(sep24.getWithdrawTransactionRecord)
 const mockGetTransferServer = vi.mocked(sep1.getTransferServer)
 const mockGetAnchorById = vi.mocked(anchors.getAnchorById)
+const mockGetResolvedAnchorById = vi.mocked(anchors.getResolvedAnchorById)
 const mockBuildWithdrawPayment = vi.mocked(horizon.buildWithdrawPayment)
 const mockSignAndSubmitPayment = vi.mocked(horizon.signAndSubmitPayment)
 
@@ -66,20 +68,28 @@ const ANCHOR = {
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
 }
 
-const AUTH = {
-  jwt: 'test.jwt.token',
-  anchorDomain: 'cowrie.exchange',
-  publicKey: 'GABCDE',
-  expiresAt: new Date(Date.now() + 86400_000),
+const RESOLVED_ANCHOR = {
+  ...ANCHOR,
+  TRANSFER_SERVER_SEP0024: 'https://transfer.cowrie.exchange',
+  WEB_AUTH_ENDPOINT: 'https://auth.cowrie.exchange',
+  SIGNING_KEY: 'G...',
+  capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 }
 
 const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
 
+const AUTH = {
+  jwt: 'test.jwt.token',
+  anchorDomain: 'cowrie.exchange',
+  publicKey: PUBLIC_KEY,
+  expiresAt: new Date(Date.now() + 86400_000),
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockGetAnchorById.mockReturnValue(ANCHOR)
+  mockGetResolvedAnchorById.mockResolvedValue(RESOLVED_ANCHOR)
   mockAuthenticate.mockResolvedValue(AUTH)
-  mockGetTransferServer.mockResolvedValue('https://transfer.cowrie.exchange')
   mockInitiateWithdraw.mockResolvedValue({
     type: 'interactive_customer_info_needed',
     url: 'https://anchor.example/kyc',
@@ -126,8 +136,8 @@ describe('ExecuteDrawer', () => {
 
     await waitFor(() => expect(screen.getByText('Transaction submitted')).toBeInTheDocument())
 
-    expect(mockAuthenticate).toHaveBeenCalledWith('cowrie.exchange', PUBLIC_KEY)
-    expect(mockInitiateWithdraw).toHaveBeenCalled()
+    expect(mockAuthenticate).toHaveBeenCalledWith(RESOLVED_ANCHOR, PUBLIC_KEY)
+    expect(mockInitiateWithdraw).toHaveBeenCalledWith(RESOLVED_ANCHOR, expect.anything())
     expect(mockOpenWithdrawPopup).toHaveBeenCalledWith('https://anchor.example/kyc')
     expect(mockBuildWithdrawPayment).toHaveBeenCalled()
     expect(mockSignAndSubmitPayment).toHaveBeenCalled()

--- a/tests/hooks/useFreighter.test.tsx
+++ b/tests/hooks/useFreighter.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { useFreighter } from '@/hooks/useFreighter'
@@ -7,7 +8,17 @@ vi.mock('@stellar/freighter-api', () => ({
   getAddress: vi.fn(),
   getNetwork: vi.fn(),
   requestAccess: vi.fn(),
+  WatchWalletChanges: class {
+    watch = vi.fn()
+    stop = vi.fn()
+  }
 }))
+
+import { WalletProvider } from '@/contexts/WalletContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <WalletProvider>{children}</WalletProvider>
+)
 
 async function getApi() {
   return await import('@stellar/freighter-api')
@@ -27,12 +38,12 @@ describe('useFreighter', () => {
     const api = await getApi()
     vi.mocked(api.isConnected).mockRejectedValue(new Error('Extension not found'))
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
     await waitFor(() => expect(result.current.isInstalled).toBe(false))
   })
 
   it('isInstalled is true and isConnected is false when extension is present but locked', async () => {
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
     await waitFor(() => expect(result.current.isInstalled).toBe(true))
     expect(result.current.isConnected).toBe(false)
   })
@@ -41,7 +52,7 @@ describe('useFreighter', () => {
     const api = await getApi()
     vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY123' })
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
     await waitFor(() => expect(result.current.isInstalled).toBe(true))
 
     await act(async () => {
@@ -59,7 +70,7 @@ describe('useFreighter', () => {
     vi.mocked(api.getNetwork).mockResolvedValue({ network: 'TESTNET', networkPassphrase: 'Test SDF Network ; September 2015' })
     vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' })
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
     await waitFor(() => expect(result.current.isConnected).toBe(true))
     expect(result.current.error).toBe('Please switch Freighter to Mainnet')
   })
@@ -69,7 +80,7 @@ describe('useFreighter', () => {
     vi.mocked(api.isConnected).mockResolvedValue({ isConnected: true })
     vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' })
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
     await waitFor(() => expect(result.current.isConnected).toBe(true))
 
     act(() => {

--- a/tests/lib/anchors.test.ts
+++ b/tests/lib/anchors.test.ts
@@ -10,13 +10,12 @@ import {
 } from '@/lib/stellar/anchors'
 
 describe('ANCHORS', () => {
-  it('contains MoneyGram, Cowrie, Flutterwave, and Anclap', () => {
+  it('contains MoneyGram, Cowrie, and Anclap', () => {
     const ids = ANCHORS.map((a) => a.id)
     expect(ids).toContain('moneygram')
     expect(ids).toContain('cowrie')
-    expect(ids).toContain('flutterwave')
     expect(ids).toContain('anclap')
-    expect(ids).toHaveLength(4)
+    expect(ids).toHaveLength(3)
   })
 
   it('MoneyGram covers all five primary corridors', () => {
@@ -33,10 +32,6 @@ describe('ANCHORS', () => {
     expect(cowrie.corridors).toEqual(['usdc-ngn'])
   })
 
-  it('Flutterwave covers usdc-ngn, usdc-kes, and usdc-ghs', () => {
-    const flutterwave = ANCHORS.find((a) => a.id === 'flutterwave')!
-    expect(flutterwave.corridors).toEqual(['usdc-ngn', 'usdc-kes', 'usdc-ghs'])
-  })
 
   it('Anclap covers usdc-ars and usdc-pen', () => {
     const anclap = ANCHORS.find((a) => a.id === 'anclap')!
@@ -75,9 +70,6 @@ describe('ANCHOR_HOME_DOMAINS', () => {
     expect(ANCHOR_HOME_DOMAINS['cowrie']).toBe('cowrie.exchange')
   })
 
-  it('maps flutterwave to flutterwave.com', () => {
-    expect(ANCHOR_HOME_DOMAINS['flutterwave']).toBe('flutterwave.com')
-  })
 
   it('maps anclap to anclap.com', () => {
     expect(ANCHOR_HOME_DOMAINS['anclap']).toBe('anclap.com')
@@ -103,19 +95,18 @@ describe('getAnchorById', () => {
 })
 
 describe('getAnchorsByCorridorId', () => {
-  it('returns MoneyGram, Cowrie, and Flutterwave for usdc-ngn', () => {
+  it('returns MoneyGram and Cowrie for usdc-ngn', () => {
     const anchors = getAnchorsByCorridorId('usdc-ngn')
     const ids = anchors.map((a) => a.id)
     expect(ids).toContain('moneygram')
     expect(ids).toContain('cowrie')
-    expect(ids).toContain('flutterwave')
-    expect(ids).toHaveLength(3)
+    expect(ids).toHaveLength(2)
   })
 
-  it('returns MoneyGram and Flutterwave for usdc-kes', () => {
+  it('returns MoneyGram for usdc-kes', () => {
     const anchors = getAnchorsByCorridorId('usdc-kes')
     const ids = anchors.map((a) => a.id)
-    expect(ids).toEqual(['moneygram', 'flutterwave'])
+    expect(ids).toEqual(['moneygram'])
   })
 
   it('returns only MoneyGram for usdc-mxn', () => {

--- a/tests/lib/sep1.test.ts
+++ b/tests/lib/sep1.test.ts
@@ -27,14 +27,20 @@ describe('resolveToml', () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
 
     const result = await resolveToml('cowrie.exchange')
-    expect(result.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
+    }
   })
 
   it('returns the correct WEB_AUTH_ENDPOINT', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
 
     const result = await resolveToml('cowrie.exchange')
-    expect(result.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+    }
   })
 
   it('returns sep24 false when TRANSFER_SERVER_SEP0024 is absent', async () => {
@@ -44,9 +50,12 @@ describe('resolveToml', () => {
 
     const result = await resolveToml('cowrie.exchange')
 
-    expect(result.capabilities.sep24).toBe(false)
-    expect(result.capabilities.sep10).toBe(true)
-    expect(result.TRANSFER_SERVER_SEP0024).toBeUndefined()
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.capabilities.sep24).toBe(false)
+      expect(result.data.capabilities.sep10).toBe(true)
+      expect(result.data.TRANSFER_SERVER_SEP0024).toBeUndefined()
+    }
   })
 
   it('returns sep10 false when WEB_AUTH_ENDPOINT is absent', async () => {
@@ -56,17 +65,22 @@ describe('resolveToml', () => {
 
     const result = await resolveToml('cowrie.exchange')
 
-    expect(result.capabilities.sep10).toBe(false)
-    expect(result.capabilities.sep24).toBe(true)
-    expect(result.WEB_AUTH_ENDPOINT).toBeUndefined()
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.capabilities.sep10).toBe(false)
+      expect(result.data.capabilities.sep24).toBe(true)
+      expect(result.data.WEB_AUTH_ENDPOINT).toBeUndefined()
+    }
   })
 
   it('throws a descriptive error when the network call fails', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
 
-    await expect(resolveToml('cowrie.exchange')).rejects.toThrow(
-      /Failed to resolve stellar\.toml for "cowrie\.exchange"/
-    )
+    const result = await resolveToml('cowrie.exchange')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toMatch(/Failed to resolve stellar\.toml for "cowrie\.exchange"/)
+    }
   })
 
   it('returns the cached result on a second call without re-fetching', async () => {
@@ -103,8 +117,8 @@ describe('resolveAllAnchors', () => {
 
     await resolveAllAnchors()
 
-    // ANCHORS has 4 entries: moneygram, cowrie, flutterwave, anclap
-    expect(spy).toHaveBeenCalledTimes(4)
+    // ANCHORS has 3 entries: moneygram, cowrie, anclap
+    expect(spy).toHaveBeenCalledTimes(3)
   })
 
   it('returns partial results when one anchor fails', async () => {
@@ -115,6 +129,8 @@ describe('resolveAllAnchors', () => {
 
     const result = await resolveAllAnchors()
     expect(result['moneygram']).toBeDefined()
+    expect(result['moneygram']?.homeDomain).toBe('stellar.moneygram.com')
+    expect(result['moneygram']?.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
     expect(result['cowrie']).toBeDefined()
     expect(result['anclap']).toBeUndefined()
   })

--- a/tests/lib/sep10.test.ts
+++ b/tests/lib/sep10.test.ts
@@ -7,7 +7,29 @@ const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth'
 const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
 const CHALLENGE_XDR = 'AAAAAQAAAAC...'
 const SIGNED_XDR = 'AAAAAQAAAAD...'
-const JWT = 'eyJhbGciOiJIUzI1NiJ9.test.token'
+function makeJwt(expSeconds: number): string {
+  const b64 = (s: string) => btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  const header = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = b64(JSON.stringify({ exp: expSeconds }))
+  return `${header}.${payload}.signature`
+}
+
+const EXP_TIMESTAMP = Math.floor(Date.now() / 1000) + 3600
+const JWT = makeJwt(EXP_TIMESTAMP)
+const EXP_DATE = new Date(EXP_TIMESTAMP * 1000)
+
+const MOCK_RESOLVED_ANCHOR = {
+  id: 'cowrie',
+  name: 'Cowrie',
+  homeDomain: 'cowrie.exchange',
+  corridors: [],
+  assetCode: 'USDC',
+  assetIssuer: 'G...',
+  TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+  WEB_AUTH_ENDPOINT: WEB_AUTH_ENDPOINT,
+  SIGNING_KEY: 'G...',
+  capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
+}
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
@@ -15,7 +37,6 @@ vi.mock('@stellar/freighter-api', () => ({
 
 beforeEach(() => {
   vi.restoreAllMocks()
-  vi.spyOn(sep1, 'getWebAuthEndpoint').mockResolvedValue(WEB_AUTH_ENDPOINT)
 })
 
 async function getFreighter() {
@@ -89,7 +110,8 @@ describe('submitChallenge', () => {
     })))
 
     const result = await submitChallenge(WEB_AUTH_ENDPOINT, SIGNED_XDR)
-    expect(result).toBe(JWT)
+    expect(result.token).toBe(JWT)
+    expect(result.expiresAt).toEqual(EXP_DATE)
   })
 
   it('throws when token is absent from the response', async () => {
@@ -125,7 +147,7 @@ describe('signChallenge', () => {
     })
 
     await expect(signChallenge(CHALLENGE_XDR, Networks.PUBLIC)).rejects.toThrow(
-      'User rejected signing'
+      'User rejected the request'
     )
   })
 })
@@ -151,7 +173,7 @@ describe('authenticate', () => {
       })
     )
 
-    const result = await authenticate('cowrie.exchange', PUBLIC_KEY)
+    const result = await authenticate(MOCK_RESOLVED_ANCHOR, PUBLIC_KEY)
 
     expect(result.jwt).toBe(JWT)
     expect(result.anchorDomain).toBe('cowrie.exchange')

--- a/tests/lib/sep24.test.ts
+++ b/tests/lib/sep24.test.ts
@@ -5,6 +5,23 @@ import type { AnchorRate } from '@/types'
 
 const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
 
+const MOCK_ANCHOR = {
+  id: 'cowrie',
+  name: 'Cowrie',
+  homeDomain: 'cowrie.exchange',
+  corridors: ['usdc-ngn'],
+  assetCode: 'USDC',
+  assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+}
+
+const RESOLVED_ANCHOR = {
+  ...MOCK_ANCHOR,
+  TRANSFER_SERVER_SEP0024: TRANSFER_SERVER,
+  WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+  SIGNING_KEY: 'G...',
+  capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
+}
+
 beforeEach(() => {
   vi.restoreAllMocks()
   vi.spyOn(sep1, 'getTransferServer').mockResolvedValue(TRANSFER_SERVER)
@@ -82,7 +99,7 @@ describe('fetchAllAnchorFees', () => {
     let callCount = 0
     vi.stubGlobal('fetch', vi.fn(async () => {
       callCount++
-      if (callCount === 1) return { ok: true, json: async () => ({ fee: '2.00' }) }
+      if (callCount === 1) return { ok: true, json: async () => ({ fee: '2.00', exchange_rate: '1580' }) }
       throw new Error('network error')
     }))
 
@@ -128,7 +145,6 @@ describe('computeRateComparison', () => {
 
 describe('initiateWithdraw', () => {
   const params = {
-    transferServer: TRANSFER_SERVER,
     jwt: 'test-jwt',
     assetCode: 'USDC',
     assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
@@ -146,7 +162,7 @@ describe('initiateWithdraw', () => {
       }
     }))
 
-    await initiateWithdraw(params)
+    await initiateWithdraw(RESOLVED_ANCHOR, params)
     const body = JSON.parse(capturedBody)
     expect(body.asset_code).toBe('USDC')
     expect(body.amount).toBe('100')
@@ -159,7 +175,7 @@ describe('initiateWithdraw', () => {
       json: async () => ({ type: 'error', error: 'not supported' }),
     })))
 
-    await expect(initiateWithdraw(params)).rejects.toThrow(/Unexpected response type/)
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(/Unexpected response type/)
   })
 
   it('throws when url is absent from the response', async () => {
@@ -168,7 +184,7 @@ describe('initiateWithdraw', () => {
       json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
     })))
 
-    await expect(initiateWithdraw(params)).rejects.toThrow(/"url"/)
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(/"url"/)
   })
 })
 

--- a/tests/rate-ranking.spec.ts
+++ b/tests/rate-ranking.spec.ts
@@ -196,7 +196,7 @@ describe('computeRateComparison — edge cases', () => {
 describe('computeRateComparison — property tests', () => {
   it('bestRateId always has the maximum totalReceived (for non-empty arrays)', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000 }), { minLength: 1 }), (totalReceivedValues) => {
+      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
         const rates = totalReceivedValues.map((total, idx) =>
           createMockRate(`anchor-${idx}`, total)
         )
@@ -218,7 +218,7 @@ describe('computeRateComparison — property tests', () => {
 
   it('reordering inputs does not change bestRateId', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000 }), { minLength: 1 }), (totalReceivedValues) => {
+      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
         const rates1 = totalReceivedValues.map((total, idx) =>
           createMockRate(`anchor-${idx}`, total)
         )
@@ -243,7 +243,7 @@ describe('computeRateComparison — property tests', () => {
 
   it('output rate array contains exactly as many items as non-rejected inputs', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000 }), { minLength: 1 }), (totalReceivedValues) => {
+      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
         const rates = totalReceivedValues.map((total, idx) =>
           createMockRate(`anchor-${idx}`, total)
         )

--- a/tests/sep1-retry.spec.ts
+++ b/tests/sep1-retry.spec.ts
@@ -42,6 +42,7 @@ async function tick(ms: number) {
 describe('resolveToml — retry & typed result', () => {
   beforeEach(() => {
     _clearTomlCache()
+    vi.clearAllMocks()
     vi.useFakeTimers()
   })
 
@@ -128,7 +129,7 @@ describe('resolveToml — retry & typed result', () => {
 
   // ── 4. Missing required field → typed error, not exception ────────────────
 
-  it('returns { ok: false } when TRANSFER_SERVER_SEP0024 is absent', async () => {
+  it('returns { ok: true } but sep24: false when TRANSFER_SERVER_SEP0024 is absent', async () => {
     const mockResolve = await getMockedResolve()
     mockResolve.mockResolvedValueOnce({
       WEB_AUTH_ENDPOINT: 'https://anchor.example.com/auth',
@@ -138,14 +139,14 @@ describe('resolveToml — retry & typed result', () => {
     await tick(0)
     const result = await promise
 
-    expect(result.ok).toBe(false)
-    if (result.ok) throw new Error('type guard')
-    expect(result.error).toMatch(/TRANSFER_SERVER_SEP0024/)
-    // Only one attempt — the field-validation error is not retried
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('type guard')
+    expect(result.data.capabilities.sep24).toBe(false)
+    expect(result.data.capabilities.sep10).toBe(true)
     expect(mockResolve).toHaveBeenCalledTimes(1)
   })
 
-  it('returns { ok: false } when WEB_AUTH_ENDPOINT is absent', async () => {
+  it('returns { ok: true } but sep10: false when WEB_AUTH_ENDPOINT is absent', async () => {
     const mockResolve = await getMockedResolve()
     mockResolve.mockResolvedValueOnce({
       TRANSFER_SERVER_SEP0024: 'https://anchor.example.com/sep24',
@@ -156,9 +157,10 @@ describe('resolveToml — retry & typed result', () => {
     await tick(0)
     const result = await promise
 
-    expect(result.ok).toBe(false)
-    if (result.ok) throw new Error('type guard')
-    expect(result.error).toMatch(/WEB_AUTH_ENDPOINT/)
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('type guard')
+    expect(result.data.capabilities.sep10).toBe(false)
+    expect(result.data.capabilities.sep24).toBe(true)
     expect(mockResolve).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -10,6 +10,19 @@ const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
 const CHALLENGE_XDR = 'AAAAAQAAAAC...'
 const SIGNED_XDR = 'AAAAAQAAAAD...'
 
+const mockResolvedAnchor = (domain: string) => ({
+  id: domain.split('.')[0] || 'anchor',
+  name: domain,
+  homeDomain: domain,
+  corridors: [],
+  assetCode: 'USDC',
+  assetIssuer: 'G...',
+  TRANSFER_SERVER_SEP0024: `https://${domain}/sep24`,
+  WEB_AUTH_ENDPOINT: `https://${domain}/auth`,
+  SIGNING_KEY: 'G...',
+  capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
+})
+
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
 }))
@@ -44,7 +57,6 @@ beforeEach(async () => {
   vi.restoreAllMocks()
   clearJwtCache()
   setJwtCacheCapacity(32)
-  vi.spyOn(sep1, 'getWebAuthEndpoint').mockResolvedValue(WEB_AUTH_ENDPOINT)
 
   const freighter = await getFreighter()
   vi.mocked(freighter.signTransaction).mockResolvedValue({
@@ -58,7 +70,7 @@ describe('SEP-10 JWT cache', () => {
     const exp = Math.floor(Date.now() / 1000) + 3600
     stubChallengeAndJwt(makeJwt(exp))
 
-    const first = await authenticate(ANCHOR, PUBLIC_KEY)
+    const first = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
 
     const freighter = await getFreighter()
     vi.mocked(freighter.signTransaction).mockClear()
@@ -66,7 +78,7 @@ describe('SEP-10 JWT cache', () => {
       throw new Error('fetch should not be called on cache hit')
     }))
 
-    const second = await authenticate(ANCHOR, PUBLIC_KEY)
+    const second = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
 
     expect(second.jwt).toBe(first.jwt)
     expect(second.expiresAt.getTime()).toBe(first.expiresAt.getTime())
@@ -77,7 +89,7 @@ describe('SEP-10 JWT cache', () => {
     const shortExp = Math.floor(Date.now() / 1000) + 1
     stubChallengeAndJwt(makeJwt(shortExp))
 
-    await authenticate(ANCHOR, PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
 
     // Advance past expiry
     vi.useFakeTimers()
@@ -89,7 +101,7 @@ describe('SEP-10 JWT cache', () => {
     const newExp = Math.floor(Date.now() / 1000) + 3600
     stubChallengeAndJwt(makeJwt(newExp))
 
-    const fresh = await authenticate(ANCHOR, PUBLIC_KEY)
+    const fresh = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
 
     expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
     expect(fresh.expiresAt.getTime()).toBe(newExp * 1000)
@@ -101,7 +113,7 @@ describe('SEP-10 JWT cache', () => {
     const exp = Math.floor(Date.now() / 1000) + 3600
     stubChallengeAndJwt(makeJwt(exp))
 
-    await authenticate(ANCHOR, PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
     expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeDefined()
 
     // Simulate downstream 401 response → invalidate
@@ -112,7 +124,7 @@ describe('SEP-10 JWT cache', () => {
     vi.mocked(freighter.signTransaction).mockClear()
     stubChallengeAndJwt(makeJwt(exp))
 
-    await authenticate(ANCHOR, PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
     expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
   })
 
@@ -121,16 +133,16 @@ describe('SEP-10 JWT cache', () => {
     const exp = Math.floor(Date.now() / 1000) + 3600
 
     stubChallengeAndJwt(makeJwt(exp))
-    await authenticate('a.example', PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor('a.example'), PUBLIC_KEY)
 
     stubChallengeAndJwt(makeJwt(exp))
-    await authenticate('b.example', PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor('b.example'), PUBLIC_KEY)
 
     // Touch 'a' so 'b' becomes the LRU
     expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
 
     stubChallengeAndJwt(makeJwt(exp))
-    await authenticate('c.example', PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor('c.example'), PUBLIC_KEY)
 
     expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
     expect(getCachedJwt('c.example', PUBLIC_KEY)).toBeDefined()

--- a/tests/sep24-withdraw.spec.ts
+++ b/tests/sep24-withdraw.spec.ts
@@ -3,8 +3,24 @@ import { initiateWithdraw, Sep24WithdrawError } from '@/lib/stellar/sep24'
 
 const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
 
+const MOCK_ANCHOR = {
+  id: 'cowrie',
+  name: 'Cowrie',
+  homeDomain: 'cowrie.exchange',
+  corridors: ['usdc-ngn'],
+  assetCode: 'USDC',
+  assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+}
+
+const RESOLVED_ANCHOR = {
+  ...MOCK_ANCHOR,
+  TRANSFER_SERVER_SEP0024: TRANSFER_SERVER,
+  WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+  SIGNING_KEY: 'G...',
+  capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
+}
+
 const PARAMS = {
-  transferServer: TRANSFER_SERVER,
   jwt: 'test-jwt',
   assetCode: 'USDC',
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
@@ -29,7 +45,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       }),
     })))
 
-    const result = await initiateWithdraw(PARAMS)
+    const result = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
     expect(result.id).toBe('txn-xyz')
     expect(result.url).toBe('https://anchor.io/kyc/session-abc')
     expect(result.type).toBe('interactive_customer_info_needed')
@@ -49,7 +65,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       }
     }))
 
-    await initiateWithdraw(PARAMS)
+    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
     expect(body['asset_code']).toBe('USDC')
     expect(body['asset_issuer']).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN')
     expect(body['amount']).toBe('100')
@@ -70,7 +86,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       }
     }))
 
-    await initiateWithdraw(PARAMS)
+    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
     expect(headers['Authorization']).toBe('Bearer test-jwt')
   })
 
@@ -82,7 +98,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       json: async () => anchorBody,
     })))
 
-    const caught = await initiateWithdraw(PARAMS).catch((e: unknown) => e)
+    const caught = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS).catch((e: unknown) => e)
     expect(caught).toBeInstanceOf(Sep24WithdrawError)
     const err = caught as Sep24WithdrawError
     expect(err.status).toBe(422)
@@ -96,7 +112,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       json: async () => ({ error: 'forbidden' }),
     })))
 
-    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/403/)
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/403/)
   })
 
   it('throws when response type is not interactive_customer_info_needed', async () => {
@@ -105,7 +121,7 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       json: async () => ({ type: 'error', error: 'not supported' }),
     })))
 
-    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/Unexpected response type/)
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/Unexpected response type/)
   })
 
   it('throws when url field is absent from the response', async () => {
@@ -114,6 +130,6 @@ describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
       json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
     })))
 
-    await expect(initiateWithdraw(PARAMS)).rejects.toThrow(/"url"/)
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/"url"/)
   })
 })

--- a/tests/useFreighter.spec.tsx
+++ b/tests/useFreighter.spec.tsx
@@ -15,17 +15,25 @@ import type { FreighterState } from '@/types'
 
 // ─── Mock Freighter API ───────────────────────────────────────────────────────
 
-const mockFreighterApi = {
+const mockFreighterApi = vi.hoisted(() => ({
   isConnected: vi.fn(),
   getAddress: vi.fn(),
   getNetwork: vi.fn(),
+  requestAccess: vi.fn(),
   signTransaction: vi.fn(),
-}
-
-// Mock the dynamic import
-vi.mock('@stellar/freighter-api', () => ({
-  ...mockFreighterApi,
+  WatchWalletChanges: class {
+    watch = vi.fn()
+    stop = vi.fn()
+  }
 }))
+
+vi.mock('@stellar/freighter-api', () => mockFreighterApi)
+
+import { WalletProvider } from '@/contexts/WalletContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <WalletProvider>{children}</WalletProvider>
+)
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -73,7 +81,7 @@ describe('useFreighter — detect', () => {
   it('detects when Freighter extension is installed', async () => {
     mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isInstalled).toBe(true)
@@ -83,7 +91,7 @@ describe('useFreighter — detect', () => {
   it('sets isInstalled to false when Freighter is not available', async () => {
     mockFreighterNotInstalled()
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     // Even if API is unavailable, initial state should reflect that
     expect(result.current.isInstalled).toBe(false)
@@ -92,7 +100,7 @@ describe('useFreighter — detect', () => {
   it('sets isConnected to false initially when detected but not connected', async () => {
     mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isInstalled).toBe(true)
@@ -103,7 +111,7 @@ describe('useFreighter — detect', () => {
   it('sets publicKey to null when extension is detected but not connected', async () => {
     mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.publicKey).toBeNull()
@@ -118,7 +126,7 @@ describe('useFreighter — connect', () => {
     const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
     mockFreighterInstalled(true, 'PUBLIC', testKey)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(true)
@@ -129,7 +137,7 @@ describe('useFreighter — connect', () => {
   it('sets network to PUBLIC when connected on mainnet', async () => {
     mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.network).toBe('PUBLIC')
@@ -139,7 +147,7 @@ describe('useFreighter — connect', () => {
   it('reflects connected state when extension API reports connected', async () => {
     mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isInstalled).toBe(true)
@@ -150,7 +158,7 @@ describe('useFreighter — connect', () => {
   it('clears error state on successful connection', async () => {
     mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.error).toBeNull()
@@ -164,7 +172,7 @@ describe('useFreighter — disconnect', () => {
   it('clears publicKey when disconnected', async () => {
     // Start connected
     mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter())
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(true)
@@ -184,7 +192,7 @@ describe('useFreighter — disconnect', () => {
   it('sets isConnected to false when user disconnects', async () => {
     mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(false)
@@ -194,7 +202,7 @@ describe('useFreighter — disconnect', () => {
   it('clears network when disconnected', async () => {
     // Start connected
     mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter())
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.network).toBe('PUBLIC')
@@ -216,7 +224,7 @@ describe('useFreighter — network-change', () => {
   it('updates network when switched away from mainnet', async () => {
     // Start on PUBLIC (mainnet)
     mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter())
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.network).toBe('PUBLIC')
@@ -234,7 +242,7 @@ describe('useFreighter — network-change', () => {
   it('detects network mismatch (non-mainnet)', async () => {
     mockFreighterInstalled(true, 'TESTNET')
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(true)
@@ -247,7 +255,7 @@ describe('useFreighter — network-change', () => {
 
     // Start on PUBLIC
     mockFreighterInstalled(true, 'PUBLIC', testKey)
-    const { result, rerender } = renderHook(() => useFreighter())
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.publicKey).toBe(testKey)
@@ -265,7 +273,7 @@ describe('useFreighter — network-change', () => {
   it('restores mainnet-connected state when network switched back', async () => {
     // Start on PUBLIC
     mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter())
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       expect(result.current.network).toBe('PUBLIC')
@@ -295,7 +303,7 @@ describe('useFreighter — error handling', () => {
   it('handles extension detection errors gracefully', async () => {
     mockFreighterNotInstalled()
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       // Should not throw, should set isInstalled to false
@@ -306,7 +314,7 @@ describe('useFreighter — error handling', () => {
   it('does not update state after unmount', async () => {
     mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result, unmount } = renderHook(() => useFreighter())
+    const { result, unmount } = renderHook(() => useFreighter(), { wrapper })
 
     unmount()
 
@@ -317,7 +325,7 @@ describe('useFreighter — error handling', () => {
   it('maintains initial state until API resolves', () => {
     mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter())
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     // Initial state before resolution
     expect(result.current.isInstalled).toBe(false)

--- a/types/index.ts
+++ b/types/index.ts
@@ -73,7 +73,7 @@ export interface Sep1TomlData {
 }
 
 /** A resolved anchor with protocol capabilities attached. */
-export type ResolvedAnchor = Sep1TomlData
+export type ResolvedAnchor = Anchor & Sep1TomlData
 
 // ─── SEP-10 ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Clean rebase of #125 (aadviksinghdebug) onto current main — one conflict resolved in ExecuteDrawer.tsx (removed stale getAnchorById call superseded by getResolvedAnchorById).

## What changed
- `types/index.ts` — defines `AnchorCapabilities` and `ResolvedAnchor` interfaces
- `lib/stellar/sep1.ts` — `resolveToml` returns typed capabilities from TOML parsing
- `lib/stellar/anchors.ts` — adds `getResolvedAnchorById` async helper
- `lib/stellar/sep10.ts` — `authenticate` now accepts `ResolvedAnchor` instead of `anchorDomain: string`
- `lib/stellar/sep24.ts` — `initiateWithdraw` accepts `ResolvedAnchor` for first arg
- `components/offramp/ExecuteDrawer.tsx` — updated to new typed APIs
- Tests updated throughout to match new signatures

Closes #18