### PR TITLE
fix(rates): pause auto-refresh when tab is hidden

### DIFF
--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,11 +1,28 @@
-import useSWR from "swr";
-import type { ApiRatesResponse, RateComparison } from "@/types";
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import useSWR from 'swr';
+import type { ApiRatesResponse, RateComparison } from '@/types';
+
+const RATES_REFRESH_INTERVAL_MS = 30_000;
+
+function getVisibilitySnapshot(): boolean {
+  return typeof document === 'undefined' || !document.hidden;
+}
+
+function subscribeToVisibilityChange(onStoreChange: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+
+  document.addEventListener('visibilitychange', onStoreChange);
+  return () => document.removeEventListener('visibilitychange', onStoreChange);
+}
+
+function useDocumentVisible(): boolean {
+  return useSyncExternalStore(subscribeToVisibilityChange, getVisibilitySnapshot, () => true);
+}
 
 async function fetcher([, corridorId, amount]: [string, string, string]): Promise<RateComparison> {
-  const url = new URL("/api/rates", window.location.origin);
-  url.searchParams.set("corridor", corridorId);
-  url.searchParams.set("amount", amount);
+  const url = new URL('/api/rates', window.location.origin);
+  url.searchParams.set('corridor', corridorId);
+  url.searchParams.set('amount', amount);
 
   const res = await fetch(url.toString());
 
@@ -18,7 +35,6 @@ async function fetcher([, corridorId, amount]: [string, string, string]): Promis
   return data.rates;
 }
 
-
 export interface UseAnchorRatesResult {
   rates: RateComparison | undefined;
   isLoading: boolean;
@@ -27,25 +43,28 @@ export interface UseAnchorRatesResult {
   refreshInflight: boolean;
 }
 
-
-export function useAnchorRates(
-  corridorId: string,
-  amount: string
-): UseAnchorRatesResult {
+export function useAnchorRates(corridorId: string, amount: string): UseAnchorRatesResult {
   const [refreshInflight, setRefreshInflight] = useState(false);
+  const isDocumentVisible = useDocumentVisible();
+  const wasDocumentVisible = useRef(isDocumentVisible);
+  const hasRateQuery = Boolean(corridorId && amount);
+  const swrKey: [string, string, string] | null =
+    hasRateQuery && isDocumentVisible ? ['/api/rates', corridorId, amount] : null;
 
-  const { data, error, isLoading, mutate } = useSWR<
-    RateComparison,
-    Error
-  >(
-    corridorId && amount ? ["/api/rates", corridorId, amount] : null,
-    fetcher,
-    {
-      refreshInterval: 30_000,
-      revalidateOnFocus: true,
-      dedupingInterval: 5_000,
+  const { data, error, isLoading, mutate } = useSWR<RateComparison, Error>(swrKey, fetcher, {
+    refreshInterval: RATES_REFRESH_INTERVAL_MS,
+    refreshWhenHidden: false,
+    revalidateOnFocus: true,
+    dedupingInterval: 5_000,
+  });
+
+  useEffect(() => {
+    if (!wasDocumentVisible.current && isDocumentVisible && hasRateQuery) {
+      void mutate();
     }
-  );
+
+    wasDocumentVisible.current = isDocumentVisible;
+  }, [hasRateQuery, isDocumentVisible, mutate]);
 
   const refresh = useCallback(async () => {
     if (refreshInflight) return;

--- a/tests/hooks/useAnchorRates.test.ts
+++ b/tests/hooks/useAnchorRates.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
-import { createElement } from 'react'
-import { SWRConfig } from 'swr'
-import { useAnchorRates } from '@/hooks/useAnchorRates'
-import type { RateComparison } from '@/types'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { useAnchorRates } from '@/hooks/useAnchorRates';
+import type { RateComparison } from '@/types';
 
 // Fresh SWR cache per test — prevents cross-test cache pollution
 const wrapper = ({ children }: { children: React.ReactNode }) =>
-  createElement(SWRConfig, { value: { provider: () => new Map() } }, children)
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
 
 const mockRates: RateComparison = {
   corridorId: 'usdc-ngn',
@@ -25,43 +25,133 @@ const mockRates: RateComparison = {
       updatedAt: new Date(),
     },
   ],
+};
+
+function setDocumentHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    value: hidden,
+  });
+}
+
+async function dispatchVisibilityChange(hidden: boolean): Promise<void> {
+  setDocumentHidden(hidden);
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
 }
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+  setDocumentHidden(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  setDocumentHidden(false);
+});
 
 describe('useAnchorRates', () => {
   it('is loading on initial render', () => {
-    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
-    expect(result.current.isLoading).toBe(true)
-  })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    );
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
+    expect(result.current.isLoading).toBe(true);
+  });
 
   it('returns rates with bestRateId once data loads', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
+      }))
+    );
 
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.rates?.bestRateId).toBe('cowrie')
-    expect(result.current.error).toBeUndefined()
-  })
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.rates?.bestRateId).toBe('cowrie');
+    expect(result.current.error).toBeUndefined();
+  });
 
   it('exposes an error string when the fetch fails', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 500,
-      json: async () => ({ message: 'All anchors failed' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'All anchors failed' }),
+      }))
+    );
 
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBe('All anchors failed')
-    expect(result.current.rates).toBeUndefined()
-  })
-})
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('All anchors failed');
+    expect(result.current.rates).toBeUndefined();
+  });
+
+  it('auto-refreshes every 30 seconds while the tab is visible', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
+
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockClear();
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses auto-refresh while hidden and resumes on visibilitychange', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
+
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockClear();
+
+    await dispatchVisibilityChange(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(90_000);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await dispatchVisibilityChange(false);
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockClear();
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
closes #188 
Summary
Added Page Visibility API handling to useAnchorRates.
Disabled SWR rate polling while document.hidden is true.
Resumed rate fetching on visibilitychange when the tab becomes visible again.
Added focused tests for visible refresh, hidden pause, and resume behavior.

Reason
This prevents unnecessary /api/rates refreshes while the page is hidden, reducing background network usage while preserving the existing 30-second refresh behavior when the tab is visible.