### PR TITLE
feat(sep38): add indicative price client

### DIFF
--- a/lib/stellar/sep38.ts
+++ b/lib/stellar/sep38.ts
@@ -1,0 +1,151 @@
+import { parseSepErrorBody } from './errors';
+
+const PRICE_PATH = '/price';
+
+export interface Sep38PriceParams {
+  quoteServer: string;
+  sell_asset: string;
+  buy_asset: string;
+  sell_amount: string;
+  buy_delivery_method?: string;
+  context: string;
+}
+
+export interface Sep38FeeDetail {
+  name: string;
+  amount: string;
+  description?: string;
+}
+
+export interface Sep38Fee {
+  total: string;
+  asset: string;
+  details?: Sep38FeeDetail[];
+}
+
+export interface Sep38PriceResponse {
+  price: string;
+  sell_amount: string;
+  buy_amount: string;
+  total_price?: string;
+  fee?: Sep38Fee;
+}
+
+function assertNonEmpty(value: string, fieldName: keyof Sep38PriceParams): void {
+  if (value.trim().length === 0) {
+    throw new Error(`SEP-38 /price requires a non-empty "${fieldName}"`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getRequiredString(data: Record<string, unknown>, fieldName: string): string {
+  const value = data[fieldName];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid SEP-38 /price response: missing "${fieldName}"`);
+  }
+  return value;
+}
+
+function parseFee(raw: unknown): Sep38Fee | undefined {
+  if (raw === undefined) return undefined;
+  if (!isRecord(raw)) {
+    throw new Error('Invalid SEP-38 /price response: "fee" must be an object');
+  }
+
+  const fee: Sep38Fee = {
+    total: getRequiredString(raw, 'total'),
+    asset: getRequiredString(raw, 'asset'),
+  };
+
+  const details = raw['details'];
+  if (details !== undefined) {
+    if (!Array.isArray(details)) {
+      throw new Error('Invalid SEP-38 /price response: "fee.details" must be an array');
+    }
+
+    fee.details = details.map((detail) => {
+      if (!isRecord(detail)) {
+        throw new Error('Invalid SEP-38 /price response: each fee detail must be an object');
+      }
+
+      const parsed: Sep38FeeDetail = {
+        name: getRequiredString(detail, 'name'),
+        amount: getRequiredString(detail, 'amount'),
+      };
+
+      if (typeof detail['description'] === 'string') {
+        parsed.description = detail['description'];
+      }
+
+      return parsed;
+    });
+  }
+
+  return fee;
+}
+
+function buildPriceUrl(params: Sep38PriceParams): string {
+  assertNonEmpty(params.quoteServer, 'quoteServer');
+  assertNonEmpty(params.sell_asset, 'sell_asset');
+  assertNonEmpty(params.buy_asset, 'buy_asset');
+  assertNonEmpty(params.sell_amount, 'sell_amount');
+  assertNonEmpty(params.context, 'context');
+
+  const quoteServer = params.quoteServer.replace(/\/+$/, '');
+  const url = new URL(`${quoteServer}${PRICE_PATH}`);
+  url.searchParams.set('sell_asset', params.sell_asset);
+  url.searchParams.set('buy_asset', params.buy_asset);
+  url.searchParams.set('sell_amount', params.sell_amount);
+  url.searchParams.set('context', params.context);
+
+  if (params.buy_delivery_method && params.buy_delivery_method.trim().length > 0) {
+    url.searchParams.set('buy_delivery_method', params.buy_delivery_method);
+  }
+
+  return url.toString();
+}
+
+function parsePriceResponse(data: unknown): Sep38PriceResponse {
+  if (!isRecord(data)) {
+    throw new Error('Invalid SEP-38 /price response: expected an object');
+  }
+
+  const response: Sep38PriceResponse = {
+    price: getRequiredString(data, 'price'),
+    sell_amount: getRequiredString(data, 'sell_amount'),
+    buy_amount: getRequiredString(data, 'buy_amount'),
+  };
+
+  if (typeof data['total_price'] === 'string') {
+    response.total_price = data['total_price'];
+  }
+
+  const fee = parseFee(data['fee']);
+  if (fee) response.fee = fee;
+
+  return response;
+}
+
+/**
+ * Fetches an indicative SEP-38 price for a specific asset pair.
+ *
+ * This wraps GET /price and intentionally supports the sell_amount path needed
+ * by the off-ramp comparator. Firm quotes belong to POST /quote.
+ */
+export async function getSep38Price(params: Sep38PriceParams): Promise<Sep38PriceResponse> {
+  const url = buildPriceUrl(params);
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
+    throw parseSepErrorBody(body, res.status);
+  }
+
+  return parsePriceResponse(await res.json());
+}

--- a/tests/sep38-price.spec.ts
+++ b/tests/sep38-price.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getSep38Price } from '@/lib/stellar/sep38';
+
+const QUOTE_SERVER = 'https://anchor.example/sep38';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getSep38Price', () => {
+  it('fetches an indicative price from a mock SEP-38 anchor', async () => {
+    let capturedUrl = '';
+    let capturedOptions: RequestInit | undefined;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: RequestInfo | URL, options?: RequestInit) => {
+        capturedUrl = String(url);
+        capturedOptions = options;
+
+        return jsonResponse({
+          price: '1580.50',
+          total_price: '1579.00',
+          sell_amount: '100.0000000',
+          buy_amount: '157900.00',
+          fee: {
+            total: '1.50',
+            asset: 'iso4217:NGN',
+            details: [
+              {
+                name: 'bank_fee',
+                amount: '1.50',
+                description: 'Local bank transfer fee',
+              },
+            ],
+          },
+        });
+      })
+    );
+
+    const price = await getSep38Price({
+      quoteServer: QUOTE_SERVER,
+      sell_asset: 'stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      buy_asset: 'iso4217:NGN',
+      sell_amount: '100',
+      buy_delivery_method: 'bank_account',
+      context: 'sep6',
+    });
+
+    const url = new URL(capturedUrl);
+
+    expect(url.origin + url.pathname).toBe(`${QUOTE_SERVER}/price`);
+    expect(url.searchParams.get('sell_asset')).toBe(
+      'stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+    );
+    expect(url.searchParams.get('buy_asset')).toBe('iso4217:NGN');
+    expect(url.searchParams.get('sell_amount')).toBe('100');
+    expect(url.searchParams.get('buy_delivery_method')).toBe('bank_account');
+    expect(url.searchParams.get('context')).toBe('sep6');
+    expect(capturedOptions?.headers).toEqual({ Accept: 'application/json' });
+    expect(price).toEqual({
+      price: '1580.50',
+      total_price: '1579.00',
+      sell_amount: '100.0000000',
+      buy_amount: '157900.00',
+      fee: {
+        total: '1.50',
+        asset: 'iso4217:NGN',
+        details: [
+          {
+            name: 'bank_fee',
+            amount: '1.50',
+            description: 'Local bank transfer fee',
+          },
+        ],
+      },
+    });
+  });
+
+  it('normalizes anchor error bodies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ error: 'pair not supported', code: 'no_market' }, 400))
+    );
+
+    await expect(
+      getSep38Price({
+        quoteServer: QUOTE_SERVER,
+        sell_asset: 'stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+        buy_asset: 'iso4217:NGN',
+        sell_amount: '100',
+        buy_delivery_method: 'bank_account',
+        context: 'sep6',
+      })
+    ).rejects.toMatchObject({
+      name: 'SepError',
+      message: 'pair not supported',
+      code: 'no_market',
+      httpStatus: 400,
+    });
+  });
+});


### PR DESCRIPTION
closes #164 
Summary
Added getSep38Price for SEP-38 GET /price indicative pair pricing.
Builds /price requests with sell_asset, buy_asset, sell_amount, optional buy_delivery_method, and context.
Preserves protocol decimal values as strings to avoid precision loss.
Added mock-anchor coverage for successful price responses and normalized anchor errors.

Reason
This implements issue #073, enabling the codebase to request per-pair indicative SEP-38 prices from an anchor quote server.