### PR TITLE
feat(kyc): interactive KYC iframe with postMessage handshake (#30)

### DIFF
--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -1,10 +1,11 @@
-'use client'
-import { useState } from 'react'
-import { authenticate } from '@/lib/stellar/sep10'
-import { initiateWithdraw, openWithdrawPopup, getWithdrawTransactionRecord } from '@/lib/stellar/sep24'
-import { getResolvedAnchorById } from '@/lib/stellar/anchors'
-import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon'
-import type { AnchorRate, ExecuteDrawerStep } from '@/types'
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { authenticate } from '@/lib/stellar/sep10';
+import { initiateWithdraw, getWithdrawTransactionRecord } from '@/lib/stellar/sep24';
+import { getResolvedAnchorById } from '@/lib/stellar/anchors';
+import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon';
+import type { AnchorRate, ExecuteDrawerStep } from '@/types';
+import { KycIframe } from './KycIframe';
 
 // ─── Step definitions ─────────────────────────────────────────────────────────
 
@@ -17,59 +18,92 @@ const STEP_LABELS: Record<ExecuteDrawerStep, string> = {
   signing: 'Sign transaction in Freighter…',
   done: 'Transaction submitted',
   error: 'Something went wrong',
-}
+};
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 interface ExecuteDrawerProps {
-  rate: AnchorRate | null
-  amount: string
-  publicKey: string
-  onClose: () => void
+  rate: AnchorRate | null;
+  amount: string;
+  publicKey: string;
+  onClose: () => void;
   /** Called once the Stellar payment is submitted; closes the drawer and hands tracking data to the page. */
-  onExecuteStarted: (transactionId: string, transferServer: string, jwt: string) => void
+  onExecuteStarted: (transactionId: string, transferServer: string, jwt: string) => void;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStarted }: ExecuteDrawerProps) {
-  const [step, setStep] = useState<ExecuteDrawerStep>('idle')
-  const [errorMsg, setErrorMsg] = useState<string | null>(null)
-  const [txHash, setTxHash] = useState<string | null>(null)
+  const [step, setStep] = useState<ExecuteDrawerStep>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [kycUrl, setKycUrl] = useState<string | null>(null);
+  const [kycOrigin, setKycOrigin] = useState<string | null>(null);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
-  const isOpen = rate !== null
+  // Holds the resolve/reject for the KYC Promise so KycIframe callbacks can
+  // settle it without touching window globals.
+  const kycResolveRef = useRef<((transactionId: string) => void) | null>(null);
+  const kycRejectRef = useRef<((error: Error) => void) | null>(null);
+
+  const isOpen = rate !== null;
+
+  // Handle escape key — prompt confirmation when a flow is in progress.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen && !['idle', 'done', 'error'].includes(step)) {
+        setShowConfirmDialog(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, step]);
 
   async function handleExecute() {
-    if (!rate) return
+    if (!rate) return;
 
-    setStep('authenticating')
-    setErrorMsg(null)
-    setTxHash(null)
+    setStep('authenticating');
+    setErrorMsg(null);
+    setTxHash(null);
 
     try {
       // Step 0 — Resolve anchor capabilities
-      const anchor = await getResolvedAnchorById(rate.anchorId)
+      const anchor = await getResolvedAnchorById(rate.anchorId);
 
       // Step 1 — SEP-10 auth
-      const auth = await authenticate(anchor, publicKey)
+      const auth = await authenticate(anchor, publicKey);
 
       // Step 2 — Initiate SEP-24 withdraw
-      setStep('initiating')
+      setStep('initiating');
       const withdrawResp = await initiateWithdraw(anchor, {
         assetCode: anchor.assetCode,
         assetIssuer: anchor.assetIssuer,
         amount,
         account: publicKey,
         jwt: auth.jwt,
-      })
+      });
 
-      // Step 3 — KYC popup
-      setStep('kyc')
-      const transactionId = await openWithdrawPopup(withdrawResp.url)
+      // Step 3 — KYC iframe
+      setStep('kyc');
+      const url = new URL(withdrawResp.url);
+      setKycUrl(withdrawResp.url);
+      setKycOrigin(url.origin);
+
+      // Wait for KYC completion signalled by KycIframe callbacks.
+      const transactionId = await new Promise<string>((resolve, reject) => {
+        kycResolveRef.current = resolve;
+        kycRejectRef.current = reject;
+      });
+
+      // Clear refs once the Promise has settled.
+      kycResolveRef.current = null;
+      kycRejectRef.current = null;
 
       // Step 4 — Fetch transaction record
-      setStep('building')
-      const record = await getWithdrawTransactionRecord(anchor.TRANSFER_SERVER_SEP0024!, transactionId, auth.jwt)
+      setStep('building');
+      const transferServer = anchor.TRANSFER_SERVER_SEP0024!;
+      const record = await getWithdrawTransactionRecord(transferServer, transactionId, auth.jwt);
 
       // Step 5 — Build payment
       const tx = await buildWithdrawPayment({
@@ -80,34 +114,58 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
         memoType: record.memoType,
         assetCode: anchor.assetCode,
         assetIssuer: anchor.assetIssuer,
-      })
+      });
 
       // Step 6 — Sign and submit
-      setStep('signing')
-      const result = await signAndSubmitPayment(tx)
-      setTxHash(result.hash ?? null)
-      setStep('done')
+      setStep('signing');
+      const result = await signAndSubmitPayment(tx);
+      setTxHash(result.hash ?? null);
+      setStep('done');
 
       // Hand tracking data to the page, then close so StatusTracker owns the viewport.
-      if (anchor.TRANSFER_SERVER_SEP0024) {
-        onExecuteStarted(transactionId, anchor.TRANSFER_SERVER_SEP0024, auth.jwt)
-      }
-      onClose()
+      onExecuteStarted(transactionId, transferServer, auth.jwt);
+      onClose();
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      
-      // Determine if it's a "User Rejected" case to avoid noisy error UI
-      if (message.includes('User rejected')) {
-        setStep('idle') // Just go back to idle instead of showing error screen
-        return
+      const message = err instanceof Error ? err.message : 'Unknown error';
+
+      // Determine if it's a "User Rejected" case to avoid noisy error UI.
+      if (message.includes('User rejected') || message.includes('User cancelled')) {
+        setStep('idle');
+        return;
       }
 
-      setErrorMsg(message)
-      setStep('error')
+      setErrorMsg(message);
+      setStep('error');
+    } finally {
+      // Ensure refs are cleaned up even on unexpected throws.
+      kycResolveRef.current = null;
+      kycRejectRef.current = null;
     }
   }
 
-  const isRunning = !['idle', 'done', 'error'].includes(step)
+  const isRunning = !['idle', 'done', 'error'].includes(step);
+
+  const handleKycComplete = (transactionId: string) => {
+    kycResolveRef.current?.(transactionId);
+  };
+
+  const handleKycCancel = () => {
+    kycRejectRef.current?.(new Error('User cancelled the transaction'));
+  };
+
+  const handleKycError = (error: Error) => {
+    kycRejectRef.current?.(error);
+  };
+
+  const handleConfirmClose = () => {
+    setShowConfirmDialog(false);
+    kycRejectRef.current?.(new Error('User cancelled the transaction'));
+    onClose();
+  };
+
+  const handleCancelClose = () => {
+    setShowConfirmDialog(false);
+  };
 
   return (
     <>
@@ -142,7 +200,12 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
               className="rounded-lg p-1 text-gray-400 hover:text-gray-600 disabled:opacity-40 dark:hover:text-gray-200"
             >
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
               </svg>
             </button>
           </div>
@@ -162,15 +225,29 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
                 <div className="flex justify-between border-t border-gray-100 pt-2 dark:border-gray-700">
                   <dt className="font-medium text-gray-700 dark:text-gray-300">You receive</dt>
                   <dd className="font-semibold text-green-600 dark:text-green-400">
-                    {(rate.totalReceived ?? 0).toLocaleString()} {rate.corridorId.split('-')[1]?.toUpperCase()}
+                    {(rate.totalReceived ?? 0).toLocaleString()}{' '}
+                    {rate.corridorId.split('-')[1]?.toUpperCase()}
                   </dd>
                 </div>
               </dl>
             </div>
           )}
 
-          {/* Step indicator */}
-          <StepIndicator step={step} />
+          {/* KYC iframe — shown only during the kyc step */}
+          {step === 'kyc' && kycUrl && kycOrigin && (
+            <div className="mb-5">
+              <KycIframe
+                url={kycUrl}
+                origin={kycOrigin}
+                onComplete={handleKycComplete}
+                onCancel={handleKycCancel}
+                onError={handleKycError}
+              />
+            </div>
+          )}
+
+          {/* Step indicator — hidden during KYC iframe */}
+          {step !== 'kyc' && <StepIndicator step={step} />}
 
           {/* Error message */}
           {step === 'error' && errorMsg && (
@@ -186,78 +263,102 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
             </p>
           )}
 
-          {/* CTA */}
-          <div className="mt-5">
-            {step === 'idle' && (
-              <button
-                onClick={handleExecute}
-                className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                Start Off-ramp
-              </button>
-            )}
-            {step === 'authenticating' && rate && (
-              <div className="flex w-full items-center justify-center gap-3 rounded-xl bg-blue-600 py-4 text-white">
-                <Spinner />
-                <div className="flex items-center gap-2">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white/20">
-                    <span className="text-sm font-bold">
-                      {rate.anchorName?.charAt(0).toUpperCase() ?? 'A'}
-                    </span>
-                  </div>
-                  <span className="text-sm font-medium">
-                    Proving wallet ownership to {rate.anchorName ?? 'anchor'}…
-                  </span>
-                </div>
-              </div>
-            )}
-            {isRunning && step !== 'authenticating' && (
-              <button
-                disabled
-                className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white opacity-75"
-              >
-                <Spinner />
-                {STEP_LABELS[step as Step]}
-              </button>
-            )}
-            {step === 'error' && (
-              <button
-                onClick={handleExecute}
-                className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
-              >
-                Try Again
-              </button>
-            )}
-            {step === 'done' && (
-              <button
-                onClick={onClose}
-                className="w-full rounded-xl bg-gray-100 py-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
-              >
-                Close
-              </button>
-            )}
-          </div>
+          {/* CTA — hidden during KYC iframe */}
+          {step !== 'kyc' && (
+            <div className="mt-5">
+              {step === 'idle' && (
+                <button
+                  onClick={handleExecute}
+                  className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                >
+                  Start Off-ramp
+                </button>
+              )}
+              {isRunning && (
+                <button
+                  disabled
+                  className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white opacity-75"
+                >
+                  <Spinner />
+                  {STEP_LABELS[step]}
+                </button>
+              )}
+              {step === 'error' && (
+                <button
+                  onClick={handleExecute}
+                  className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+                >
+                  Try Again
+                </button>
+              )}
+              {step === 'done' && (
+                <button
+                  onClick={onClose}
+                  className="w-full rounded-xl bg-gray-100 py-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+                >
+                  Close
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </div>
+
+      {/* Confirmation Dialog */}
+      {showConfirmDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="fixed inset-0 bg-black/50" onClick={handleCancelClose} />
+          <div className="relative z-10 mx-4 max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+            <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+              Cancel Off-ramp?
+            </h3>
+            <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+              Are you sure you want to cancel the off-ramp process? This will close the KYC form and
+              you'll need to start over.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handleCancelClose}
+                className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                Keep Going
+              </button>
+              <button
+                onClick={handleConfirmClose}
+                className="flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+              >
+                Cancel Process
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
-  )
+  );
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-const ORDERED_STEPS: ExecuteDrawerStep[] = ['authenticating', 'initiating', 'kyc', 'building', 'signing', 'done']
+const ORDERED_STEPS: ExecuteDrawerStep[] = [
+  'authenticating',
+  'initiating',
+  'kyc',
+  'building',
+  'signing',
+  'done',
+];
 
 function StepIndicator({ step }: { step: ExecuteDrawerStep }) {
-  if (step === 'idle') return null
+  if (step === 'idle') return null;
 
   return (
     <ol className="space-y-1">
       {ORDERED_STEPS.map((s) => {
-        const currentIdx = ORDERED_STEPS.indexOf(step === 'error' ? 'authenticating' : step)
-        const thisIdx = ORDERED_STEPS.indexOf(s)
-        const isComplete = step !== 'error' && thisIdx < ORDERED_STEPS.indexOf(step)
-        const isActive = s === step && step !== 'error' && step !== 'done'
-        const isPending = thisIdx > currentIdx && step !== 'done'
+        const currentIdx = ORDERED_STEPS.indexOf(step === 'error' ? 'authenticating' : step);
+        const thisIdx = ORDERED_STEPS.indexOf(s);
+        const isComplete = step !== 'error' && thisIdx < ORDERED_STEPS.indexOf(step);
+        const isActive = s === step && step !== 'error' && step !== 'done';
+        const isPending = thisIdx > currentIdx && step !== 'done';
 
         return (
           <li key={s} className="flex items-center gap-2 text-xs">
@@ -283,10 +384,10 @@ function StepIndicator({ step }: { step: ExecuteDrawerStep }) {
               {STEP_LABELS[s]}
             </span>
           </li>
-        )
+        );
       })}
     </ol>
-  )
+  );
 }
 
 function Spinner() {
@@ -306,5 +407,5 @@ function Spinner() {
         d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
       />
     </svg>
-  )
+  );
 }

--- a/components/offramp/KycIframe.tsx
+++ b/components/offramp/KycIframe.tsx
@@ -1,0 +1,113 @@
+'use client';
+import type { KycPostMessage } from '@/types';
+import { useEffect, useRef, useState } from 'react';
+
+export interface KycIframeProps {
+  url: string;
+  origin: string;
+  onComplete: (transactionId: string) => void;
+  onCancel: () => void;
+  onError: (error: Error) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function KycIframe({ url, origin, onComplete, onCancel, onError }: KycIframeProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Verify origin for security
+      if (event.origin !== origin) return;
+
+      try {
+        const data = event.data as KycPostMessage;
+
+        if (data.type === 'stellar_transaction_created' && data.transaction_id) {
+          onComplete(data.transaction_id);
+        } else if (data.type === 'stellar_cancel') {
+          onCancel();
+        }
+      } catch (err) {
+        onError(err instanceof Error ? err : new Error('Unknown postMessage error'));
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [origin, onComplete, onCancel, onError]);
+
+  const handleIframeLoad = () => {
+    setIsLoading(false);
+    setHasError(false);
+  };
+
+  const handleIframeError = () => {
+    setIsLoading(false);
+    setHasError(true);
+    onError(new Error('Failed to load KYC iframe'));
+  };
+
+  const openInNewTab = () => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="relative h-full min-h-[500px] w-full">
+      {isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900">
+          <div className="flex flex-col items-center gap-3">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent"></div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Loading KYC form...</p>
+          </div>
+        </div>
+      )}
+
+      {hasError && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-white dark:bg-gray-900 p-6">
+          <div className="text-center">
+            <div className="mb-4 text-red-500">
+              <svg
+                className="mx-auto h-12 w-12"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+            <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+              Unable to load KYC form
+            </h3>
+            <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+              The anchor's KYC form couldn't be loaded in this frame.
+            </p>
+            <button
+              onClick={openInNewTab}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Open in New Tab
+            </button>
+          </div>
+        </div>
+      )}
+
+      <iframe
+        ref={iframeRef}
+        src={url}
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        className={`h-full w-full border-0 ${isLoading || hasError ? 'invisible' : ''}`}
+        onLoad={handleIframeLoad}
+        onError={handleIframeError}
+        title="KYC Verification"
+      />
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -464,7 +463,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -513,9 +511,30 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1855,6 +1874,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
@@ -2368,6 +2410,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2457,7 +2500,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2504,7 +2548,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2515,7 +2558,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2526,7 +2568,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2583,7 +2624,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3248,7 +3288,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3676,7 +3715,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4177,7 +4215,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4444,7 +4483,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4646,7 +4684,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6553,6 +6590,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6675,7 +6713,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -7237,6 +7274,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7252,6 +7290,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7264,7 +7303,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7346,7 +7386,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7356,7 +7395,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8328,7 +8366,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8582,7 +8619,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8758,7 +8794,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9496,7 +9531,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,121 +2,121 @@
 
 /** A Stellar anchor that supports SEP-24 withdrawals and/or deposits. */
 export interface Anchor {
-  id: string
-  name: string
-  homeDomain: string
-  corridors: string[] // corridor IDs this anchor serves
-  assetCode: string
-  assetIssuer: string
+  id: string;
+  name: string;
+  homeDomain: string;
+  corridors: string[]; // corridor IDs this anchor serves
+  assetCode: string;
+  assetIssuer: string;
 }
 
 /** A payment corridor from one asset to a fiat currency in a given country. */
 export interface Corridor {
-  id: string // e.g. 'usdc-ngn'
-  from: string // asset code, e.g. 'USDC'
-  to: string // fiat currency code, e.g. 'NGN'
-  countryCode: string // ISO 3166-1 alpha-2
-  countryName: string
+  id: string; // e.g. 'usdc-ngn'
+  from: string; // asset code, e.g. 'USDC'
+  to: string; // fiat currency code, e.g. 'NGN'
+  countryCode: string; // ISO 3166-1 alpha-2
+  countryName: string;
 }
 
 // ─── Rate comparison ──────────────────────────────────────────────────────────
 
 /** The fee structure an anchor charges for a given corridor and amount. */
 export interface AnchorRate {
-  anchorId: string
-  anchorName: string
-  corridorId: string
-  fee: number | null // flat fee in USDC; null when anchor is unreachable
-  feeType: 'flat' | 'percent' | 'combined'
-  exchangeRate: number | null // local currency units per 1 USDC; null when anchor is unreachable
-  totalReceived: number | null // computed: (amount - fee) * exchangeRate; null when anchor is unreachable
-  updatedAt: Date
+  anchorId: string;
+  anchorName: string;
+  corridorId: string;
+  fee: number | null; // flat fee in USDC; null when anchor is unreachable
+  feeType: 'flat' | 'percent' | 'combined';
+  exchangeRate: number | null; // local currency units per 1 USDC; null when anchor is unreachable
+  totalReceived: number | null; // computed: (amount - fee) * exchangeRate; null when anchor is unreachable
+  updatedAt: Date;
   /** Discriminates the origin of the rate data. */
-  source: 'sep38' | 'sep24-fee' | 'unavailable'
+  source: 'sep38' | 'sep24-fee' | 'unavailable';
 }
 
 /** The result of comparing all anchor rates for a single corridor. */
 export interface RateComparison {
-  corridorId: string
-  rates: AnchorRate[]
-  bestRateId: string // anchorId of the anchor with the highest totalReceived
+  corridorId: string;
+  rates: AnchorRate[];
+  bestRateId: string; // anchorId of the anchor with the highest totalReceived
 }
 
 // ─── Wallet ───────────────────────────────────────────────────────────────────
 
 /** The current state of the Freighter browser extension. */
 export interface FreighterState {
-  isInstalled: boolean
-  isConnected: boolean
-  publicKey: string | null
-  network: string | null
-  error: string | null
+  isInstalled: boolean;
+  isConnected: boolean;
+  publicKey: string | null;
+  network: string | null;
+  error: string | null;
 }
 
 // ─── SEP-1 ────────────────────────────────────────────────────────────────────
 
 /** Per-anchor protocol capability flags derived from the resolved TOML. */
 export interface AnchorCapabilities {
-  sep10: boolean
-  sep24: boolean
-  sep38: boolean
-  sep12: boolean
+  sep10: boolean;
+  sep24: boolean;
+  sep38: boolean;
+  sep12: boolean;
 }
 
 /** Relevant fields from a stellar.toml file resolved via SEP-1. */
 export interface Sep1TomlData {
-  domain: string
-  TRANSFER_SERVER_SEP0024: string | null
-  ANCHOR_QUOTE_SERVER: string | null
-  WEB_AUTH_ENDPOINT: string | null
-  SIGNING_KEY: string | null
-  NETWORK_PASSPHRASE: string | null
-  CURRENCIES: Array<{ code: string; issuer?: string }>
-  capabilities: AnchorCapabilities
+  domain: string;
+  TRANSFER_SERVER_SEP0024: string | null;
+  ANCHOR_QUOTE_SERVER: string | null;
+  WEB_AUTH_ENDPOINT: string | null;
+  SIGNING_KEY: string | null;
+  NETWORK_PASSPHRASE: string | null;
+  CURRENCIES: Array<{ code: string; issuer?: string }>;
+  capabilities: AnchorCapabilities;
 }
 
 /** A normalized stellar.toml response for an anchor resolved via SEP-1. */
-export type ResolvedAnchorToml = Sep1TomlData
+export type ResolvedAnchorToml = Sep1TomlData;
 
 /** A resolved anchor with protocol capabilities attached. */
-export type ResolvedAnchor = Anchor & Sep1TomlData
+export type ResolvedAnchor = Anchor & Sep1TomlData;
 
 // ─── SEP-10 ───────────────────────────────────────────────────────────────────
 
 /** A JWT issued by an anchor after successful SEP-10 authentication. */
 export interface Sep10Auth {
-  jwt: string
-  anchorDomain: string
-  publicKey: string
-  expiresAt: Date
+  jwt: string;
+  anchorDomain: string;
+  publicKey: string;
+  expiresAt: Date;
 }
 
 // ─── SEP-24 ───────────────────────────────────────────────────────────────────
 
 /** Parameters for the SEP-24 GET /fee endpoint. */
 export interface Sep24FeeParams {
-  anchorDomain: string
-  operation: 'deposit' | 'withdraw'
-  assetCode: string
-  assetIssuer: string
-  amount: string
-  type: 'bank_account' | 'cash' | 'mobile_money'
+  anchorDomain: string;
+  operation: 'deposit' | 'withdraw';
+  assetCode: string;
+  assetIssuer: string;
+  amount: string;
+  type: 'bank_account' | 'cash' | 'mobile_money';
 }
 
 /** Body sent to POST /transactions/withdraw/interactive. */
 export interface Sep24WithdrawRequest {
-  assetCode: string
-  assetIssuer: string
-  amount: string
-  account: string // user's Stellar public key
-  jwt: string
+  assetCode: string;
+  assetIssuer: string;
+  amount: string;
+  account: string; // user's Stellar public key
+  jwt: string;
 }
 
 /** Response from POST /transactions/withdraw/interactive. */
 export interface Sep24WithdrawResponse {
-  type: 'interactive_customer_info_needed'
-  url: string
-  id: string
+  type: 'interactive_customer_info_needed';
+  url: string;
+  id: string;
 }
 
 /** All possible raw status strings an anchor may return for a SEP-24 transaction. */
@@ -135,7 +135,7 @@ export type WithdrawStatusValue =
   | 'no_market'
   | 'too_small'
   | 'too_large'
-  | 'expired'
+  | 'expired';
 
 /**
  * Canonical app-wide status enum.
@@ -150,76 +150,76 @@ export type WithdrawStatus =
   | 'no_market'
   | 'refunded'
   | 'expired'
-  | 'error'
+  | 'error';
 
 /** Payment breakdown for a refunded SEP-24 transaction. */
 export interface Sep24RefundPayment {
-  id: string
-  id_type: string
-  amount: string
-  fee: string
+  id: string;
+  id_type: string;
+  amount: string;
+  fee: string;
 }
 
 /** Refund details for a SEP-24 transaction. */
 export interface Sep24Refunds {
-  amount_refunded: string
-  amount_fee: string
-  payments: Sep24RefundPayment[]
+  amount_refunded: string;
+  amount_fee: string;
+  payments: Sep24RefundPayment[];
 }
 
 /** The live record of a SEP-24 withdrawal transaction returned by the anchor. */
 export interface Sep24Transaction {
-  id: string
-  status: WithdrawStatusValue
-  amountIn?: string | undefined
-  amountInAsset?: string | undefined
-  amountOut?: string | undefined
-  amountOutAsset?: string | undefined
-  amountFee?: string | undefined
-  updatedAt: Date
-  stellarTransactionId?: string | undefined
-  externalTransactionId?: string | undefined
-  refunds?: Sep24Refunds | undefined
+  id: string;
+  status: WithdrawStatusValue;
+  amountIn?: string | undefined;
+  amountInAsset?: string | undefined;
+  amountOut?: string | undefined;
+  amountOutAsset?: string | undefined;
+  amountFee?: string | undefined;
+  updatedAt: Date;
+  stellarTransactionId?: string | undefined;
+  externalTransactionId?: string | undefined;
+  refunds?: Sep24Refunds | undefined;
 }
 
 // ─── Post-execute handoff ─────────────────────────────────────────────────────
 
 /** Data passed from ExecuteDrawer to the page after a successful withdrawal initiation. */
 export interface WithdrawHandoffPayload {
-  transactionId: string
-  transferServer: string
-  jwt: string
+  transactionId: string;
+  transferServer: string;
+  jwt: string;
 }
 
 // ─── API ──────────────────────────────────────────────────────────────────────
 
 /** Shape returned by GET /api/rates. */
 export interface ApiRatesResponse {
-  rates: RateComparison
-  fetchedAt: string
+  rates: RateComparison;
+  fetchedAt: string;
 }
 
 /** Shape returned by API routes on error. */
 export interface ApiError {
-  code: string
-  message: string
-  anchorId?: string
+  code: string;
+  message: string;
+  anchorId?: string;
 }
 
 // ─── UI helpers ───────────────────────────────────────────────────────────────
 
 /** A country supported by the off-ramp module. */
 export interface Country {
-  code: string // ISO 3166-1 alpha-2
-  name: string
-  currency: string // ISO 4217
-  currencySymbol: string
-  flag: string
+  code: string; // ISO 3166-1 alpha-2
+  name: string;
+  currency: string; // ISO 4217
+  currencySymbol: string;
+  flag: string;
 }
 
-export type OfframpSortKey = 'rate' | 'fee' | 'time' | 'total'
-export type SortDirection = 'asc' | 'desc'
-export type RiskLevel = 'low' | 'medium' | 'high'
+export type OfframpSortKey = 'rate' | 'fee' | 'time' | 'total';
+export type SortDirection = 'asc' | 'desc';
+export type RiskLevel = 'low' | 'medium' | 'high';
 
 // ─── ExecuteDrawer state machine ─────────────────────────────────────────────
 
@@ -232,28 +232,42 @@ export type ExecuteDrawerStep =
   | 'building'
   | 'signing'
   | 'done'
-  | 'error'
+  | 'error';
 
 // ─── Stellar assets (used by Horizon swap routing) ────────────────────────────
 
 export interface StellarAsset {
-  code: string
-  issuer?: string
-  name: string
-  logoUrl?: string
+  code: string;
+  issuer?: string;
+  name: string;
+  logoUrl?: string;
 }
 
 export interface SwapRoute {
-  routeId: string
-  source: 'SDEX' | 'Soroswap' | 'Phoenix' | 'Aquarius'
-  fromAsset: StellarAsset
-  toAsset: StellarAsset
-  fromAmount: number
-  toAmount: number
-  price: number
-  priceImpact: number
-  fee: number
-  path: StellarAsset[]
-  estimatedTime: string
-  lastUpdated: Date
+  routeId: string;
+  source: 'SDEX' | 'Soroswap' | 'Phoenix' | 'Aquarius';
+  fromAsset: StellarAsset;
+  toAsset: StellarAsset;
+  fromAmount: number;
+  toAmount: number;
+  price: number;
+  priceImpact: number;
+  fee: number;
+  path: StellarAsset[];
+  estimatedTime: string;
+  lastUpdated: Date;
+}
+
+// ─── KYC iframe ────────────────────────────────────────────────────────────────
+
+/** PostMessage data structure for KYC iframe communication */
+export interface KycPostMessage {
+  type: 'stellar_transaction_created' | 'stellar_cancel';
+  transaction_id?: string;
+}
+
+/** Configuration for KYC iframe component */
+export interface KycIframeConfig {
+  url: string;
+  origin: string;
 }


### PR DESCRIPTION
Clean rebase of #134 (Joe8175) onto current main. Two conflicts resolved: ExecuteDrawer API updated to use getResolvedAnchorById/ResolvedAnchor signatures; window.currentKycResolve global replaced with kycResolveRef/kycRejectRef (useRef).

## What changed
- `components/offramp/KycIframe.tsx` (new) — sandboxed iframe (allow-forms allow-scripts allow-same-origin); postMessage listener for stellar_transaction_created/stellar_cancel; fallback "Open in new tab" button; onComplete/onCancel/onError callbacks
- `components/offramp/ExecuteDrawer.tsx` — iframe replaces popup; kycUrl/kycOrigin state; escape-key confirmation dialog; Promise resolved via useRef callbacks instead of window globals
- `types/index.ts` — adds KycPostMessage, KycIframeConfig, WithdrawHandoffPayload, expired to WithdrawStatusValue

Closes #30