### PR TITLE
feat(sep1): real stellar.toml resolution with helpers and resolveAnchor (#11)

### DIFF
--- a/lib/stellar/sep1.ts
+++ b/lib/stellar/sep1.ts
@@ -10,7 +10,7 @@ export type TomlResult =
 
 // ─── In-memory cache ──────────────────────────────────────────────────────────
 
-const TTL_MS = 60 * 60 * 1000 // 1 hour
+const TTL_MS = 15 * 60 * 1000 // 15 minutes
 
 interface CacheEntry {
   data: Sep1TomlData
@@ -19,78 +19,64 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>()
 
-// ─── Retry configuration ──────────────────────────────────────────────────────
-
-const RETRY_CONFIG = {
-  maxAttempts: 3,     // 1 initial + 2 retries
-  baseDelayMs: 250,   // 250 ms base
-  backoffFactor: 2,   // 2× exponential: 250 → 500 → 1000
-  totalBudgetMs: 5000 // hard ceiling across all attempts
-} as const
-
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function normalizeDomain(domain: string): string {
+  const normalized = domain.trim().toLowerCase()
+
+  if (!normalized) {
+    throw new Error('Anchor domain is required')
+  }
+
+  return normalized
 }
 
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  config = RETRY_CONFIG
-): Promise<T> {
-  const deadline = Date.now() + config.totalBudgetMs
-  let lastError: unknown
+function getString(raw: Record<string, unknown>, key: string): string | null {
+  const value = raw[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
 
-  for (let attempt = 0; attempt < config.maxAttempts; attempt++) {
-    try {
-      return await fn()
-    } catch (err) {
-      lastError = err
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
 
-      // No more attempts or budget exhausted — bail out immediately
-      const isLastAttempt = attempt === config.maxAttempts - 1
-      const delayMs = config.baseDelayMs * config.backoffFactor ** attempt
-      const wouldExceedBudget = Date.now() + delayMs > deadline
+function getCurrencies(raw: Record<string, unknown>): Sep1TomlData['CURRENCIES'] {
+  const currencies = raw['CURRENCIES']
+  if (!Array.isArray(currencies)) {
+    return []
+  }
 
-      if (isLastAttempt || wouldExceedBudget) break
-
-      await sleep(delayMs)
+  return currencies.flatMap((currency) => {
+    if (!isRecord(currency) || typeof currency['code'] !== 'string') {
+      return []
     }
-  }
 
-  throw lastError
+    const parsed: Sep1TomlData['CURRENCIES'][number] = {
+      code: currency['code'],
+    }
+
+    if (typeof currency['issuer'] === 'string') {
+      parsed.issuer = currency['issuer']
+    }
+
+    return [parsed]
+  })
 }
 
-// ─── Core resolver (internal — throws on failure) ────────────────────────────
+function toSep1TomlData(domain: string, raw: Record<string, unknown>): Sep1TomlData {
+  const transferServer = getString(raw, 'TRANSFER_SERVER_SEP0024')
+  const webAuthEndpoint = getString(raw, 'WEB_AUTH_ENDPOINT')
+  const signingKey = getString(raw, 'SIGNING_KEY')
+  const quoteServer = getString(raw, 'ANCHOR_QUOTE_SERVER')
 
-async function resolveTomlUnsafe(domain: string): Promise<Sep1TomlData> {
-  const cached = cache.get(domain)
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.data
-  }
-
-  let raw: Record<string, unknown>
-  try {
-    raw = await withRetry(() => StellarToml.Resolver.resolve(domain))
-  } catch (err) {
-    cache.delete(domain)
-    throw new Error(
-      `Failed to resolve stellar.toml for "${domain}": ${err instanceof Error ? err.message : String(err)}`
-    )
-  }
-
-  const transferServer = typeof raw['TRANSFER_SERVER_SEP0024'] === 'string' ? raw['TRANSFER_SERVER_SEP0024'] : undefined
-  const webAuthEndpoint = typeof raw['WEB_AUTH_ENDPOINT'] === 'string' ? raw['WEB_AUTH_ENDPOINT'] : undefined
-  const signingKey = typeof raw['SIGNING_KEY'] === 'string' ? raw['SIGNING_KEY'] : undefined
-  const quoteServer = typeof raw['QUOTE_SERVER'] === 'string' ? raw['QUOTE_SERVER'] : undefined
-
-  const data: Sep1TomlData = {
+  return {
+    domain,
     TRANSFER_SERVER_SEP0024: transferServer,
+    ANCHOR_QUOTE_SERVER: quoteServer,
     WEB_AUTH_ENDPOINT: webAuthEndpoint,
     SIGNING_KEY: signingKey,
-    CURRENCIES: Array.isArray(raw['CURRENCIES'])
-      ? (raw['CURRENCIES'] as Array<{ code: string; issuer?: string }>)
-      : undefined,
+    NETWORK_PASSPHRASE: getString(raw, 'NETWORK_PASSPHRASE'),
+    CURRENCIES: getCurrencies(raw),
     capabilities: {
       sep10: Boolean(webAuthEndpoint),
       sep24: Boolean(transferServer),
@@ -98,43 +84,93 @@ async function resolveTomlUnsafe(domain: string): Promise<Sep1TomlData> {
       sep12: Boolean(signingKey),
     },
   }
+}
 
-  cache.set(domain, { data, expiresAt: Date.now() + TTL_MS })
-  return data
+function requireTomlField(
+  domain: string,
+  toml: Sep1TomlData,
+  field: 'TRANSFER_SERVER_SEP0024' | 'WEB_AUTH_ENDPOINT',
+  protocolName: string
+): string {
+  const value = toml[field]
+
+  if (!value) {
+    throw new Error(
+      `Missing ${field} in stellar.toml for "${domain}". ` +
+        `This anchor does not support ${protocolName}.`
+    )
+  }
+
+  return value
+}
+
+/**
+ * Resolves an anchor stellar.toml file via SEP-1.
+ * Results are cached in memory for 15 minutes. Failed resolutions are not cached.
+ */
+export async function resolveAnchor(domain: string): Promise<Sep1TomlData> {
+  const cacheKey = normalizeDomain(domain)
+  const cached = cache.get(cacheKey)
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data
+  }
+
+  try {
+    const raw = (await StellarToml.Resolver.resolve(cacheKey)) as Record<string, unknown>
+    const data = toSep1TomlData(cacheKey, raw)
+
+    cache.set(cacheKey, { data, expiresAt: Date.now() + TTL_MS })
+    return data
+  } catch (err) {
+    cache.delete(cacheKey)
+    throw new Error(
+      `Failed to resolve stellar.toml for "${cacheKey}": ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
 }
 
 // ─── Public safe resolver (never throws) ─────────────────────────────────────
+
+/**
+ * Backwards-compatible wrapper around resolveAnchor.
+ * Returns a TomlResult discriminated union so existing callers that check
+ * `result.ok` continue to compile and run without changes.
+ */
 export async function resolveToml(domain: string): Promise<TomlResult> {
   try {
-    const data = await resolveTomlUnsafe(domain)
+    const data = await resolveAnchor(domain)
     return { ok: true, data }
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) }
   }
 }
 
-// ─── Convenience wrappers ─────────────────────────────────────────────────────
-export async function getTransferServer(domain: string): Promise<string | null> {
-  const result = await resolveToml(domain)
-  return result.ok ? (result.data.TRANSFER_SERVER_SEP0024 ?? null) : null
+/**
+ * Returns the SEP-24 transfer server URL for the given anchor domain.
+ */
+export async function getTransferServer(domain: string): Promise<string> {
+  const toml = await resolveAnchor(domain)
+  return requireTomlField(domain, toml, 'TRANSFER_SERVER_SEP0024', 'SEP-24')
 }
 
-export async function getWebAuthEndpoint(domain: string): Promise<string | null> {
-  const result = await resolveToml(domain)
-  return result.ok ? (result.data.WEB_AUTH_ENDPOINT ?? null) : null
+/**
+ * Returns the SEP-10 web auth endpoint URL for the given anchor domain.
+ */
+export async function getWebAuthEndpoint(domain: string): Promise<string> {
+  const toml = await resolveAnchor(domain)
+  return requireTomlField(domain, toml, 'WEB_AUTH_ENDPOINT', 'SEP-10 authentication')
 }
-
-// ─── Bulk resolver ────────────────────────────────────────────────────────────
 
 /**
  * Resolves stellar.toml for all known anchors in parallel.
- * Anchors that fail resolution are logged but do not cause the function to throw.
+ * Anchors that fail resolution are skipped.
  */
 export async function resolveAllAnchors(): Promise<Record<string, ResolvedAnchor>> {
   const results = await Promise.allSettled(
-    ANCHORS.map((anchor) =>
-      resolveTomlUnsafe(anchor.homeDomain).then((data) => ({ anchor, data }))
-    )
+    ANCHORS.map((anchor) => resolveAnchor(anchor.homeDomain).then((data) => ({ anchor, data })))
   )
 
   const resolved: Record<string, ResolvedAnchor> = {}

--- a/tests/lib/sep1.test.ts
+++ b/tests/lib/sep1.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { StellarToml } from '@stellar/stellar-sdk'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Networks, StellarToml } from '@stellar/stellar-sdk'
 import {
+  resolveAnchor,
   resolveToml,
   getTransferServer,
   getWebAuthEndpoint,
@@ -10,8 +11,10 @@ import {
 
 const VALID_TOML = {
   TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+  ANCHOR_QUOTE_SERVER: 'https://cowrie.exchange/quotes',
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'GABCDEF',
+  NETWORK_PASSPHRASE: Networks.PUBLIC,
   CURRENCIES: [
     { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
   ],
@@ -20,76 +23,153 @@ const VALID_TOML = {
 beforeEach(() => {
   _clearTomlCache()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
-describe('resolveToml', () => {
-  it('returns the correct TRANSFER_SERVER_SEP0024', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+afterEach(() => {
+  vi.useRealTimers()
+})
 
-    const result = await resolveToml('cowrie.exchange')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.data.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
-    }
+describe('resolveAnchor', () => {
+  it('calls StellarToml.Resolver.resolve and extracts SEP-1 fields', async () => {
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+
+    const result = await resolveAnchor('cowrie.exchange')
+
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
+    expect(result).toEqual({
+      domain: 'cowrie.exchange',
+      TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+      ANCHOR_QUOTE_SERVER: 'https://cowrie.exchange/quotes',
+      WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+      SIGNING_KEY: 'GABCDEF',
+      NETWORK_PASSPHRASE: Networks.PUBLIC,
+      CURRENCIES: [
+        { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+      ],
+      capabilities: {
+        sep10: true,
+        sep24: true,
+        sep38: true,
+        sep12: true,
+      },
+    })
   })
 
-  it('returns the correct WEB_AUTH_ENDPOINT', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+  it('normalizes domain casing for cache keys', async () => {
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
 
-    const result = await resolveToml('cowrie.exchange')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.data.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
-    }
+    await resolveAnchor(' Cowrie.Exchange ')
+    await resolveAnchor('cowrie.exchange')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
   })
 
-  it('returns sep24 false when TRANSFER_SERVER_SEP0024 is absent', async () => {
+  it('returns nullable fields when optional TOML values are absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({} as never)
+
+    const result = await resolveAnchor('cowrie.exchange')
+
+    expect(result.TRANSFER_SERVER_SEP0024).toBeNull()
+    expect(result.ANCHOR_QUOTE_SERVER).toBeNull()
+    expect(result.WEB_AUTH_ENDPOINT).toBeNull()
+    expect(result.SIGNING_KEY).toBeNull()
+    expect(result.NETWORK_PASSPHRASE).toBeNull()
+    expect(result.CURRENCIES).toEqual([])
+  })
+
+  it('sets sep24 false and sep10 true when TRANSFER_SERVER_SEP0024 is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
     } as never)
 
-    const result = await resolveToml('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange')
 
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.data.capabilities.sep24).toBe(false)
-      expect(result.data.capabilities.sep10).toBe(true)
-      expect(result.data.TRANSFER_SERVER_SEP0024).toBeUndefined()
-    }
+    expect(result.capabilities.sep24).toBe(false)
+    expect(result.capabilities.sep10).toBe(true)
+    expect(result.TRANSFER_SERVER_SEP0024).toBeNull()
   })
 
-  it('returns sep10 false when WEB_AUTH_ENDPOINT is absent', async () => {
+  it('sets sep10 false and sep24 true when WEB_AUTH_ENDPOINT is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
     } as never)
 
-    const result = await resolveToml('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange')
 
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.data.capabilities.sep10).toBe(false)
-      expect(result.data.capabilities.sep24).toBe(true)
-      expect(result.data.WEB_AUTH_ENDPOINT).toBeUndefined()
-    }
+    expect(result.capabilities.sep10).toBe(false)
+    expect(result.capabilities.sep24).toBe(true)
+    expect(result.WEB_AUTH_ENDPOINT).toBeNull()
   })
 
   it('throws a descriptive error when the network call fails', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
 
+    await expect(resolveAnchor('cowrie.exchange')).rejects.toThrow(
+      /Failed to resolve stellar\.toml for "cowrie\.exchange"/
+    )
+  })
+
+  it('returns a cache hit in under 1ms', async () => {
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+
+    await resolveAnchor('cowrie.exchange')
+
+    const startedAt = performance.now()
+    const cached = await resolveAnchor('cowrie.exchange')
+    const elapsedMs = performance.now() - startedAt
+
+    expect(cached.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+    expect(elapsedMs).toBeLessThan(1)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes the cached TOML after the 15-minute TTL expires', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const spy = vi
+      .spyOn(StellarToml.Resolver, 'resolve')
+      .mockResolvedValueOnce(VALID_TOML as never)
+      .mockResolvedValueOnce({
+        ...VALID_TOML,
+        WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/new-auth',
+      } as never)
+
+    await resolveAnchor('cowrie.exchange')
+    vi.setSystemTime(new Date('2026-01-01T00:15:00.001Z'))
+
+    const refreshed = await resolveAnchor('cowrie.exchange')
+
+    expect(refreshed.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/new-auth')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('resolveToml', () => {
+  it('returns ok:true with data on success', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+
     const result = await resolveToml('cowrie.exchange')
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.ANCHOR_QUOTE_SERVER).toBe('https://cowrie.exchange/quotes')
+      expect(result.data.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
+      expect(result.data.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+    }
+  })
+
+  it('returns ok:false with error message on failure', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
+
+    const result = await resolveToml('cowrie.exchange')
+
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.error).toMatch(/Failed to resolve stellar\.toml for "cowrie\.exchange"/)
     }
-  })
-
-  it('returns the cached result on a second call without re-fetching', async () => {
-    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
-
-    await resolveToml('cowrie.exchange')
-    await resolveToml('cowrie.exchange')
-
-    expect(spy).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -100,6 +180,16 @@ describe('getTransferServer', () => {
     const url = await getTransferServer('cowrie.exchange')
     expect(url).toBe('https://cowrie.exchange/sep24')
   })
+
+  it('throws when TRANSFER_SERVER_SEP0024 is absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
+      WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
+    } as never)
+
+    await expect(getTransferServer('cowrie.exchange')).rejects.toThrow(
+      /Missing TRANSFER_SERVER_SEP0024.*"cowrie\.exchange"/
+    )
+  })
 })
 
 describe('getWebAuthEndpoint', () => {
@@ -108,6 +198,16 @@ describe('getWebAuthEndpoint', () => {
 
     const url = await getWebAuthEndpoint('cowrie.exchange')
     expect(url).toBe('https://cowrie.exchange/auth')
+  })
+
+  it('throws when WEB_AUTH_ENDPOINT is absent', async () => {
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
+      TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
+    } as never)
+
+    await expect(getWebAuthEndpoint('cowrie.exchange')).rejects.toThrow(
+      /Missing WEB_AUTH_ENDPOINT.*"cowrie\.exchange"/
+    )
   })
 })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -65,12 +65,18 @@ export interface AnchorCapabilities {
 
 /** Relevant fields from a stellar.toml file resolved via SEP-1. */
 export interface Sep1TomlData {
-  TRANSFER_SERVER_SEP0024: string | undefined
-  WEB_AUTH_ENDPOINT: string | undefined
-  SIGNING_KEY: string | undefined
-  CURRENCIES: Array<{ code: string; issuer?: string }> | undefined
+  domain: string
+  TRANSFER_SERVER_SEP0024: string | null
+  ANCHOR_QUOTE_SERVER: string | null
+  WEB_AUTH_ENDPOINT: string | null
+  SIGNING_KEY: string | null
+  NETWORK_PASSPHRASE: string | null
+  CURRENCIES: Array<{ code: string; issuer?: string }>
   capabilities: AnchorCapabilities
 }
+
+/** A normalized stellar.toml response for an anchor resolved via SEP-1. */
+export type ResolvedAnchorToml = Sep1TomlData
 
 /** A resolved anchor with protocol capabilities attached. */
 export type ResolvedAnchor = Anchor & Sep1TomlData


### PR DESCRIPTION
Clean rebase of #131 (Gozirimdev) onto current main. Three conflicts resolved: capabilities from PR #125 preserved, resolveToml kept returning TomlResult for backwards-compat callers, resolveAnchor added as new throwing primary.

## What changed
- `lib/stellar/sep1.ts` — adds helpers (normalizeDomain, getString, isRecord, getCurrencies, toSep1TomlData, requireTomlField); resolveAnchor(domain) throws on failure; resolveToml wrapped for TomlResult compat; TTL reduced to 15 min; retry logic removed
- `types/index.ts` — Sep1TomlData extended with domain, ANCHOR_QUOTE_SERVER, NETWORK_PASSPHRASE, CURRENCIES; capabilities field retained
- `tests/lib/sep1.test.ts` — comprehensive test coverage for resolveAnchor and resolveToml

Closes #11