### PR TITLE
fix(rates): stale UI on refresh — skeleton during inflight refetch (#9)

### DIFF
--- a/app/offramp/page.tsx
+++ b/app/offramp/page.tsx
@@ -23,7 +23,7 @@ export default function OfframpPage() {
   const [trackingJwt, setTrackingJwt] = useState<string | null>(null)
 
   const { isConnected, publicKey } = useFreighter()
-  const { rates, isLoading, error, mutate } = useAnchorRates(corridorId, amount)
+  const { rates, isLoading, error, mutate, refreshInflight } = useAnchorRates(corridorId, amount)
 
   const withdrawStatus = useWithdrawStatus(
     trackingTransferServer,
@@ -111,6 +111,7 @@ export default function OfframpPage() {
         <RateTable
           rates={rates}
           isLoading={isLoading}
+          refreshInflight={refreshInflight}
           error={error}
           onSelectAnchor={handleSelectAnchor}
         />

--- a/components/offramp/RateTable.tsx
+++ b/components/offramp/RateTable.tsx
@@ -30,12 +30,13 @@ function sourceBadge(source: AnchorRate['source']): React.ReactNode {
 interface RateTableProps {
   rates: RateComparison | undefined
   isLoading: boolean
+  refreshInflight?: boolean
   error: string | undefined
   onSelectAnchor: (rate: AnchorRate) => void
 }
 
-export function RateTable({ rates, isLoading, error, onSelectAnchor }: RateTableProps) {
-  if (isLoading && (!rates || rates.rates.length === 0)) {
+export function RateTable({ rates, isLoading, refreshInflight, error, onSelectAnchor }: RateTableProps) {
+  if ((isLoading || refreshInflight) && (!rates || rates.rates.length === 0)) {
     return (
       <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
         <Skeleton rows={5} />

--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,47 +1,73 @@
-import useSWR from 'swr'
-import type { ApiRatesResponse, RateComparison } from '@/types'
+import useSWR from "swr";
+import type { ApiRatesResponse, RateComparison } from "@/types";
+import { useState, useCallback } from "react";
 
 async function fetcher([, corridorId, amount]: [string, string, string]): Promise<RateComparison> {
-  const url = new URL('/api/rates', window.location.origin)
-  url.searchParams.set('corridor', corridorId)
-  url.searchParams.set('amount', amount)
+  const url = new URL("/api/rates", window.location.origin);
+  url.searchParams.set("corridor", corridorId);
+  url.searchParams.set("amount", amount);
 
-  const res = await fetch(url.toString())
+  const res = await fetch(url.toString());
+
   if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`)
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`);
   }
 
-  const data: ApiRatesResponse = await res.json()
-  return data.rates
+  const data: ApiRatesResponse = await res.json();
+  return data.rates;
 }
+
 
 export interface UseAnchorRatesResult {
-  rates: RateComparison | undefined
-  isLoading: boolean
-  error: string | undefined
-  mutate: () => void
+  rates: RateComparison | undefined;
+  isLoading: boolean;
+  error: string | undefined;
+  mutate: () => Promise<void>;
+  refreshInflight: boolean;
 }
 
-/**
- * Fetches live anchor rates for the given corridor and amount.
- * Refreshes every 30 seconds and revalidates when the tab regains focus.
- */
-export function useAnchorRates(corridorId: string, amount: string): UseAnchorRatesResult {
-  const { data, error, isLoading, mutate } = useSWR<RateComparison, Error>(
-    ['/api/rates', corridorId, amount],
+
+export function useAnchorRates(
+  corridorId: string,
+  amount: string
+): UseAnchorRatesResult {
+  const [refreshInflight, setRefreshInflight] = useState(false);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    RateComparison,
+    Error
+  >(
+    corridorId && amount ? ["/api/rates", corridorId, amount] : null,
     fetcher,
     {
       refreshInterval: 30_000,
       revalidateOnFocus: true,
       dedupingInterval: 5_000,
     }
-  )
+  );
+
+  const refresh = useCallback(async () => {
+    if (refreshInflight) return;
+
+    setRefreshInflight(true);
+
+    try {
+      // clear stale UI immediately
+      await mutate(undefined, { revalidate: false });
+
+      // fetch fresh data
+      await mutate();
+    } finally {
+      setRefreshInflight(false);
+    }
+  }, [mutate, refreshInflight]);
 
   return {
     rates: data,
     isLoading,
     error: error?.message,
-    mutate,
-  }
+    mutate: refresh,
+    refreshInflight,
+  };
 }


### PR DESCRIPTION
Clean rebase of #128 (Tobiloba0) with fixes applied: duplicate RateTable export removed, refreshInflight prop wired through to page.tsx.

## What changed
- `hooks/useAnchorRates.ts` — adds `refreshInflight` state; `mutate` now calls `mutate(undefined)` to clear stale rows then refetches; concurrent refreshes are blocked
- `components/offramp/RateTable.tsx` — adds `refreshInflight` prop; shows skeletons when `isLoading || refreshInflight`
- `app/offramp/page.tsx` — destructures and passes `refreshInflight` to `RateTable`

Closes #9