### PR TITLE
Fix/replay protection

### DIFF
--- a/app/api/intent/offramp/route.ts
+++ b/app/api/intent/offramp/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server'
+import { registerIntentReplay } from '@/lib/intent/replay'
+
+type IntentPayload = {
+  account?: unknown
+  nonce?: unknown
+  deadline?: unknown
+  intentHash?: unknown
+}
+
+type IntentReplayBody = {
+  publicKey?: unknown
+  account?: unknown
+  nonce?: unknown
+  deadline?: unknown
+  intentHash?: unknown
+  intent?: IntentPayload
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function pickValue(...values: unknown[]): string | null {
+  for (const value of values) {
+    const text = readString(value)
+    if (text) return text
+  }
+  return null
+}
+
+function jsonError(status: number, code: string, message: string): NextResponse {
+  return NextResponse.json({ code, message }, { status })
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const body = (await request.json().catch(() => null)) as IntentReplayBody | null
+
+  if (!body || typeof body !== 'object') {
+    return jsonError(400, 'invalid_request', 'Request body must be valid JSON.')
+  }
+
+  const publicKey = pickValue(body.publicKey, body.account, body.intent?.account)
+  const nonce = pickValue(body.nonce, body.intent?.nonce)
+  const deadline = pickValue(body.deadline, body.intent?.deadline)
+  const intentHash = pickValue(body.intentHash, body.intent?.intentHash)
+
+  if (!publicKey || !nonce || !deadline || !intentHash) {
+    return jsonError(400, 'invalid_request', 'Expected publicKey, nonce, deadline, and intentHash.')
+  }
+
+  const result = registerIntentReplay({ publicKey, nonce, deadline })
+
+  if (!result.ok) {
+    return jsonError(result.status, result.code, result.message)
+  }
+
+  return NextResponse.json({ ok: true, intentHash }, { status: 200 })
+}

--- a/lib/intent/replay.ts
+++ b/lib/intent/replay.ts
@@ -1,0 +1,78 @@
+const nonceStore = new Map<string, Map<string, number>>()
+
+export type IntentReplayInput = {
+  publicKey: string
+  nonce: string
+  deadline: string | number | Date
+}
+
+export type IntentReplayResult =
+  | { ok: true }
+  | { ok: false; status: 409 | 410; code: 'replay_detected' | 'deadline_expired'; message: string }
+
+function toDeadlineMs(deadline: string | number | Date): number {
+  if (deadline instanceof Date) return deadline.getTime()
+  if (typeof deadline === 'number') return deadline
+  return Date.parse(deadline)
+}
+
+function pruneExpiredNonces(publicKey: string, now: number): void {
+  const existing = nonceStore.get(publicKey)
+  if (!existing) return
+
+  for (const [nonce, expiresAt] of existing.entries()) {
+    if (expiresAt <= now) {
+      existing.delete(nonce)
+    }
+  }
+
+  if (existing.size === 0) {
+    nonceStore.delete(publicKey)
+  }
+}
+
+export function clearIntentReplayStore(): void {
+  nonceStore.clear()
+}
+
+export function registerIntentReplay(
+  input: IntentReplayInput,
+  now = Date.now()
+): IntentReplayResult {
+  const deadlineMs = toDeadlineMs(input.deadline)
+
+  if (!Number.isFinite(deadlineMs)) {
+    return {
+      ok: false,
+      status: 410,
+      code: 'deadline_expired',
+      message: 'Intent deadline is invalid or expired.',
+    }
+  }
+
+  if (deadlineMs <= now) {
+    return {
+      ok: false,
+      status: 410,
+      code: 'deadline_expired',
+      message: 'Intent deadline has expired.',
+    }
+  }
+
+  pruneExpiredNonces(input.publicKey, now)
+
+  const existing = nonceStore.get(input.publicKey) ?? new Map<string, number>()
+  if (existing.has(input.nonce)) {
+    return {
+      ok: false,
+      status: 409,
+      code: 'replay_detected',
+      message: 'Nonce already used for this public key.',
+    }
+  }
+
+  existing.set(input.nonce, deadlineMs)
+  nonceStore.set(input.publicKey, existing)
+
+  return { ok: true }
+}

--- a/tests/intent-replay.spec.ts
+++ b/tests/intent-replay.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { POST } from '@/app/api/intent/offramp/route'
+import { clearIntentReplayStore } from '@/lib/intent/replay'
+
+const NOW = new Date('2026-05-29T12:00:00.000Z')
+
+const BASE_BODY = {
+  publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDE',
+  nonce: 'nonce-123',
+  deadline: '2026-05-29T12:05:00.000Z',
+  intentHash: 'intent-hash-123',
+}
+
+function buildRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/intent/offramp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  clearIntentReplayStore()
+})
+
+afterEach(() => {
+  clearIntentReplayStore()
+  vi.useRealTimers()
+})
+
+describe('POST /api/intent/offramp replay protection', () => {
+  it('accepts the first submission of an intent', async () => {
+    const response = await POST(buildRequest(BASE_BODY))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, intentHash: BASE_BODY.intentHash })
+  })
+
+  it('returns 409 for a repeated submission with the same public key and nonce', async () => {
+    await POST(buildRequest(BASE_BODY))
+
+    const response = await POST(buildRequest(BASE_BODY))
+    const payload = (await response.json()) as { code: string; message: string }
+
+    expect(response.status).toBe(409)
+    expect(payload.code).toBe('replay_detected')
+    expect(payload.message).toMatch(/nonce/i)
+  })
+
+  it('returns 410 when the deadline has passed', async () => {
+    const response = await POST(
+      buildRequest({
+        ...BASE_BODY,
+        deadline: '2026-05-29T11:59:59.000Z',
+      })
+    )
+    const payload = (await response.json()) as { code: string; message: string }
+
+    expect(response.status).toBe(410)
+    expect(payload.code).toBe('deadline_expired')
+    expect(payload.message).toMatch(/expired/i)
+  })
+
+  it('keeps replay state isolated per public key', async () => {
+    await POST(buildRequest(BASE_BODY))
+
+    const response = await POST(
+      buildRequest({
+        ...BASE_BODY,
+        publicKey: 'GBCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCD',
+      })
+    )
+
+    expect(response.status).toBe(200)
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR!

Before you submit:
  • Conventional Commits title — the PR title is linted (feat / fix / docs /
    refactor / test / chore / ci / perf / build / style / revert, with an
    optional scope and a short description). See .github/workflows/pr-title.yml.
  • One logical change per PR. If you have an unrelated cleanup, split it.
  • Fill in every section below. Delete none of them — leave "N/A" if a
    section genuinely doesn't apply and say *why*.
-->

## Summary

Replay protection now rejects duplicate intent submissions for the same public key and nonce within the intent's deadline window. This closes a replay path in the intent offramp flow and ensures expired payloads fail fast instead of being accepted into the in-memory submission store.

## Linked issue

Closes #208

## Changes

- `lib/intent/replay.ts` adds a small in-memory replay store keyed by public key, prunes expired entries, and returns typed outcomes for the two failure modes required by the issue: `409 replay_detected` and `410 deadline_expired`.
- `app/api/intent/offramp/route.ts` wires the replay guard into the POST handler, accepts the intent fields from either a flat body or a nested `intent` object, and returns JSON errors with the appropriate HTTP status codes.
- `tests/intent-replay.spec.ts` covers the first submission happy path, duplicate-submission rejection, expired-deadline rejection, and public-key isolation so the replay store cannot bleed across users.

## Testing notes

**Automated**
- `npm run typecheck` · ⏳  run
- `npm run lint` · ⏳  run
- `npm run test` · ⏳  run
- `npm run build` · ⏳  run

**New / modified tests**
- `tests/intent-replay.spec.ts` — verifies the intent offramp returns `200` on first submission, `409` on duplicate nonce replay, `410` on expired deadline, and allows the same nonce for a different public key.

**Manual verification** (if applicable)
- `npx vitest run tests/intent-replay.spec.ts --reporter=verbose` completed successfully and passed all 4 assertions.

## Screenshots / recordings

N/A — no user-visible change.

| Before | After |
| --- | --- |
| N/A | N/A |

## Checklist

**Correctness**
- [ ] The PR title follows Conventional Commits (auto-linted)
- [x] One logical change; unrelated cleanup was split into a separate PR
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes with **zero new warnings** (we run `--max-warnings 0` in CI)
- [ ] `npm run test` passes; new behaviour has a test
- [ ] `npm run build` passes

**Data integrity**
- [x] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
- [x] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
- [N/A — not touching an anchor] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
- [N/A — not touching SEP-10] If touching SEP-10: network passphrase assertion is intact (mainnet only)
- [N/A — not touching SEP-24 fetches] If touching SEP-24: the 10s `AbortController` timeout is intact on anchor fetches
- [N/A — not touching the status poll] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop

**Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
- [x] No new code path holds user keys, user funds, or long-lived anchor JWTs
- [x] Every signing action is performed by the user's wallet (Freighter today)
- [x] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`

**Docs**
- [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
- [ ] API / schema change → relevant `docs/*.md` updated in the same PR
- [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
- [N/A — no public UI] Public-facing feature → screenshot added to `docs/showcase/images/` when relevant
- [N/A — no env vars added] New env var → `.env.example` + README env table updated

**Release hygiene**
- [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
- [x] No dependency added without justification in the PR description
- [x] No breaking change hidden inside a non-breaking commit

## Breaking changes

None.

## For reviewers

The key thing to sanity-check is the replay boundary: a nonce is only rejected for the same public key, and the store is pruned against the submitted deadline so an expired intent does not linger indefinitely. The route intentionally accepts both flat and nested intent payloads so it can interoperate with the planned signed-intent shape without requiring a second parser branch.

<!--
One last thing: this PR template is part of the product. If any section
above feels wrong or missing, open a PR against `.github/PULL_REQUEST_TEMPLATE.md`
itself — meta-PRs are welcome.
-->