### PR TITLE
feat: keyboard-nav, slow-3G, no-freighter e2e tests + SignedIntent en…

### DIFF
--- a/.github/OSS_WEEK_CONTRIBUTOR_BOARD.md
+++ b/.github/OSS_WEEK_CONTRIBUTOR_BOARD.md
@@ -20,48 +20,48 @@ document.** That is not a rhetorical line — it is the explicit commitment.
 
 ## 🟢 Start here (self-contained, < 2 hours)
 
-| # | Ticket | What you ship | Files touched |
-|---|--------|---------------|---------------|
-| 1  | `issue.md#015` | Skeleton loader on the rate table while SWR loads | `components/rate-table/*` |
-| 2  | `issue.md#022` | Error boundary + retry for a failed anchor TOML fetch | `lib/sep1/*`, `components/` |
-| 3  | `issue.md#031` | `formatCurrency` helper + unit tests | `lib/format/*` |
-| 4  | `issue.md#037` | `.env.example` audit + README env-var section parity | `.env.example`, `README.md` |
-| 5  | `issue.md#044` | Keyboard focus ring on all interactive rate rows | `components/rate-table/*` |
-| 6  | `issue.md#051` | Favicon set (16/32/180/192/512) — drop assets into `public/brand/` | `public/brand/` |
-| 7  | `issue.md#056` | Empty-state copy + illustration for zero-rates case | `components/empty-state/*` |
-| 8  | `issue.md#063` | Lint rule sweep: convert remaining `no-explicit-any` sites | `lib/*`, `hooks/*` |
-| 9  | `issue.md#068` | README "Troubleshooting" section — top five setup gotchas | `README.md` |
-| 10 | `issue.md#072` | Basic i18n scaffolding: extract hard-coded strings from header | `components/header/*` |
+| #   | Ticket         | What you ship                                                      | Files touched               |
+| --- | -------------- | ------------------------------------------------------------------ | --------------------------- |
+| 1   | `issue.md#015` | Skeleton loader on the rate table while SWR loads                  | `components/rate-table/*`   |
+| 2   | `issue.md#022` | Error boundary + retry for a failed anchor TOML fetch              | `lib/sep1/*`, `components/` |
+| 3   | `issue.md#031` | `formatCurrency` helper + unit tests                               | `lib/format/*`              |
+| 4   | `issue.md#037` | `.env.example` audit + README env-var section parity               | `.env.example`, `README.md` |
+| 5   | `issue.md#044` | Keyboard focus ring on all interactive rate rows                   | `components/rate-table/*`   |
+| 6   | `issue.md#051` | Favicon set (16/32/180/192/512) — drop assets into `public/brand/` | `public/brand/`             |
+| 7   | `issue.md#056` | Empty-state copy + illustration for zero-rates case                | `components/empty-state/*`  |
+| 8   | `issue.md#063` | Lint rule sweep: convert remaining `no-explicit-any` sites         | `lib/*`, `hooks/*`          |
+| 9   | `issue.md#068` | README "Troubleshooting" section — top five setup gotchas          | `README.md`                 |
+| 10  | `issue.md#072` | Basic i18n scaffolding: extract hard-coded strings from header     | `components/header/*`       |
 
 ## 🟡 Next rung (~1 day, single module)
 
-| # | Ticket | What you ship | Files touched |
-|---|--------|---------------|---------------|
-| 11 | `issue.md#078` | Replay-protection nonce for signed intents | `lib/intent/*` |
-| 12 | `issue.md#082` | SEP-38 quote fetcher with timeout + retry backoff | `lib/sep38/*` |
-| 13 | `issue.md#089` | Anchor failure-rate counter → writes to the scoring store | `lib/reputation/*` |
-| 14 | `issue.md#094` | `/api/health` endpoint with anchor-status rollup | `app/api/health/*` |
-| 15 | `issue.md#101` | Address-book for NGN bank codes (validation + autocomplete) | `constants/bank-codes.ts` |
-| 16 | `issue.md#108` | Status tracker page: poll SEP-24 `/transaction` until terminal | `app/status/*` |
-| 17 | `issue.md#112` | Split-routing mock solver (deterministic, test-backed) | `lib/router/*` |
-| 18 | `issue.md#119` | Sentry reporter scaffold — no secrets yet, pluggable | `lib/telemetry/*` |
-| 19 | `issue.md#126` | Rate-table column sort by net landed value | `components/rate-table/*` |
-| 20 | `issue.md#134` | Persist last-used corridor in `localStorage` | `hooks/use-corridor.ts` |
+| #   | Ticket         | What you ship                                                  | Files touched             |
+| --- | -------------- | -------------------------------------------------------------- | ------------------------- |
+| 11  | `issue.md#078` | Replay-protection nonce for signed intents                     | `lib/intent/*`            |
+| 12  | `issue.md#082` | SEP-38 quote fetcher with timeout + retry backoff              | `lib/sep38/*`             |
+| 13  | `issue.md#089` | Anchor failure-rate counter → writes to the scoring store      | `lib/reputation/*`        |
+| 14  | `issue.md#094` | `/api/health` endpoint with anchor-status rollup               | `app/api/health/*`        |
+| 15  | `issue.md#101` | Address-book for NGN bank codes (validation + autocomplete)    | `constants/bank-codes.ts` |
+| 16  | `issue.md#108` | Status tracker page: poll SEP-24 `/transaction` until terminal | `app/status/*`            |
+| 17  | `issue.md#112` | Split-routing mock solver (deterministic, test-backed)         | `lib/router/*`            |
+| 18  | `issue.md#119` | Sentry reporter scaffold — no secrets yet, pluggable           | `lib/telemetry/*`         |
+| 19  | `issue.md#126` | Rate-table column sort by net landed value                     | `components/rate-table/*` |
+| 20  | `issue.md#134` | Persist last-used corridor in `localStorage`                   | `hooks/use-corridor.ts`   |
 
 ## 🔵 Bigger bites (multi-module, pair with a reviewer first)
 
-| # | Ticket | What you ship | Files touched |
-|---|--------|---------------|---------------|
-| 21 | `issue.md#146` | Canonical intent hashing — deterministic JSON + Ed25519 verify | `lib/intent/*` + tests |
-| 22 | `issue.md#153` | Public read API: `GET /v1/public/scores` with cache + schema | `app/api/v1/*`, `docs/INTENT_API.md` |
-| 23 | `issue.md#161` | MCP tool: `stellar_intel.price_offramp` | `packages/mcp/*` |
-| 24 | `issue.md#168` | Composite score formula + test vectors for three anchors | `lib/reputation/*` |
-| 25 | `issue.md#174` | Soroban contract skeleton: `write_observation`, `read_score` | `contracts/oracle/*` |
-| 26 | `issue.md#182` | Anchor scorecard page (public, per-anchor) | `app/anchors/[id]/*` |
-| 27 | `issue.md#189` | SEP-10 auth: challenge tx, sign, submit, token cache | `lib/sep10/*` |
-| 28 | `issue.md#196` | Leaderboard page — top-5 anchors by net landed value, 30d | `app/leaderboard/*` |
-| 29 | `issue.md#203` | Playwright smoke test for the full off-ramp happy path | `tests/e2e/*` |
-| 30 | `issue.md#208` | Grafana dashboard JSON committed + linked from README | `docs/observability/*` |
+| #   | Ticket         | What you ship                                                  | Files touched                        |
+| --- | -------------- | -------------------------------------------------------------- | ------------------------------------ |
+| 21  | `issue.md#146` | Canonical intent hashing — deterministic JSON + Ed25519 verify | `lib/intent/*` + tests               |
+| 22  | `issue.md#153` | Public read API: `GET /v1/public/scores` with cache + schema   | `app/api/v1/*`, `docs/INTENT_API.md` |
+| 23  | `issue.md#161` | MCP tool: `stellar_intel.price_offramp`                        | `packages/mcp/*`                     |
+| 24  | `issue.md#168` | Composite score formula + test vectors for three anchors       | `lib/reputation/*`                   |
+| 25  | `issue.md#174` | Soroban contract skeleton: `write_observation`, `read_score`   | `contracts/oracle/*`                 |
+| 26  | `issue.md#182` | Anchor scorecard page (public, per-anchor)                     | `app/anchors/[id]/*`                 |
+| 27  | `issue.md#189` | SEP-10 auth: challenge tx, sign, submit, token cache           | `lib/sep10/*`                        |
+| 28  | `issue.md#196` | Leaderboard page — top-5 anchors by net landed value, 30d      | `app/leaderboard/*`                  |
+| 29  | `issue.md#203` | Playwright smoke test for the full off-ramp happy path         | `tests/e2e/*`                        |
+| 30  | `issue.md#208` | Grafana dashboard JSON committed + linked from README          | `docs/observability/*`               |
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -63,18 +63,20 @@ valid. "Hard to test" is not.
 -->
 
 **Automated**
+
 - `npm run typecheck` · ⏳ not run / ✅ green / ❌ failing
 - `npm run lint` · ⏳ not run / ✅ green / ❌ failing
 - `npm run test` · ⏳ not run / ✅ green / ❌ failing
 - `npm run build` · ⏳ not run / ✅ green / ❌ failing
 
-**New / modified tests**
--
+## **New / modified tests**
 
 **Manual verification** (if applicable)
+
 <!-- e.g. "Connected Freighter on mainnet, executed USDC→NGN for $5 via
 MoneyGram testnet deployment, observed StatusTracker reach `completed` in
 3m12s. Stellar Expert link: …" -->
+
 -
 
 ## Screenshots / recordings
@@ -90,8 +92,8 @@ For pure backend / doc / CI PRs, write "N/A — no user-visible change".
 -->
 
 | Before | After |
-| --- | --- |
-|  |  |
+| ------ | ----- |
+|        |       |
 
 ## Checklist
 
@@ -101,6 +103,7 @@ merge a PR with an unaddressed box.
 -->
 
 **Correctness**
+
 - [ ] The PR title follows Conventional Commits (auto-linted)
 - [ ] One logical change; unrelated cleanup was split into a separate PR
 - [ ] `npm run typecheck` passes
@@ -109,6 +112,7 @@ merge a PR with an unaddressed box.
 - [ ] `npm run build` passes
 
 **Data integrity**
+
 - [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
 - [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
 - [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
@@ -117,11 +121,13 @@ merge a PR with an unaddressed box.
 - [ ] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop
 
 **Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
+
 - [ ] No new code path holds user keys, user funds, or long-lived anchor JWTs
 - [ ] Every signing action is performed by the user's wallet (Freighter today)
 - [ ] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`
 
 **Docs**
+
 - [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
 - [ ] API / schema change → relevant `docs/*.md` updated in the same PR
 - [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
@@ -129,6 +135,7 @@ merge a PR with an unaddressed box.
 - [ ] New env var → `.env.example` + README env table updated
 
 **Release hygiene**
+
 - [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
 - [ ] No dependency added without justification in the PR description
 - [ ] No breaking change hidden inside a non-breaking commit

--- a/README.md
+++ b/README.md
@@ -144,17 +144,17 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 
 The full doc surface lives under [`docs/`](docs/). Start with:
 
-| Document                                              | What it covers                                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [docs/PROPOSAL.md](docs/PROPOSAL.md)                  | Grant thesis: execution-layer framing, intent primitive, reputation oracle moat.     |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)          | System diagram, intent router, Soroban oracle, MCP/agent surface, SEP-10/24/38 flow. |
-| [docs/ROADMAP.md](docs/ROADMAP.md)                    | Milestone waves v1.0 → v5, with tickable per-wave scope.                             |
-| [docs/INTENT_API.md](docs/INTENT_API.md)              | Intent schema, signing rules, replay protection, `curl` + TS snippets.               |
-| [docs/ANCHOR_REPUTATION.md](docs/ANCHOR_REPUTATION.md)| Scoring methodology, composite formula, dispute process.                             |
-| [docs/ORACLE_SPEC.md](docs/ORACLE_SPEC.md)            | Soroban contract interface, consumer examples, publisher whitelist policy.           |
-| [docs/MCP.md](docs/MCP.md)                            | Tool list, `claude mcp add` instructions, example prompts, agent-safety notes.       |
-| [docs/SECURITY.md](docs/SECURITY.md)                  | Non-custodial guarantee, key handling, disclosure email, supply-chain policy.        |
-| [docs/FAQ.md](docs/FAQ.md)                            | "Is this custodial?", "what if an anchor fails?", "how are we different?".           |
+| Document                                               | What it covers                                                                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| [docs/PROPOSAL.md](docs/PROPOSAL.md)                   | Grant thesis: execution-layer framing, intent primitive, reputation oracle moat.     |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)           | System diagram, intent router, Soroban oracle, MCP/agent surface, SEP-10/24/38 flow. |
+| [docs/ROADMAP.md](docs/ROADMAP.md)                     | Milestone waves v1.0 → v5, with tickable per-wave scope.                             |
+| [docs/INTENT_API.md](docs/INTENT_API.md)               | Intent schema, signing rules, replay protection, `curl` + TS snippets.               |
+| [docs/ANCHOR_REPUTATION.md](docs/ANCHOR_REPUTATION.md) | Scoring methodology, composite formula, dispute process.                             |
+| [docs/ORACLE_SPEC.md](docs/ORACLE_SPEC.md)             | Soroban contract interface, consumer examples, publisher whitelist policy.           |
+| [docs/MCP.md](docs/MCP.md)                             | Tool list, `claude mcp add` instructions, example prompts, agent-safety notes.       |
+| [docs/SECURITY.md](docs/SECURITY.md)                   | Non-custodial guarantee, key handling, disclosure email, supply-chain policy.        |
+| [docs/FAQ.md](docs/FAQ.md)                             | "Is this custodial?", "what if an anchor fails?", "how are we different?".           |
 
 ---
 

--- a/app/api/intent/offramp/route.ts
+++ b/app/api/intent/offramp/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { SignedIntentEnvelopeSchema } from '@/types/intent'
+import { verifyEnvelope } from '@/lib/intent/envelope'
+import type { ApiError } from '@/types'
+
+// ─── POST /api/intent/offramp ─────────────────────────────────────────────────
+
+/**
+ * Accepts a signed off-ramp intent envelope, verifies the Ed25519 signature,
+ * then forwards the intent to the routing layer.
+ *
+ * Responses:
+ *   200 — envelope accepted, intent queued for routing
+ *   400 — malformed JSON or envelope fails Zod validation
+ *   401 — signature verification failed
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // ── Parse body ──────────────────────────────────────────────────────────────
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json<ApiError>(
+      { code: 'INVALID_JSON', message: 'Request body must be valid JSON.' },
+      { status: 400 }
+    )
+  }
+
+  // ── Validate envelope shape ─────────────────────────────────────────────────
+  const parsed = SignedIntentEnvelopeSchema.safeParse(body)
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((i) => i.message).join('; ')
+    return NextResponse.json<ApiError>(
+      { code: 'INVALID_ENVELOPE', message },
+      { status: 400 }
+    )
+  }
+
+  // ── Verify signature ────────────────────────────────────────────────────────
+  // verifyEnvelope re-canonicalizes the intent, re-hashes it, and checks the
+  // Ed25519 signature. Returns false on any mismatch or bad key material.
+  if (!verifyEnvelope(parsed.data)) {
+    return NextResponse.json<ApiError>(
+      { code: 'INVALID_SIGNATURE', message: 'Envelope signature verification failed.' },
+      { status: 401 }
+    )
+  }
+
+  // ── Route intent ────────────────────────────────────────────────────────────
+  // Signature is valid — hand off to the off-ramp intent router.
+  // TODO: invoke anchor-specific withdrawal flow via intent router.
+  const { intent } = parsed.data
+
+  return NextResponse.json(
+    { ok: true, intent },
+    { status: 200 }
+  )
+}

--- a/app/api/intent/offramp/route.ts
+++ b/app/api/intent/offramp/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { SignedIntentEnvelopeSchema } from '@/types/intent'
-import { verifyEnvelope } from '@/lib/intent/envelope'
-import type { ApiError } from '@/types'
+import { NextRequest, NextResponse } from 'next/server';
+import { SignedIntentEnvelopeSchema } from '@/types/intent';
+import { verifyEnvelope } from '@/lib/intent/envelope';
+import type { ApiError } from '@/types';
 
 // ─── POST /api/intent/offramp ─────────────────────────────────────────────────
 
@@ -16,24 +16,21 @@ import type { ApiError } from '@/types'
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
   // ── Parse body ──────────────────────────────────────────────────────────────
-  let body: unknown
+  let body: unknown;
   try {
-    body = await req.json()
+    body = await req.json();
   } catch {
     return NextResponse.json<ApiError>(
       { code: 'INVALID_JSON', message: 'Request body must be valid JSON.' },
       { status: 400 }
-    )
+    );
   }
 
   // ── Validate envelope shape ─────────────────────────────────────────────────
-  const parsed = SignedIntentEnvelopeSchema.safeParse(body)
+  const parsed = SignedIntentEnvelopeSchema.safeParse(body);
   if (!parsed.success) {
-    const message = parsed.error.issues.map((i) => i.message).join('; ')
-    return NextResponse.json<ApiError>(
-      { code: 'INVALID_ENVELOPE', message },
-      { status: 400 }
-    )
+    const message = parsed.error.issues.map((i) => i.message).join('; ');
+    return NextResponse.json<ApiError>({ code: 'INVALID_ENVELOPE', message }, { status: 400 });
   }
 
   // ── Verify signature ────────────────────────────────────────────────────────
@@ -43,16 +40,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json<ApiError>(
       { code: 'INVALID_SIGNATURE', message: 'Envelope signature verification failed.' },
       { status: 401 }
-    )
+    );
   }
 
   // ── Route intent ────────────────────────────────────────────────────────────
   // Signature is valid — hand off to the off-ramp intent router.
   // TODO: invoke anchor-specific withdrawal flow via intent router.
-  const { intent } = parsed.data
+  const { intent } = parsed.data;
 
-  return NextResponse.json(
-    { ok: true, intent },
-    { status: 200 }
-  )
+  return NextResponse.json({ ok: true, intent }, { status: 200 });
 }

--- a/app/offramp/page.tsx
+++ b/app/offramp/page.tsx
@@ -1,56 +1,57 @@
-'use client'
-import { useState, useCallback, useEffect } from 'react'
-import { TERMINAL_STATES } from '@/lib/stellar/sep24'
-import { WalletButton } from '@/components/ui/WalletButton'
-import { AmountInput } from '@/components/ui/AmountInput'
-import { CorridorSelector } from '@/components/ui/CorridorSelector'
-import { RateTable } from '@/components/offramp/RateTable'
-import { ExecuteDrawer } from '@/components/offramp/ExecuteDrawer'
-import { StatusTracker } from '@/components/offramp/StatusTracker'
-import { useAnchorRates } from '@/hooks/useAnchorRates'
-import { useFreighter } from '@/hooks/useFreighter'
-import { useWithdrawStatus } from '@/hooks/useWithdrawStatus'
-import type { AnchorRate } from '@/types'
+'use client';
+import { useState, useCallback, useEffect } from 'react';
+import { TERMINAL_STATES } from '@/lib/stellar/sep24';
+import { WalletButton } from '@/components/ui/WalletButton';
+import { AmountInput } from '@/components/ui/AmountInput';
+import { CorridorSelector } from '@/components/ui/CorridorSelector';
+import { RateTable } from '@/components/offramp/RateTable';
+import { ExecuteDrawer } from '@/components/offramp/ExecuteDrawer';
+import { StatusTracker } from '@/components/offramp/StatusTracker';
+import { useAnchorRates } from '@/hooks/useAnchorRates';
+import { useFreighter } from '@/hooks/useFreighter';
+import { useWithdrawStatus } from '@/hooks/useWithdrawStatus';
+import type { AnchorRate } from '@/types';
 
 export default function OfframpPage() {
-  const [corridorId, setCorridorId] = useState('usdc-ngn')
-  const [amount, setAmount] = useState('100')
-  const [selectedRate, setSelectedRate] = useState<AnchorRate | null>(null)
+  const [corridorId, setCorridorId] = useState('usdc-ngn');
+  const [amount, setAmount] = useState('100');
+  const [selectedRate, setSelectedRate] = useState<AnchorRate | null>(null);
 
   // Post-execute status tracking
-  const [trackingTransactionId, setTrackingTransactionId] = useState<string | null>(null)
-  const [trackingTransferServer, setTrackingTransferServer] = useState<string | null>(null)
-  const [trackingJwt, setTrackingJwt] = useState<string | null>(null)
+  const [trackingTransactionId, setTrackingTransactionId] = useState<string | null>(null);
+  const [trackingTransferServer, setTrackingTransferServer] = useState<string | null>(null);
+  const [trackingJwt, setTrackingJwt] = useState<string | null>(null);
 
-  const { isConnected, publicKey } = useFreighter()
-  const { rates, isLoading, error, mutate, refreshInflight } = useAnchorRates(corridorId, amount)
+  const { isConnected, publicKey } = useFreighter();
+  const { rates, isLoading, error, mutate, refreshInflight } = useAnchorRates(corridorId, amount);
 
   const withdrawStatus = useWithdrawStatus(
     trackingTransferServer,
     trackingTransactionId,
     trackingJwt
-  )
+  );
 
   const handleSelectAnchor = useCallback((rate: AnchorRate) => {
-    setSelectedRate(rate)
-  }, [])
+    setSelectedRate(rate);
+  }, []);
 
   const handleDrawerClose = useCallback(() => {
-    setSelectedRate(null)
-  }, [])
+    setSelectedRate(null);
+  }, []);
 
   const handleExecuteStarted = useCallback(
     (transactionId: string, transferServer: string, jwt: string) => {
-      setTrackingTransactionId(transactionId)
-      setTrackingTransferServer(transferServer)
-      setTrackingJwt(jwt)
+      setTrackingTransactionId(transactionId);
+      setTrackingTransferServer(transferServer);
+      setTrackingJwt(jwt);
     },
     []
-  )
+  );
 
   // Reputation writer hook: trigger when transaction reaches terminal state
   useEffect(() => {
     if (withdrawStatus.status && TERMINAL_STATES.has(withdrawStatus.status)) {
+      // eslint-disable-next-line no-console
       console.log('[Reputation] Transaction terminal state reached:', {
         transactionId: trackingTransactionId,
         status: withdrawStatus.status,
@@ -62,9 +63,19 @@ export default function OfframpPage() {
         stellarTransactionId: withdrawStatus.stellarTransactionId,
         externalTransactionId: withdrawStatus.externalTransactionId,
         timestamp: new Date().toISOString(),
-      })
+      });
     }
-  }, [withdrawStatus.status, withdrawStatus.amountIn, withdrawStatus.amountOut, withdrawStatus.amountFee, withdrawStatus.stellarTransactionId, withdrawStatus.externalTransactionId, trackingTransactionId])
+  }, [
+    withdrawStatus.status,
+    withdrawStatus.amountIn,
+    withdrawStatus.amountInAsset,
+    withdrawStatus.amountOut,
+    withdrawStatus.amountOutAsset,
+    withdrawStatus.amountFee,
+    withdrawStatus.stellarTransactionId,
+    withdrawStatus.externalTransactionId,
+    trackingTransactionId,
+  ]);
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
@@ -102,8 +113,18 @@ export default function OfframpPage() {
             onClick={() => mutate()}
             className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-300"
           >
-            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            <svg
+              className="h-3.5 w-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
             </svg>
             Refresh
           </button>
@@ -144,5 +165,5 @@ export default function OfframpPage() {
         onExecuteStarted={handleExecuteStarted}
       />
     </div>
-  )
+  );
 }

--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -33,7 +33,13 @@ interface ExecuteDrawerProps {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStarted }: ExecuteDrawerProps) {
+export function ExecuteDrawer({
+  rate,
+  amount,
+  publicKey,
+  onClose,
+  onExecuteStarted,
+}: ExecuteDrawerProps) {
   const [step, setStep] = useState<ExecuteDrawerStep>('idle');
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
@@ -314,7 +320,7 @@ export function ExecuteDrawer({ rate, amount, publicKey, onClose, onExecuteStart
             </h3>
             <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
               Are you sure you want to cancel the off-ramp process? This will close the KYC form and
-              you'll need to start over.
+              you&apos;ll need to start over.
             </p>
             <div className="flex gap-3">
               <button

--- a/components/offramp/KycIframe.tsx
+++ b/components/offramp/KycIframe.tsx
@@ -87,7 +87,7 @@ export function KycIframe({ url, origin, onComplete, onCancel, onError }: KycIfr
               Unable to load KYC form
             </h3>
             <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
-              The anchor's KYC form couldn't be loaded in this frame.
+              The anchor&apos;s KYC form couldn&apos;t be loaded in this frame.
             </p>
             <button
               onClick={openInNewTab}

--- a/components/offramp/RateTable.tsx
+++ b/components/offramp/RateTable.tsx
@@ -1,7 +1,7 @@
-'use client'
-import { formatCurrency, formatRate } from '@/lib/utils'
-import type { RateComparison, AnchorRate } from '@/types'
-import { Skeleton } from '@/components/ui/Skeleton'
+'use client';
+import { formatCurrency, formatRate } from '@/lib/utils';
+import type { RateComparison, AnchorRate } from '@/types';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 function sourceBadge(source: AnchorRate['source']): React.ReactNode {
   switch (source) {
@@ -10,38 +10,44 @@ function sourceBadge(source: AnchorRate['source']): React.ReactNode {
         <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/40 dark:text-green-300">
           SEP-38
         </span>
-      )
+      );
     case 'sep24-fee':
-      return null
+      return null;
     case 'unavailable':
       return (
         <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
           Unavailable
         </span>
-      )
+      );
     default: {
-      const _exhaustive: never = source
-      void _exhaustive
-      return null
+      const _exhaustive: never = source;
+      void _exhaustive;
+      return null;
     }
   }
 }
 
 interface RateTableProps {
-  rates: RateComparison | undefined
-  isLoading: boolean
-  refreshInflight?: boolean
-  error: string | undefined
-  onSelectAnchor: (rate: AnchorRate) => void
+  rates: RateComparison | undefined;
+  isLoading: boolean;
+  refreshInflight?: boolean;
+  error: string | undefined;
+  onSelectAnchor: (rate: AnchorRate) => void;
 }
 
-export function RateTable({ rates, isLoading, refreshInflight, error, onSelectAnchor }: RateTableProps) {
+export function RateTable({
+  rates,
+  isLoading,
+  refreshInflight,
+  error,
+  onSelectAnchor,
+}: RateTableProps) {
   if ((isLoading || refreshInflight) && (!rates || rates.rates.length === 0)) {
     return (
       <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
         <Skeleton rows={5} />
       </div>
-    )
+    );
   }
 
   return (
@@ -49,15 +55,24 @@ export function RateTable({ rates, isLoading, refreshInflight, error, onSelectAn
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50">
-            <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-gray-400">Anchor</th>
-            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">Fee</th>
-            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">Rate</th>
-            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">You Receive</th>
-            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">Action</th>
+            <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-gray-400">
+              Anchor
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">
+              Fee
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">
+              Rate
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">
+              You Receive
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-gray-600 dark:text-gray-400">
+              Action
+            </th>
           </tr>
         </thead>
         <tbody>
-
           {!isLoading && error && (
             <tr>
               <td colSpan={5} className="px-4 py-8 text-center">
@@ -80,58 +95,62 @@ export function RateTable({ rates, isLoading, refreshInflight, error, onSelectAn
             </tr>
           )}
 
-          {!isLoading && !error && rates?.rates.map((rate) => {
-            const isBest = rate.anchorId === rates.bestRateId
-            const isUnavailable = rate.source === 'unavailable'
-            const currency = rate.corridorId.split('-')[1]?.toUpperCase() ?? ''
+          {!isLoading &&
+            !error &&
+            rates?.rates.map((rate) => {
+              const isBest = rate.anchorId === rates.bestRateId;
+              const isUnavailable = rate.source === 'unavailable';
+              const currency = rate.corridorId.split('-')[1]?.toUpperCase() ?? '';
 
-            return (
-              <tr
-                key={rate.anchorId}
-                className={
-                  isBest && !isUnavailable
-                    ? 'border-t border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/20'
-                    : 'border-t border-gray-200 dark:border-gray-700'
-                }
-              >
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-gray-900 dark:text-white">
-                      {rate.anchorName}
-                    </span>
-                    {isBest && !isUnavailable && (
-                      <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
-                        Best Rate
+              return (
+                <tr
+                  key={rate.anchorId}
+                  className={
+                    isBest && !isUnavailable
+                      ? 'border-t border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/20'
+                      : 'border-t border-gray-200 dark:border-gray-700'
+                  }
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900 dark:text-white">
+                        {rate.anchorName}
                       </span>
-                    )}
-                    {sourceBadge(rate.source)}
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">
-                  {rate.fee !== null ? formatCurrency(rate.fee, 'USD') : '—'}
-                </td>
-                <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">
-                  {rate.exchangeRate !== null && rate.exchangeRate > 0
-                    ? formatRate(rate.exchangeRate, 'USDC', currency)
-                    : '—'}
-                </td>
-                <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-white">
-                  {rate.totalReceived !== null ? formatCurrency(rate.totalReceived, currency) : '—'}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <button
-                    onClick={() => onSelectAnchor(rate)}
-                    disabled={isUnavailable}
-                    className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    Off-ramp
-                  </button>
-                </td>
-              </tr>
-            )
-          })}
+                      {isBest && !isUnavailable && (
+                        <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                          Best Rate
+                        </span>
+                      )}
+                      {sourceBadge(rate.source)}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">
+                    {rate.fee !== null ? formatCurrency(rate.fee, 'USD') : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">
+                    {rate.exchangeRate !== null && rate.exchangeRate > 0
+                      ? formatRate(rate.exchangeRate, 'USDC', currency)
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-white">
+                    {rate.totalReceived !== null
+                      ? formatCurrency(rate.totalReceived, currency)
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => onSelectAnchor(rate)}
+                      disabled={isUnavailable}
+                      className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      Off-ramp
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
         </tbody>
       </table>
     </div>
-  )
+  );
 }

--- a/components/offramp/StatusTracker.tsx
+++ b/components/offramp/StatusTracker.tsx
@@ -1,25 +1,25 @@
-'use client'
-import type { WithdrawStatusValue, Sep24Transaction } from '@/types'
-import { formatDeliveredAmount } from '@/lib/format'
-import { Timeline } from './Timeline'
+'use client';
+import type { WithdrawStatusValue, Sep24Transaction } from '@/types';
+import { formatDeliveredAmount } from '@/lib/format';
+import { Timeline } from './Timeline';
 
 interface StatusTrackerProps {
-  transactionId: string
-  status: WithdrawStatusValue | undefined
-  amountIn: string | undefined
-  amountInAsset: string | undefined
-  amountOut: string | undefined
-  amountOutAsset: string | undefined
-  amountFee: string | undefined
+  transactionId: string;
+  status: WithdrawStatusValue | undefined;
+  amountIn: string | undefined;
+  amountInAsset: string | undefined;
+  amountOut: string | undefined;
+  amountOutAsset: string | undefined;
+  amountFee: string | undefined;
   /** ISO 4217 currency code for the destination corridor (e.g. "NGN", "KES"). */
-  currencyCode: string
-  stellarTransactionId: string | undefined
-  externalTransactionId: string | undefined
-  refunds?: Sep24Transaction['refunds']
-  isLoading: boolean
-  error: string | undefined
-  onRetryAnchor?: () => void
-  onAdjust?: () => void
+  currencyCode: string;
+  stellarTransactionId: string | undefined;
+  externalTransactionId: string | undefined;
+  refunds?: Sep24Transaction['refunds'];
+  isLoading: boolean;
+  error: string | undefined;
+  onRetryAnchor?: () => void;
+  onAdjust?: () => void;
 }
 
 const STATUS_LABELS: Record<WithdrawStatusValue, string> = {
@@ -38,25 +38,33 @@ const STATUS_LABELS: Record<WithdrawStatusValue, string> = {
   too_small: 'Amount too small',
   too_large: 'Amount too large',
   expired: 'Transaction expired',
-}
+};
 
-const TERMINAL: WithdrawStatusValue[] = ['completed', 'refunded', 'error', 'no_market', 'too_small', 'too_large', 'expired']
+const TERMINAL: WithdrawStatusValue[] = [
+  'completed',
+  'refunded',
+  'error',
+  'no_market',
+  'too_small',
+  'too_large',
+  'expired',
+];
 
 function statusColor(status: WithdrawStatusValue | undefined): string {
-  if (!status) return 'text-gray-500'
-  if (status === 'completed') return 'text-green-600 dark:text-green-400'
+  if (!status) return 'text-gray-500';
+  if (status === 'completed') return 'text-green-600 dark:text-green-400';
   if (['error', 'no_market', 'too_small', 'too_large'].includes(status))
-    return 'text-red-600 dark:text-red-400'
-  if (status === 'refunded') return 'text-yellow-600 dark:text-yellow-400'
-  return 'text-blue-600 dark:text-blue-400'
+    return 'text-red-600 dark:text-red-400';
+  if (status === 'refunded') return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-blue-600 dark:text-blue-400';
 }
 
 function statusDot(status: WithdrawStatusValue | undefined): string {
-  if (!status) return 'bg-gray-300'
-  if (status === 'completed') return 'bg-green-500'
-  if (['error', 'no_market', 'too_small', 'too_large'].includes(status)) return 'bg-red-500'
-  if (status === 'refunded') return 'bg-yellow-500'
-  return 'bg-blue-500 animate-pulse'
+  if (!status) return 'bg-gray-300';
+  if (status === 'completed') return 'bg-green-500';
+  if (['error', 'no_market', 'too_small', 'too_large'].includes(status)) return 'bg-red-500';
+  if (status === 'refunded') return 'bg-yellow-500';
+  return 'bg-blue-500 animate-pulse';
 }
 
 export function StatusTracker({
@@ -74,8 +82,8 @@ export function StatusTracker({
   isLoading,
   error,
 }: StatusTrackerProps) {
-  const isTerminal = status ? TERMINAL.includes(status) : false
-  const isCompleted = status === 'completed'
+  const isTerminal = status ? TERMINAL.includes(status) : false;
+  const isCompleted = status === 'completed';
 
   return (
     <div
@@ -87,7 +95,9 @@ export function StatusTracker({
     >
       <div className="mb-4 flex items-start justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Transaction Status</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Transaction Status
+          </h3>
           <p className="mt-0.5 font-mono text-xs text-gray-400">{transactionId}</p>
         </div>
         {!isTerminal && (
@@ -158,7 +168,9 @@ export function StatusTracker({
       {/* Refund details */}
       {status === 'refunded' && refunds && (
         <div className="mb-4 mt-2 rounded-lg bg-yellow-50 p-4 dark:bg-yellow-900/20">
-          <h4 className="mb-2 text-sm font-semibold text-yellow-800 dark:text-yellow-300">Refund Details</h4>
+          <h4 className="mb-2 text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+            Refund Details
+          </h4>
           <dl className="space-y-1.5 text-sm">
             {refunds.amount_refunded && (
               <div className="flex justify-between">
@@ -177,21 +189,27 @@ export function StatusTracker({
               </div>
             )}
           </dl>
-          
+
           {refunds.payments && refunds.payments.length > 0 && (
             <div className="mt-3 pt-3 border-t border-yellow-200/50 dark:border-yellow-700/50">
-              <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-300 mb-2">Refund Payments</p>
+              <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-300 mb-2">
+                Refund Payments
+              </p>
               <div className="space-y-2">
                 {refunds.payments.map((p, i) => (
                   <div key={i} className="text-xs bg-white/50 dark:bg-black/20 rounded p-2">
                     <div className="flex justify-between mb-1">
                       <span className="text-yellow-700 dark:text-yellow-400">Amount</span>
-                      <span className="font-medium text-yellow-900 dark:text-yellow-200">{p.amount}</span>
+                      <span className="font-medium text-yellow-900 dark:text-yellow-200">
+                        {p.amount}
+                      </span>
                     </div>
                     {p.fee && (
                       <div className="flex justify-between mb-1">
                         <span className="text-yellow-700 dark:text-yellow-400">Fee</span>
-                        <span className="font-medium text-yellow-900 dark:text-yellow-200">{p.fee}</span>
+                        <span className="font-medium text-yellow-900 dark:text-yellow-200">
+                          {p.fee}
+                        </span>
                       </div>
                     )}
                     <div className="mt-1 pt-1 border-t border-yellow-200/30 dark:border-yellow-700/30">
@@ -232,13 +250,13 @@ export function StatusTracker({
       {/* Vertical Timeline */}
       <Timeline status={status} />
     </div>
-  )
+  );
 }
 
 function parseAsset(assetStr: string | undefined): string | null {
-  if (!assetStr) return null
-  if (assetStr === 'stellar:native') return 'XLM'
+  if (!assetStr) return null;
+  if (assetStr === 'stellar:native') return 'XLM';
   // stellar:USDC:GA5Z... -> USDC
-  const parts = assetStr.split(':')
-  return parts[1] ?? null
+  const parts = assetStr.split(':');
+  return parts[1] ?? null;
 }

--- a/components/offramp/Timeline.tsx
+++ b/components/offramp/Timeline.tsx
@@ -1,9 +1,9 @@
-import { CheckIcon } from 'lucide-react'
-import type { WithdrawStatusValue } from '@/types'
-import { mapToCanonical } from '@/lib/stellar/sep24-status-map'
+import { CheckIcon } from 'lucide-react';
+import type { WithdrawStatusValue } from '@/types';
+import { mapToCanonical } from '@/lib/stellar/sep24-status-map';
 
 export interface TimelineProps {
-  status: WithdrawStatusValue | undefined
+  status: WithdrawStatusValue | undefined;
 }
 
 const STAGES = [
@@ -12,35 +12,36 @@ const STAGES = [
   { id: 'pending_stellar', label: 'Confirming on Stellar' },
   { id: 'pending_external', label: 'Sending to Bank' },
   { id: 'completed', label: 'Completed' },
-] as const
-
-type StageId = (typeof STAGES)[number]['id']
+] as const;
 
 export function Timeline({ status }: TimelineProps) {
-  const canonical = status ? mapToCanonical(status) : undefined
+  const canonical = status ? mapToCanonical(status) : undefined;
 
   // If terminal error state, we might still want to show where it stopped,
   // but for simplicity, we map canonical progress index.
-  const currentIndex = STAGES.findIndex((s) => s.id === canonical)
+  const currentIndex = STAGES.findIndex((s) => s.id === canonical);
 
-  // If the state is not in the STAGES list (e.g. error, refunded), 
+  // If the state is not in the STAGES list (e.g. error, refunded),
   // we either highlight the last known step or we just rely on currentIndex being -1.
   // Actually, if it's refunded/error, we could just not render the timeline or render it halted.
   // We'll render it up to where we know, but since canonical won't match, currentIndex is -1.
   // Let's assume if canonical is an error state, we still want to show something.
   // For now, let's just use currentIndex to determine active/past/future.
-  
-  const activeIndex = currentIndex >= 0 ? currentIndex : 0
-  const isTerminalError = ['error', 'refunded', 'no_market', 'expired'].includes(canonical ?? '')
+
+  const activeIndex = currentIndex >= 0 ? currentIndex : 0;
+  const isTerminalError = ['error', 'refunded', 'no_market', 'expired'].includes(canonical ?? '');
 
   return (
-    <div className="mt-6 pt-6 border-t border-gray-100 dark:border-gray-800" aria-label="Transaction progress timeline">
+    <div
+      className="mt-6 pt-6 border-t border-gray-100 dark:border-gray-800"
+      aria-label="Transaction progress timeline"
+    >
       <h4 className="sr-only">Progress Timeline</h4>
       <div className="space-y-4">
         {STAGES.map((stage, idx) => {
-          const isCompleted = idx < activeIndex || canonical === 'completed'
-          const isActive = idx === activeIndex && !isTerminalError && canonical !== 'completed'
-          const isFuture = idx > activeIndex || (idx === activeIndex && isTerminalError)
+          const isCompleted = idx < activeIndex || canonical === 'completed';
+          const isActive = idx === activeIndex && !isTerminalError && canonical !== 'completed';
+          const _isFuture = idx > activeIndex || (idx === activeIndex && isTerminalError);
 
           return (
             <div
@@ -78,8 +79,8 @@ export function Timeline({ status }: TimelineProps) {
                     isActive
                       ? 'text-gray-900 dark:text-white'
                       : isCompleted
-                      ? 'text-gray-700 dark:text-gray-300'
-                      : 'text-gray-400 dark:text-gray-500'
+                        ? 'text-gray-700 dark:text-gray-300'
+                        : 'text-gray-400 dark:text-gray-500'
                   }`}
                 >
                   {stage.label}
@@ -89,9 +90,9 @@ export function Timeline({ status }: TimelineProps) {
                 </span>
               </div>
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }

--- a/components/ui/AmountInput.tsx
+++ b/components/ui/AmountInput.tsx
@@ -1,9 +1,9 @@
-'use client'
-import { useState, useEffect, useRef } from 'react'
+'use client';
+import { useState, useEffect, useRef } from 'react';
 
-const POSITIVE_DECIMAL_RE = /^\d*\.?\d{0,7}$/
+const POSITIVE_DECIMAL_RE = /^\d*\.?\d{0,7}$/;
 
-const SUGGESTED_AMOUNTS = [50, 100, 500]
+const SUGGESTED_AMOUNTS = [50, 100, 500];
 
 function formatChipLabel(value: number): string {
   try {
@@ -11,74 +11,76 @@ function formatChipLabel(value: number): string {
       style: 'currency',
       currency: 'USD',
       maximumFractionDigits: 0,
-    }).format(value)
+    }).format(value);
   } catch {
-    return `$${value}`
+    return `$${value}`;
   }
 }
 
 function validate(raw: string): string | null {
-  if (!POSITIVE_DECIMAL_RE.test(raw)) return null
-  const n = Number(raw)
-  if (!Number.isFinite(n) || n <= 0) return null
-  return raw
+  if (!POSITIVE_DECIMAL_RE.test(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return raw;
 }
 
 interface AmountInputProps {
-  value: string
-  onChange: (value: string) => void
-  disabled?: boolean
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
 }
 
 export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
-  const [raw, setRaw] = useState(value)
-  const [error, setError] = useState<string | null>(null)
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [raw, setRaw] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    setRaw(value)
-    setError(null)
-  }, [value])
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRaw(value);
+
+    setError(null);
+  }, [value]);
 
   useEffect(() => {
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
-    }
-  }, [])
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   function handleChipClick(value: number) {
-    const str = String(value)
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    setRaw(str)
-    setError(null)
-    onChange(str)
+    const str = String(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setRaw(str);
+    setError(null);
+    onChange(str);
   }
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const input = e.target.value
-    setRaw(input)
+    const input = e.target.value;
+    setRaw(input);
 
-    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (debounceRef.current) clearTimeout(debounceRef.current);
 
     if (input === '') {
-      setError(null)
-      debounceRef.current = setTimeout(() => onChange(''), 250)
-      return
+      setError(null);
+      debounceRef.current = setTimeout(() => onChange(''), 250);
+      return;
     }
 
     if (input.endsWith('.')) {
-      setError(null)
-      return
+      setError(null);
+      return;
     }
 
-    const validated = validate(input)
+    const validated = validate(input);
     if (validated === null) {
-      setError('Enter a positive number with up to 7 decimal places')
-      return
+      setError('Enter a positive number with up to 7 decimal places');
+      return;
     }
 
-    setError(null)
-    debounceRef.current = setTimeout(() => onChange(validated), 250)
+    setError(null);
+    debounceRef.current = setTimeout(() => onChange(validated), 250);
   }
 
   return (
@@ -128,5 +130,5 @@ export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
         </p>
       )}
     </div>
-  )
+  );
 }

--- a/components/ui/CorridorSelector.tsx
+++ b/components/ui/CorridorSelector.tsx
@@ -1,5 +1,5 @@
-'use client'
-import { CORRIDORS } from '@/constants/anchors'
+'use client';
+import { CORRIDORS } from '@/constants/anchors';
 
 const COUNTRY_FLAGS: Record<string, string> = {
   NG: '🇳🇬',
@@ -9,11 +9,11 @@ const COUNTRY_FLAGS: Record<string, string> = {
   BR: '🇧🇷',
   AR: '🇦🇷',
   PE: '🇵🇪',
-}
+};
 
 interface CorridorSelectorProps {
-  value: string
-  onChange: (corridorId: string) => void
+  value: string;
+  onChange: (corridorId: string) => void;
 }
 
 /**
@@ -38,5 +38,5 @@ export function CorridorSelector({ value, onChange }: CorridorSelectorProps) {
         ))}
       </select>
     </div>
-  )
+  );
 }

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,5 +1,5 @@
 interface SkeletonProps {
-  rows?: number
+  rows?: number;
 }
 
 export function Skeleton({ rows = 5 }: SkeletonProps) {
@@ -17,5 +17,5 @@ export function Skeleton({ rows = 5 }: SkeletonProps) {
         ))}
       </tbody>
     </table>
-  )
+  );
 }

--- a/components/ui/WalletButton.tsx
+++ b/components/ui/WalletButton.tsx
@@ -1,10 +1,10 @@
-'use client'
-import { useFreighter } from '@/hooks/useFreighter'
-import { truncatePublicKey } from '@/lib/utils'
-import { Button } from './Button'
+'use client';
+import { useFreighter } from '@/hooks/useFreighter';
+import { truncatePublicKey } from '@/lib/utils';
+import { Button } from './Button';
 
 export function WalletButton() {
-  const { isInstalled, isConnected, publicKey, network, connect, error } = useFreighter()
+  const { isInstalled, isConnected, publicKey, network, connect, error } = useFreighter();
 
   // State 1: not-detected — Freighter extension is not installed
   if (!isInstalled) {
@@ -17,7 +17,7 @@ export function WalletButton() {
       >
         Install Freighter
       </a>
-    )
+    );
   }
 
   // State 2: disconnected — extension present, wallet not connected
@@ -33,7 +33,7 @@ export function WalletButton() {
           </p>
         )}
       </div>
-    )
+    );
   }
 
   // State 3: wrong-network — connected but not on Mainnet
@@ -60,7 +60,7 @@ export function WalletButton() {
           </a>
         </p>
       </div>
-    )
+    );
   }
 
   // State 4: connected — on Mainnet with a valid public key
@@ -73,5 +73,5 @@ export function WalletButton() {
         Mainnet
       </span>
     </div>
-  )
+  );
 }

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -42,7 +42,6 @@ export const SUPPORTED_COUNTRIES: Country[] = [
   { code: 'DE', name: 'Germany', currency: 'EUR', currencySymbol: '€', flag: '🇩🇪' },
 ];
 
-
 export const REVALIDATION_INTERVAL = 30_000; // 30 seconds
 
 export const SWAP_SOURCES = ['SDEX', 'Soroswap', 'Phoenix', 'Aquarius'] as const;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -14,7 +14,6 @@ export const USDC_ASSET: StellarAsset = {
 
 export const XLM_ASSET: StellarAsset = {
   code: 'XLM',
-  issuer: undefined,
   name: 'Stellar Lumens',
 };
 

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -1,26 +1,26 @@
-'use client'
+'use client';
 
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
-import type { FreighterState } from '@/types'
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import type { FreighterState } from '@/types';
 
 import {
   UserRejectedError,
   NetworkError,
   ConnectionError,
   UnknownWalletError,
-} from '@/lib/stellar/errors'
+} from '@/lib/stellar/errors';
 
-import { WatchWalletChanges } from '@stellar/freighter-api'
+import { WatchWalletChanges } from '@stellar/freighter-api';
 
 // Freighter API is a browser extension — import lazily to avoid SSR errors
 async function getFreighterApi() {
-  const mod = await import('@stellar/freighter-api')
-  return mod
+  const mod = await import('@stellar/freighter-api');
+  return mod;
 }
 
 interface WalletContextType extends FreighterState {
-  connect: () => Promise<void>
-  disconnect: () => void
+  connect: () => Promise<void>;
+  disconnect: () => void;
 }
 
 const INITIAL_STATE: FreighterState = {
@@ -29,43 +29,42 @@ const INITIAL_STATE: FreighterState = {
   publicKey: null,
   network: null,
   error: null,
-}
+};
 
-const WalletContext = createContext<WalletContextType | undefined>(undefined)
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<FreighterState>(INITIAL_STATE)
-  const mountedRef = useRef(true)
+  const [state, setState] = useState<FreighterState>(INITIAL_STATE);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true
+    mountedRef.current = true;
     return () => {
-      mountedRef.current = false
-    }
-  }, [])
+      mountedRef.current = false;
+    };
+  }, []);
 
   // Check extension presence on mount
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
 
     async function checkInstalled() {
       try {
-        const { isConnected, getAddress, getNetwork } = await getFreighterApi()
-        const connResult = await isConnected()
+        const { isConnected, getAddress, getNetwork } = await getFreighterApi();
+        const connResult = await isConnected();
 
-        if (cancelled) return
+        if (cancelled) return;
 
         if (connResult.error || !connResult.isConnected) {
-          setState((s) => ({ ...s, isInstalled: true, isConnected: false }))
-          return
+          setState((s) => ({ ...s, isInstalled: true, isConnected: false }));
+          return;
         }
 
-        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
-        if (cancelled) return
+        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
+        if (cancelled) return;
 
-        const networkName = netResult.network ?? null
-        const networkError =
-          networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+        const networkName = netResult.network ?? null;
+        const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
 
         setState({
           isInstalled: true,
@@ -73,23 +72,22 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           publicKey: addrResult.address ?? null,
           network: networkName,
           error: networkError,
-        })
+        });
       } catch {
-        if (cancelled) return
-        setState({ ...INITIAL_STATE, isInstalled: false })
+        if (cancelled) return;
+        setState({ ...INITIAL_STATE, isInstalled: false });
       }
     }
 
-    checkInstalled()
+    checkInstalled();
 
     // Watch for live changes (account/network switches)
-    const watcher = new WatchWalletChanges(2000)
+    const watcher = new WatchWalletChanges(2000);
     watcher.watch((result: { address?: string; network?: string }) => {
-      if (!mountedRef.current) return
+      if (!mountedRef.current) return;
 
-      const networkName = result.network ?? null
-      const networkError =
-        networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+      const networkName = result.network ?? null;
+      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
 
       setState((s: FreighterState) => {
         // Only update if something actually changed to prevent re-render loops
@@ -98,7 +96,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           s.network === networkName &&
           s.error === networkError
         ) {
-          return s
+          return s;
         }
 
         return {
@@ -107,29 +105,28 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           publicKey: result.address ?? null,
           network: networkName,
           error: networkError,
-        }
-      })
-    })
+        };
+      });
+    });
 
     return () => {
-      cancelled = true
-      watcher.stop()
-    }
-  }, [])
+      cancelled = true;
+      watcher.stop();
+    };
+  }, []);
 
   const connect = useCallback(async () => {
-    setState((s) => ({ ...s, error: null }))
+    setState((s) => ({ ...s, error: null }));
     try {
-      const { requestAccess, getAddress, getNetwork } = await getFreighterApi()
-      const accessResult = await requestAccess()
-      if (accessResult.error) throw new Error(String(accessResult.error))
+      const { requestAccess, getAddress, getNetwork } = await getFreighterApi();
+      const accessResult = await requestAccess();
+      if (accessResult.error) throw new Error(String(accessResult.error));
 
-      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
-      if (!mountedRef.current) return
+      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
+      if (!mountedRef.current) return;
 
-      const networkName = netResult.network ?? null
-      const networkError =
-        networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+      const networkName = netResult.network ?? null;
+      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
 
       setState({
         isInstalled: true,
@@ -137,21 +134,24 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         publicKey: addrResult.address ?? null,
         network: networkName,
         error: networkError,
-      })
+      });
     } catch (err) {
-      if (!mountedRef.current) return
-      
-      let mappedError: Error
-      const message = err instanceof Error ? err.message : String(err)
+      if (!mountedRef.current) return;
+
+      let mappedError: Error;
+      const message = err instanceof Error ? err.message : String(err);
 
       if (message.includes('User rejected')) {
-        mappedError = new UserRejectedError()
-      } else if (message.includes('switch Freighter to Mainnet') || message.includes('Network mismatch')) {
-        mappedError = new NetworkError(message)
+        mappedError = new UserRejectedError();
+      } else if (
+        message.includes('switch Freighter to Mainnet') ||
+        message.includes('Network mismatch')
+      ) {
+        mappedError = new NetworkError(message);
       } else if (message.includes('not found') || message.includes('locked')) {
-        mappedError = new ConnectionError(message)
+        mappedError = new ConnectionError(message);
       } else {
-        mappedError = new UnknownWalletError(message)
+        mappedError = new UnknownWalletError(message);
       }
 
       setState((s) => ({
@@ -159,9 +159,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         isConnected: false,
         publicKey: null,
         error: mappedError.message,
-      }))
+      }));
     }
-  }, [])
+  }, []);
 
   const disconnect = useCallback(() => {
     setState({
@@ -170,22 +170,22 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       publicKey: null,
       network: null,
       error: null,
-    })
-  }, [])
+    });
+  }, []);
 
   const value = {
     ...state,
     connect,
     disconnect,
-  }
+  };
 
-  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }
 
 export function useWallet() {
-  const context = useContext(WalletContext)
+  const context = useContext(WalletContext);
   if (context === undefined) {
-    throw new Error('useWallet must be used within a WalletProvider')
+    throw new Error('useWallet must be used within a WalletProvider');
   }
-  return context
+  return context;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,27 +85,27 @@ writes to Soroban — never to move user funds.
 
 ## 2. Component inventory & repo layout
 
-| Module | Role | Path | Status |
-| --- | --- | --- | --- |
-| **Offramp page** | The end-user surface. Corridor select → rate table → execute drawer → status tracker. | `app/offramp/page.tsx` | ✅ |
-| **RateTable** | Sortable list of live anchor quotes for the selected corridor. | `components/offramp/RateTable.tsx` | ✅ |
-| **ExecuteDrawer** | 6-step SEP-10/24 off-ramp: `authenticating → initiating → kyc → building → signing → done`. | `components/offramp/ExecuteDrawer.tsx` | ✅ |
-| **StatusTracker** | Polls `/transaction?id=...` and renders the SEP-24 state machine. | `components/offramp/StatusTracker.tsx` | ✅ |
-| **Anchor registry** | Typed list of anchors + corridors + assets. Single source of truth. | `lib/stellar/anchors.ts` | ✅ |
-| **SEP-1 resolver** | `stellar.toml` discovery, TRANSFER_SERVER_SEP0024 + WEB_AUTH_ENDPOINT extraction. | `lib/stellar/sep1.ts` | ✅ |
-| **SEP-10 client** | Challenge fetch, Freighter sign, JWT exchange. Network asserted as mainnet. | `lib/stellar/sep10.ts` | ✅ |
-| **SEP-24 client** | `/fee`, `/transactions/withdraw/interactive`, `/transaction` wrappers. 10s timeout. | `lib/stellar/sep24.ts` | ✅ |
-| **Horizon helper** | Build + sign + submit the user's withdrawal payment on the Stellar ledger. | `lib/stellar/horizon.ts` | ✅ |
-| **Freighter hook** | Wallet connection state + account + network. | `hooks/useFreighter.ts` | ✅ |
-| **Rates hook** | SWR-powered parallel rate aggregation across all anchors on a corridor. | `hooks/useAnchorRates.ts` | ✅ |
-| **Status hook** | SWR polling loop keyed by `[transferServer, transactionId, jwt]`. | `hooks/useWithdrawStatus.ts` | ✅ |
-| **SEP-38 client** | Firm-quote RFQ against anchors; supersedes the `/fee` + stored-rate approach. | `lib/stellar/sep38.ts` | 🛠️ v1.1 |
-| **Intent canonicalizer** | Deterministic JSON → hash → sign. | `lib/intent/canonical.ts` | 🛠️ v1.2 |
-| **Intent router (solver)** | Scores candidate anchors by net landed value; returns a single-anchor or split plan. | `lib/router/` | 🛠️ v1.2 |
-| **Publisher worker** | Signs outcome tuples and invokes the Soroban contract. | `lib/publisher/` | 🛠️ v2 |
-| **Soroban oracle contract** | On-chain reputation storage + read helpers. | `contracts/oracle/` | 🛠️ v2 |
-| **MCP server** | Exposes router + oracle as MCP tools. | `packages/mcp/` | 🛠️ v4 |
-| **SDK** | Typed client for the API + MCP. | `packages/sdk/` | 🛠️ v4 |
+| Module                      | Role                                                                                        | Path                                   | Status  |
+| --------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
+| **Offramp page**            | The end-user surface. Corridor select → rate table → execute drawer → status tracker.       | `app/offramp/page.tsx`                 | ✅      |
+| **RateTable**               | Sortable list of live anchor quotes for the selected corridor.                              | `components/offramp/RateTable.tsx`     | ✅      |
+| **ExecuteDrawer**           | 6-step SEP-10/24 off-ramp: `authenticating → initiating → kyc → building → signing → done`. | `components/offramp/ExecuteDrawer.tsx` | ✅      |
+| **StatusTracker**           | Polls `/transaction?id=...` and renders the SEP-24 state machine.                           | `components/offramp/StatusTracker.tsx` | ✅      |
+| **Anchor registry**         | Typed list of anchors + corridors + assets. Single source of truth.                         | `lib/stellar/anchors.ts`               | ✅      |
+| **SEP-1 resolver**          | `stellar.toml` discovery, TRANSFER_SERVER_SEP0024 + WEB_AUTH_ENDPOINT extraction.           | `lib/stellar/sep1.ts`                  | ✅      |
+| **SEP-10 client**           | Challenge fetch, Freighter sign, JWT exchange. Network asserted as mainnet.                 | `lib/stellar/sep10.ts`                 | ✅      |
+| **SEP-24 client**           | `/fee`, `/transactions/withdraw/interactive`, `/transaction` wrappers. 10s timeout.         | `lib/stellar/sep24.ts`                 | ✅      |
+| **Horizon helper**          | Build + sign + submit the user's withdrawal payment on the Stellar ledger.                  | `lib/stellar/horizon.ts`               | ✅      |
+| **Freighter hook**          | Wallet connection state + account + network.                                                | `hooks/useFreighter.ts`                | ✅      |
+| **Rates hook**              | SWR-powered parallel rate aggregation across all anchors on a corridor.                     | `hooks/useAnchorRates.ts`              | ✅      |
+| **Status hook**             | SWR polling loop keyed by `[transferServer, transactionId, jwt]`.                           | `hooks/useWithdrawStatus.ts`           | ✅      |
+| **SEP-38 client**           | Firm-quote RFQ against anchors; supersedes the `/fee` + stored-rate approach.               | `lib/stellar/sep38.ts`                 | 🛠️ v1.1 |
+| **Intent canonicalizer**    | Deterministic JSON → hash → sign.                                                           | `lib/intent/canonical.ts`              | 🛠️ v1.2 |
+| **Intent router (solver)**  | Scores candidate anchors by net landed value; returns a single-anchor or split plan.        | `lib/router/`                          | 🛠️ v1.2 |
+| **Publisher worker**        | Signs outcome tuples and invokes the Soroban contract.                                      | `lib/publisher/`                       | 🛠️ v2   |
+| **Soroban oracle contract** | On-chain reputation storage + read helpers.                                                 | `contracts/oracle/`                    | 🛠️ v2   |
+| **MCP server**              | Exposes router + oracle as MCP tools.                                                       | `packages/mcp/`                        | 🛠️ v4   |
+| **SDK**                     | Typed client for the API + MCP.                                                             | `packages/sdk/`                        | 🛠️ v4   |
 
 > All module paths are namespaced — no runtime concern spans two modules in
 > opposite directions. `lib/stellar/*` has no dependencies on `lib/router/*`
@@ -121,26 +121,26 @@ the atomic unit every other component is built around.
 ```ts
 // types/intent.ts — planned shape
 interface Intent {
-  version: 1
-  nonce: string                 // 128-bit random, replay protection
-  account: string               // user's Stellar public key
-  corridor: `${string}-${string}` // e.g. 'usdc-ngn'
-  sellAsset: { code: string; issuer: string }
-  sellAmount: string            // decimal string
-  buyAsset: { code: string }    // fiat, e.g. 'NGN'
-  minReceive: string            // floor on delivered amount
-  deliveryHint: DeliveryHint    // bank / mobile-money / cash pickup
-  deadline: string              // RFC3339
+  version: 1;
+  nonce: string; // 128-bit random, replay protection
+  account: string; // user's Stellar public key
+  corridor: `${string}-${string}`; // e.g. 'usdc-ngn'
+  sellAsset: { code: string; issuer: string };
+  sellAmount: string; // decimal string
+  buyAsset: { code: string }; // fiat, e.g. 'NGN'
+  minReceive: string; // floor on delivered amount
+  deliveryHint: DeliveryHint; // bank / mobile-money / cash pickup
+  deadline: string; // RFC3339
   preferences?: {
-    allowSplit: boolean         // default: true
-    maxAnchors: number          // default: 2
-    preferAnchorIds?: string[]  // user whitelist
-  }
+    allowSplit: boolean; // default: true
+    maxAnchors: number; // default: 2
+    preferAnchorIds?: string[]; // user whitelist
+  };
 }
 interface SignedIntent {
-  intent: Intent
-  intentHash: string            // sha-256 over canonical JSON
-  signature: string             // ed25519 over intentHash, by account
+  intent: Intent;
+  intentHash: string; // sha-256 over canonical JSON
+  signature: string; // ed25519 over intentHash, by account
 }
 ```
 
@@ -230,14 +230,14 @@ Implemented in `lib/stellar/sep10.ts`. Key invariants:
 
 `ExecuteDrawer` walks six steps, each with an error state and a cancel path:
 
-| Step | Substrate | What happens | Failure recovery |
-| --- | --- | --- | --- |
-| `authenticating` | SEP-10 | Fetch challenge, sign, exchange for JWT. | Retry in-place; on rejection, return to idle. |
-| `initiating` | SEP-24 | `POST /transactions/withdraw/interactive` with JWT. | Surface anchor error; retry with fresh JWT. |
-| `kyc` | Anchor-hosted iframe | Open the returned URL in a popup. Anchor owns the KYC surface. | On popup close without success, poll `/transaction` for `pending_user`. |
-| `building` | Horizon | `buildWithdrawPayment` — construct the USDC payment to the anchor's receiving address at the quoted amount. | Fee estimation retries; network reselect. |
-| `signing` | Freighter | User signs the payment XDR. | User-reject returns to idle; signature-required errors surface. |
-| `done` | — | Drawer closes; `onSuccess` hoists `{ transactionId, transferServer, jwt }` to the page; `StatusTracker` mounts. | Terminal. |
+| Step             | Substrate            | What happens                                                                                                    | Failure recovery                                                        |
+| ---------------- | -------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `authenticating` | SEP-10               | Fetch challenge, sign, exchange for JWT.                                                                        | Retry in-place; on rejection, return to idle.                           |
+| `initiating`     | SEP-24               | `POST /transactions/withdraw/interactive` with JWT.                                                             | Surface anchor error; retry with fresh JWT.                             |
+| `kyc`            | Anchor-hosted iframe | Open the returned URL in a popup. Anchor owns the KYC surface.                                                  | On popup close without success, poll `/transaction` for `pending_user`. |
+| `building`       | Horizon              | `buildWithdrawPayment` — construct the USDC payment to the anchor's receiving address at the quoted amount.     | Fee estimation retries; network reselect.                               |
+| `signing`        | Freighter            | User signs the payment XDR.                                                                                     | User-reject returns to idle; signature-required errors surface.         |
+| `done`           | —                    | Drawer closes; `onSuccess` hoists `{ transactionId, transferServer, jwt }` to the page; `StatusTracker` mounts. | Terminal.                                                               |
 
 **The `done` hoist is the fix for credibility bug #2** (see `PROPOSAL.md § 5`).
 Before `commit 45a82eb` the drawer completed the withdrawal but never told the
@@ -367,7 +367,7 @@ sequenceDiagram
 ### Properties
 
 - **User-witnessed, not anchor-claimed.** The outcome's `delivered_amount`
-  comes from the SEP-24 `/transaction` response *and* (where possible) a
+  comes from the SEP-24 `/transaction` response _and_ (where possible) a
   ledger lookup of the `stellar_transaction_id`. The user's wallet signs the
   trigger. An anchor cannot inflate its own delivery numbers.
 - **Publisher cannot invent.** The publisher key signs transport, not
@@ -467,26 +467,26 @@ and read reputation — with zero held keys.
 
 ### Tools
 
-| Tool | Input | Output | Authority |
-| --- | --- | --- | --- |
-| `list_corridors` | — | `Corridor[]` | Read-only. |
-| `list_anchors_for_corridor` | `{ corridorId }` | `Anchor[]` | Read-only. |
-| `quote_corridor` | `{ corridorId, sellAmount, deliveryHint? }` | `Plan` | Read-only; RFQs live anchors. |
-| `build_intent` | `{ plan, deadlineSeconds, preferences? }` | `Intent` (unsigned) | Read-only. |
-| `submit_signed_intent` | `{ intent, signature }` | `{ transactionIds[] }` | Executes — requires user signature from the calling wallet. |
-| `read_reputation` | `{ anchorId, corridorId }` | `Aggregate` | Read-only. |
-| `read_outcome` | `{ intentHash }` | `Outcome \| null` | Read-only. |
-| `watch_transaction` | `{ transactionId, transferServer, jwt }` | Event stream | Read-only. |
+| Tool                        | Input                                       | Output                 | Authority                                                   |
+| --------------------------- | ------------------------------------------- | ---------------------- | ----------------------------------------------------------- |
+| `list_corridors`            | —                                           | `Corridor[]`           | Read-only.                                                  |
+| `list_anchors_for_corridor` | `{ corridorId }`                            | `Anchor[]`             | Read-only.                                                  |
+| `quote_corridor`            | `{ corridorId, sellAmount, deliveryHint? }` | `Plan`                 | Read-only; RFQs live anchors.                               |
+| `build_intent`              | `{ plan, deadlineSeconds, preferences? }`   | `Intent` (unsigned)    | Read-only.                                                  |
+| `submit_signed_intent`      | `{ intent, signature }`                     | `{ transactionIds[] }` | Executes — requires user signature from the calling wallet. |
+| `read_reputation`           | `{ anchorId, corridorId }`                  | `Aggregate`            | Read-only.                                                  |
+| `read_outcome`              | `{ intentHash }`                            | `Outcome \| null`      | Read-only.                                                  |
+| `watch_transaction`         | `{ transactionId, transferServer, jwt }`    | Event stream           | Read-only.                                                  |
 
 ### Agent-safety invariants
 
-1. **No signing in the MCP.** `submit_signed_intent` *requires* a signature
+1. **No signing in the MCP.** `submit_signed_intent` _requires_ a signature
    produced by the end-user's wallet. The server never holds a key capable of
    moving funds.
 2. **Scoped JWTs.** The MCP never caches an anchor JWT longer than a single
    intent's lifetime.
 3. **Auditable.** Every `submit_signed_intent` call logs `intent_hash +
-   signature + caller` to an append-only local log for the user to review.
+signature + caller` to an append-only local log for the user to review.
 4. **Rate-limited.** Per-caller and per-account quote caps prevent an agent
    from hammering anchors during a runaway loop.
 

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -5,14 +5,14 @@
 > so a dollar reaches a bank account in Lagos, Buenos Aires, or Manila with
 > the certainty of a tracked parcel, not the hope of a carrier pigeon.
 
-| | |
-| --- | --- |
-| **Submitted by** | Evan Ezedike &nbsp;·&nbsp; `@Ezedike-Evan` &nbsp;·&nbsp; egwomevan323@gmail.com |
-| **Repository** | [github.com/Ezedike-Evan/stellar-intel](https://github.com/Ezedike-Evan/stellar-intel) |
-| **Live demo** | [stellar-intel.vercel.app](https://stellar-intel.vercel.app) |
-| **License** | MIT |
-| **Resubmission date** | 2026-04-30 (target) |
-| **Supersedes** | First submission, declined on the two bugs documented in [§ 5 Credibility-fix log](#5-credibility-fix-log) |
+|                       |                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Submitted by**      | Evan Ezedike &nbsp;·&nbsp; `@Ezedike-Evan` &nbsp;·&nbsp; egwomevan323@gmail.com                            |
+| **Repository**        | [github.com/Ezedike-Evan/stellar-intel](https://github.com/Ezedike-Evan/stellar-intel)                     |
+| **Live demo**         | [stellar-intel.vercel.app](https://stellar-intel.vercel.app)                                               |
+| **License**           | MIT                                                                                                        |
+| **Resubmission date** | 2026-04-30 (target)                                                                                        |
+| **Supersedes**        | First submission, declined on the two bugs documented in [§ 5 Credibility-fix log](#5-credibility-fix-log) |
 
 ---
 
@@ -194,19 +194,19 @@ layer for any AI that needs to move money through a stablecoin corridor.
 
 All live in the repository today, on `main`, under MIT license.
 
-| Area | Shipped | Evidence |
-| --- | --- | --- |
-| **Anchors integrated** | MoneyGram (SEP-24 confirmed), Cowrie (NGN), Anclap (ARS, PEN) | `lib/stellar/anchors.ts`, commits `be007c7`, `45a82eb` |
-| **Corridors live** | 7: NGN, KES, GHS, MXN, BRL, ARS, PEN | `CORRIDORS` registry, `lib/stellar/anchors.ts` |
-| **SEP-10 auth** | Full challenge-sign-verify flow via Freighter | `lib/stellar/sep10.ts`, `ExecuteDrawer` step 2 |
-| **SEP-24 flow** | 6-step interactive withdrawal with error recovery | `components/offramp/ExecuteDrawer.tsx`, commit `45a82eb` |
-| **Rate aggregation** | Parallel SEP-38 quote solicitor, net-landed-value ranking | `hooks/useRates.ts`, `components/offramp/RateTable.tsx` |
-| **Status tracking** | Polling tracker wired to a live `transactionId`, with refund & terminal states | `components/offramp/StatusTracker.tsx`, commit `548a09b` |
-| **Offramp page** | Full off-ramp assembly — corridor → quote → sign → execute → track | `app/offramp/page.tsx`, commit `548a09b` |
-| **Env hardening** | Browser-safe env validation, graceful offline fallback | commit `5d40936` |
-| **Tests** | Vitest unit suites for anchor registry, SEP-1 TOML parsing, horizon helpers | `tests/` |
-| **CI** | 11 workflows: ci, bundle-size, codeql, data-health, deploy, dependency-review, lighthouse, pr-title, release, stale, api-availability | `.github/workflows/` |
-| **License & governance** | MIT, CONTRIBUTING, Changelog, issue + PR templates | repo root |
+| Area                     | Shipped                                                                                                                               | Evidence                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Anchors integrated**   | MoneyGram (SEP-24 confirmed), Cowrie (NGN), Anclap (ARS, PEN)                                                                         | `lib/stellar/anchors.ts`, commits `be007c7`, `45a82eb`   |
+| **Corridors live**       | 7: NGN, KES, GHS, MXN, BRL, ARS, PEN                                                                                                  | `CORRIDORS` registry, `lib/stellar/anchors.ts`           |
+| **SEP-10 auth**          | Full challenge-sign-verify flow via Freighter                                                                                         | `lib/stellar/sep10.ts`, `ExecuteDrawer` step 2           |
+| **SEP-24 flow**          | 6-step interactive withdrawal with error recovery                                                                                     | `components/offramp/ExecuteDrawer.tsx`, commit `45a82eb` |
+| **Rate aggregation**     | Parallel SEP-38 quote solicitor, net-landed-value ranking                                                                             | `hooks/useRates.ts`, `components/offramp/RateTable.tsx`  |
+| **Status tracking**      | Polling tracker wired to a live `transactionId`, with refund & terminal states                                                        | `components/offramp/StatusTracker.tsx`, commit `548a09b` |
+| **Offramp page**         | Full off-ramp assembly — corridor → quote → sign → execute → track                                                                    | `app/offramp/page.tsx`, commit `548a09b`                 |
+| **Env hardening**        | Browser-safe env validation, graceful offline fallback                                                                                | commit `5d40936`                                         |
+| **Tests**                | Vitest unit suites for anchor registry, SEP-1 TOML parsing, horizon helpers                                                           | `tests/`                                                 |
+| **CI**                   | 11 workflows: ci, bundle-size, codeql, data-health, deploy, dependency-review, lighthouse, pr-title, release, stale, api-availability | `.github/workflows/`                                     |
+| **License & governance** | MIT, CONTRIBUTING, Changelog, issue + PR templates                                                                                    | repo root                                                |
 
 The v1 product compares rates across three anchors and seven corridors in real
 time, executes an off-ramp end-to-end, and tracks it to completion without
@@ -220,10 +220,10 @@ on.
 Two bugs sank the first submission. Both are fixed on `main`; both have
 regression tests.
 
-| # | Bug | Symptom (before) | Root cause | Fix | Evidence (after) |
-| --- | --- | --- | --- | --- | --- |
-| 1 | **`exchangeRate` returns `0` on Cowrie USDC→NGN** (issue.md #001) | Cowrie rows rendered `₦0` per USDC, making the whole rate table unusable for the headline corridor. | Decimal parse treated `sell_amount` as integer atomic units, but Cowrie's SEP-38 response delivers it as a decimal string. Fee was also being subtracted twice. | Rewrote the rate adapter to branch on `sell_amount` type, asserted the invariant in a unit test. | `tests/anchors.cowrie.exchangeRate.spec.ts` — `exchangeRate > 0` for every sampled quote. |
-| 2 | **`StatusTracker` never mounts** (issue.md #002) | After a successful withdrawal, the page still showed the "connect wallet" card — the user had no way to know anything happened. | `ExecuteDrawer` completed the withdrawal but never propagated `{ transactionId, transferServer, jwt }` back to the page, so the tracker's mount condition was permanently false. | Added an `onSuccess` prop that lifts the tracking tuple to the page; drawer closes on success and `StatusTracker` owns the viewport. | Commit `45a82eb`; e2e test `tests/offramp-e2e.spec.ts` — successful execute renders `StatusTracker` with a live id. |
+| #   | Bug                                                               | Symptom (before)                                                                                                                | Root cause                                                                                                                                                                       | Fix                                                                                                                                  | Evidence (after)                                                                                                    |
+| --- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| 1   | **`exchangeRate` returns `0` on Cowrie USDC→NGN** (issue.md #001) | Cowrie rows rendered `₦0` per USDC, making the whole rate table unusable for the headline corridor.                             | Decimal parse treated `sell_amount` as integer atomic units, but Cowrie's SEP-38 response delivers it as a decimal string. Fee was also being subtracted twice.                  | Rewrote the rate adapter to branch on `sell_amount` type, asserted the invariant in a unit test.                                     | `tests/anchors.cowrie.exchangeRate.spec.ts` — `exchangeRate > 0` for every sampled quote.                           |
+| 2   | **`StatusTracker` never mounts** (issue.md #002)                  | After a successful withdrawal, the page still showed the "connect wallet" card — the user had no way to know anything happened. | `ExecuteDrawer` completed the withdrawal but never propagated `{ transactionId, transferServer, jwt }` back to the page, so the tracker's mount condition was permanently false. | Added an `onSuccess` prop that lifts the tracking tuple to the page; drawer closes on success and `StatusTracker` owns the viewport. | Commit `45a82eb`; e2e test `tests/offramp-e2e.spec.ts` — successful execute renders `StatusTracker` with a live id. |
 
 Both fixes are covered by CI on every PR. The `data-health` workflow runs
 nightly against production anchors to ensure the Cowrie rate path stays
@@ -237,16 +237,16 @@ Each wave is a ship-stop with merge-ready PRs, not a wish list. Full ticket
 expansion lives in [`issue.md`](../issue.md) (250 tracked issues) and
 [`docs/ROADMAP.md`](ROADMAP.md).
 
-| Wave | Theme | Key deliverables | Gate |
-| --- | --- | --- | --- |
-| **v1.0 Executable** (✅ shipped) | A correct, demonstrable off-ramp | 3 anchors, 7 corridors, SEP-10/24 complete, StatusTracker live | This submission |
-| **v1.1 Hardening** | Reliability & coverage | Retry/backoff on anchor timeouts; refund UX; dispute modal; 80%+ coverage on `lib/stellar/*` | 30 days post-grant |
-| **v1.2 Router + Seeds** | Multi-anchor split routing | Solver v1 picks the minimum-cost combination; nightly synthetic probes seed corridor coverage | 60 days |
-| **v1.3 Polish** | Grant-reviewer UX | Cookbook, benchmarks, live oracle explorer, anchor onboarding kit | 90 days |
-| **v2 Observable** | Public reputation API + Soroban oracle mainnet | `GET /v1/public/scores`; on-chain reads from Soroban; per-corridor leaderboard UI | 120 days |
-| **v3 Guaranteed** | Intent-level guarantees | Deadline enforcement, slippage bounds, partial-fill handling | 180 days |
-| **v4 Universal** | MCP agent surface GA + SDK | `@stellarintel/sdk` on npm, `@stellarintel/mcp` on npm, embeddable widget | 240 days |
-| **v5 Institutional** | Compliance-grade primitives | Jurisdictional memo, SBOM, non-custody attestation, institutional reporting | 365 days |
+| Wave                             | Theme                                          | Key deliverables                                                                              | Gate               |
+| -------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------ |
+| **v1.0 Executable** (✅ shipped) | A correct, demonstrable off-ramp               | 3 anchors, 7 corridors, SEP-10/24 complete, StatusTracker live                                | This submission    |
+| **v1.1 Hardening**               | Reliability & coverage                         | Retry/backoff on anchor timeouts; refund UX; dispute modal; 80%+ coverage on `lib/stellar/*`  | 30 days post-grant |
+| **v1.2 Router + Seeds**          | Multi-anchor split routing                     | Solver v1 picks the minimum-cost combination; nightly synthetic probes seed corridor coverage | 60 days            |
+| **v1.3 Polish**                  | Grant-reviewer UX                              | Cookbook, benchmarks, live oracle explorer, anchor onboarding kit                             | 90 days            |
+| **v2 Observable**                | Public reputation API + Soroban oracle mainnet | `GET /v1/public/scores`; on-chain reads from Soroban; per-corridor leaderboard UI             | 120 days           |
+| **v3 Guaranteed**                | Intent-level guarantees                        | Deadline enforcement, slippage bounds, partial-fill handling                                  | 180 days           |
+| **v4 Universal**                 | MCP agent surface GA + SDK                     | `@stellarintel/sdk` on npm, `@stellarintel/mcp` on npm, embeddable widget                     | 240 days           |
+| **v5 Institutional**             | Compliance-grade primitives                    | Jurisdictional memo, SBOM, non-custody attestation, institutional reporting                   | 365 days           |
 
 ---
 
@@ -276,13 +276,13 @@ We are requesting the standard Stellar Community Fund Tier-2 grant. A detailed
 budget breakdown lives in the companion document submitted to the committee.
 Headline allocation:
 
-| Bucket | Share | Purpose |
-| --- | --- | --- |
-| Core engineering | ~55% | v1.1–v1.3 waves, Soroban oracle publisher, MCP server |
-| Contributor funnel | ~15% | Good-first-issue triage, office hours, contributor swag, bounty pool |
-| Anchor outreach | ~10% | Travel to one Stellar Meridian event; in-person integration work with 2 anchors |
-| Audit & security | ~15% | Soroban contract audit (one firm), SEP-24 flow review, SBOM tooling |
-| Infra & ops | ~5% | Vercel production, monitoring, status page, log drains |
+| Bucket             | Share | Purpose                                                                         |
+| ------------------ | ----- | ------------------------------------------------------------------------------- |
+| Core engineering   | ~55%  | v1.1–v1.3 waves, Soroban oracle publisher, MCP server                           |
+| Contributor funnel | ~15%  | Good-first-issue triage, office hours, contributor swag, bounty pool            |
+| Anchor outreach    | ~10%  | Travel to one Stellar Meridian event; in-person integration work with 2 anchors |
+| Audit & security   | ~15%  | Soroban contract audit (one firm), SEP-24 flow review, SBOM tooling             |
+| Infra & ops        | ~5%   | Vercel production, monitoring, status page, log drains                          |
 
 Every deliverable is gated on a merged PR with CI green and a dated release
 tag. Fund release against milestones, not dates.
@@ -291,14 +291,14 @@ tag. Fund release against milestones, not dates.
 
 ## 9. Risks and mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-| --- | --- | --- | --- |
-| An anchor disputes a reputation outcome | Medium | Medium | Dispute modal (issue.md #166); every outcome is user-signed and replayable from the ledger, so the dispute resolves on evidence, not opinion. |
-| MSB / VASP classification risk | Low | High | [`docs/NON_CUSTODY.md`](NON_CUSTODY.md) + [`docs/JURISDICTIONAL.md`](JURISDICTIONAL.md): every leg is signed by the user, anchor takes custody under SEP-24, Stellar enforces atomicity. We never touch funds. |
-| Anchor churn (one of the three goes dark) | Medium | Low | Registry design already handles dynamic anchor add/remove; synthetic probes surface outages within 30 minutes. |
-| Soroban oracle consumer ergonomics | Medium | Medium | Ship a Rust + TS consumer library alongside the contract; seed three reference integrations in the cookbook. |
-| Solo-maintainer bus factor | High | High | This grant funds the contributor ladder: `docs/CONTRIBUTOR_LADDER.md` defines Triager → Reviewer → Maintainer with merge-count criteria. Target: two additional reviewers by end of v1.3. |
-| Agent misuse (agent drains a wallet) | Low | High | MCP surface is **advisory + user-signed** — every `execute_intent` call must be signed by the user's wallet. No held keys, no autonomous spend. |
+| Risk                                      | Likelihood | Impact | Mitigation                                                                                                                                                                                                     |
+| ----------------------------------------- | ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| An anchor disputes a reputation outcome   | Medium     | Medium | Dispute modal (issue.md #166); every outcome is user-signed and replayable from the ledger, so the dispute resolves on evidence, not opinion.                                                                  |
+| MSB / VASP classification risk            | Low        | High   | [`docs/NON_CUSTODY.md`](NON_CUSTODY.md) + [`docs/JURISDICTIONAL.md`](JURISDICTIONAL.md): every leg is signed by the user, anchor takes custody under SEP-24, Stellar enforces atomicity. We never touch funds. |
+| Anchor churn (one of the three goes dark) | Medium     | Low    | Registry design already handles dynamic anchor add/remove; synthetic probes surface outages within 30 minutes.                                                                                                 |
+| Soroban oracle consumer ergonomics        | Medium     | Medium | Ship a Rust + TS consumer library alongside the contract; seed three reference integrations in the cookbook.                                                                                                   |
+| Solo-maintainer bus factor                | High       | High   | This grant funds the contributor ladder: `docs/CONTRIBUTOR_LADDER.md` defines Triager → Reviewer → Maintainer with merge-count criteria. Target: two additional reviewers by end of v1.3.                      |
+| Agent misuse (agent drains a wallet)      | Low        | High   | MCP surface is **advisory + user-signed** — every `execute_intent` call must be signed by the user's wallet. No held keys, no autonomous spend.                                                                |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,13 +37,13 @@ opens. A wave does not open early. A wave does not ship partial.
 
 ## At a glance
 
-| Version | Theme | Scope | Target gate | Status |
-| --- | --- | --- | --- | --- |
-| **v1 Executable** | A correct, demonstrable off-ramp | `#001–#150` · 150 tickets · 4 waves | `npm run test:release` green; feature flags default-on | 🟢 Wave 1.0 substantially shipped |
-| **v2 Observable** | Reputation as product surface, Soroban on mainnet | `#151–#250` · 100 tickets · 4 waves | Soroban contract deployed, ≥3 publishers, ≥1000 outcomes | ⚪ Not started |
-| **v3 Guaranteed** | Intent-level SLAs, slippage bounds, recurring intents | Planned · scope decomposed post-v2 | Slippage-bound compliance ≥ 99.5% over 10k intents | ⚪ Not started |
-| **v4 Universal** | SDK + MCP GA + embeddable widget | Planned · scope decomposed post-v3 | `@stellarintel/sdk` + `@stellarintel/mcp` on npm; 3 reference integrations | ⚪ Not started |
-| **v5 Institutional** | Compliance-grade primitives, audit-ready | Planned · scope decomposed post-v4 | Third-party audit report published; SBOM on every release | ⚪ Not started |
+| Version              | Theme                                                 | Scope                               | Target gate                                                                | Status                            |
+| -------------------- | ----------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------- | --------------------------------- |
+| **v1 Executable**    | A correct, demonstrable off-ramp                      | `#001–#150` · 150 tickets · 4 waves | `npm run test:release` green; feature flags default-on                     | 🟢 Wave 1.0 substantially shipped |
+| **v2 Observable**    | Reputation as product surface, Soroban on mainnet     | `#151–#250` · 100 tickets · 4 waves | Soroban contract deployed, ≥3 publishers, ≥1000 outcomes                   | ⚪ Not started                    |
+| **v3 Guaranteed**    | Intent-level SLAs, slippage bounds, recurring intents | Planned · scope decomposed post-v2  | Slippage-bound compliance ≥ 99.5% over 10k intents                         | ⚪ Not started                    |
+| **v4 Universal**     | SDK + MCP GA + embeddable widget                      | Planned · scope decomposed post-v3  | `@stellarintel/sdk` + `@stellarintel/mcp` on npm; 3 reference integrations | ⚪ Not started                    |
+| **v5 Institutional** | Compliance-grade primitives, audit-ready              | Planned · scope decomposed post-v4  | Third-party audit report published; SBOM on every release                  | ⚪ Not started                    |
 
 ---
 
@@ -412,8 +412,8 @@ compounds.
 
 ## v3 Guaranteed
 
-**Thesis.** Up to this point, an intent is a *preference*. In v3 it
-becomes a *guarantee*: deadline enforcement, slippage-bound compliance,
+**Thesis.** Up to this point, an intent is a _preference_. In v3 it
+becomes a _guarantee_: deadline enforcement, slippage-bound compliance,
 recurring intents that auto-execute under a standing signed authorization.
 
 Scope is decomposed post-v2; the shape is already committed.

--- a/docs/STRICT_LINTING.md
+++ b/docs/STRICT_LINTING.md
@@ -26,19 +26,19 @@ Two guiding principles:
 
 Every PR runs, in order of earliest failure:
 
-| Gate | Command | Fails on |
-|------|---------|----------|
-| **Prettier** | `npm run format:check` | Any unformatted diff. Rerun `npm run format` to fix. |
-| **ESLint (zero warnings)** | `npm run lint` | Any `no-explicit-any`, `no-unused-vars`, `no-console`, Next.js core-web-vital rule. |
-| **TypeScript** | `npm run typecheck` | Any type error under the strict flag set below. |
-| **Vitest** | `npm run test` | Any failing unit test. Coverage uploaded to Codecov. |
-| **Next build** | `npm run build` | Build error, missing env var at build-time, circular import. |
-| **Commitlint** | workflow `commitlint` | Commit that does not match `<type>[(scope)]: <subject>`. |
-| **PR title** | workflow `pr-title` | PR title not following Conventional Commits. |
-| **Dependency review** | workflow `dependency-review` | New dep with GPL / AGPL licence or CVE ≥ moderate. |
-| **Bundle size** | workflow `bundle-size` | > 10 kB total JS growth vs. base branch without a size label. |
-| **Lighthouse** | workflow `lighthouse` | Posted as comment; informational unless performance degrades sharply. |
-| **CodeQL** | workflow `codeql` | Security-extended + security-and-quality queries. |
+| Gate                       | Command                      | Fails on                                                                            |
+| -------------------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| **Prettier**               | `npm run format:check`       | Any unformatted diff. Rerun `npm run format` to fix.                                |
+| **ESLint (zero warnings)** | `npm run lint`               | Any `no-explicit-any`, `no-unused-vars`, `no-console`, Next.js core-web-vital rule. |
+| **TypeScript**             | `npm run typecheck`          | Any type error under the strict flag set below.                                     |
+| **Vitest**                 | `npm run test`               | Any failing unit test. Coverage uploaded to Codecov.                                |
+| **Next build**             | `npm run build`              | Build error, missing env var at build-time, circular import.                        |
+| **Commitlint**             | workflow `commitlint`        | Commit that does not match `<type>[(scope)]: <subject>`.                            |
+| **PR title**               | workflow `pr-title`          | PR title not following Conventional Commits.                                        |
+| **Dependency review**      | workflow `dependency-review` | New dep with GPL / AGPL licence or CVE ≥ moderate.                                  |
+| **Bundle size**            | workflow `bundle-size`       | > 10 kB total JS growth vs. base branch without a size label.                       |
+| **Lighthouse**             | workflow `lighthouse`        | Posted as comment; informational unless performance degrades sharply.               |
+| **CodeQL**                 | workflow `codeql`            | Security-extended + security-and-quality queries.                                   |
 
 Run the full local equivalent with `npm run test:release`.
 
@@ -48,13 +48,13 @@ Run the full local equivalent with `npm run test:release`.
 
 Enabled in `tsconfig.json`:
 
-| Flag | Catches |
-|------|---------|
-| `strict` | All the standard strict-mode checks (`strictNullChecks`, `noImplicitAny`, …). |
-| `noUncheckedIndexedAccess` | `arr[i]` is inferred as `T \| undefined`, forcing explicit null checks on index access. |
-| `noImplicitOverride` | Subclass methods must use `override`, preventing accidental parent-method shadowing. |
-| `exactOptionalPropertyTypes` | `{ x?: T }` and `{ x?: T \| undefined }` are distinct. Prevents "undefined leaked through an optional". |
-| `noFallthroughCasesInSwitch` | Every non-empty `case` ends in a terminator. |
+| Flag                               | Catches                                                                                                    |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `strict`                           | All the standard strict-mode checks (`strictNullChecks`, `noImplicitAny`, …).                              |
+| `noUncheckedIndexedAccess`         | `arr[i]` is inferred as `T \| undefined`, forcing explicit null checks on index access.                    |
+| `noImplicitOverride`               | Subclass methods must use `override`, preventing accidental parent-method shadowing.                       |
+| `exactOptionalPropertyTypes`       | `{ x?: T }` and `{ x?: T \| undefined }` are distinct. Prevents "undefined leaked through an optional".    |
+| `noFallthroughCasesInSwitch`       | Every non-empty `case` ends in a terminator.                                                               |
 | `forceConsistentCasingInFileNames` | Prevents import-path case drift between macOS/Windows (case-insensitive FS) and Linux CI (case-sensitive). |
 
 These are deliberately opinionated. If a flag blocks you, prefer adding

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,10 @@ const eslintConfig = defineConfig([
       ...tseslint.configs.recommended.rules,
       'no-console': 'warn',
       'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
       '@typescript-eslint/no-explicit-any': 'error',
       'no-restricted-imports': [
         'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,10 +12,11 @@ const eslintConfig = defineConfig([
   {
     plugins: { '@typescript-eslint': tseslint },
     languageOptions: { parser: tsParser },
+    settings: { react: { version: '18' } },
     rules: {
       ...tseslint.configs.recommended.rules,
       'no-console': 'warn',
-      'no-unused-vars': 'error',
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       'no-restricted-imports': [
         'error',

--- a/hooks/useAnchorAuth.ts
+++ b/hooks/useAnchorAuth.ts
@@ -1,14 +1,14 @@
-'use client'
+'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react'
-import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10'
-import type { Sep10Auth } from '@/types'
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10';
+import type { Sep10Auth } from '@/types';
 
 export interface UseAnchorAuthResult {
-  jwt: string | null
-  authenticate: () => Promise<void>
-  isAuthenticating: boolean
-  error: string | null
+  jwt: string | null;
+  authenticate: () => Promise<void>;
+  isAuthenticating: boolean;
+  error: string | null;
 }
 
 /**
@@ -24,85 +24,88 @@ export interface UseAnchorAuthResult {
  * @param publicKey The user's Stellar public key
  * @returns Authentication state and handler
  */
-export function useAnchorAuth(anchorDomain: string | null, publicKey: string | null): UseAnchorAuthResult {
-  const [jwt, setJwt] = useState<string | null>(null)
-  const [isAuthenticating, setIsAuthenticating] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+export function useAnchorAuth(
+  anchorDomain: string | null,
+  publicKey: string | null
+): UseAnchorAuthResult {
+  const [jwt, setJwt] = useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Track pending authentication to enable cancellation on unmount
-  const abortControllerRef = useRef<AbortController | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   // Cleanup: cancel pending requests on unmount
   useEffect(() => {
     return () => {
       if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
+        abortControllerRef.current.abort();
       }
-    }
-  }, [])
+    };
+  }, []);
 
   // Stable authenticate callback
   const handleAuthenticate = useCallback(async () => {
     // Validate inputs
     if (!anchorDomain || !publicKey) {
-      setError('Missing anchor domain or public key')
-      return
+      setError('Missing anchor domain or public key');
+      return;
     }
 
     // Cancel any pending request
     if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
+      abortControllerRef.current.abort();
     }
 
     // Create new abort controller for this request
-    abortControllerRef.current = new AbortController()
-    const signal = abortControllerRef.current.signal
+    abortControllerRef.current = new AbortController();
+    const signal = abortControllerRef.current.signal;
 
-    setIsAuthenticating(true)
-    setError(null)
+    setIsAuthenticating(true);
+    setError(null);
 
     try {
-      const auth: Sep10Auth = await authenticate(anchorDomain, publicKey)
+      const auth: Sep10Auth = await authenticate(anchorDomain, publicKey);
 
       // Check if request was cancelled
       if (signal.aborted) {
-        return
+        return;
       }
 
-      setJwt(auth.jwt)
-      setError(null)
+      setJwt(auth.jwt);
+      setError(null);
     } catch (err) {
       // Only update state if request was not cancelled
       if (!signal.aborted) {
-        const message = err instanceof Error ? err.message : String(err)
-        setError(message)
-        setJwt(null)
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setJwt(null);
       }
     } finally {
       // Only update loading state if request was not cancelled
       if (!signal.aborted) {
-        setIsAuthenticating(false)
+        setIsAuthenticating(false);
       }
     }
-  }, [anchorDomain, publicKey])
+  }, [anchorDomain, publicKey]);
 
   // Invalidate cached token (useful for 401 responses)
   useEffect(() => {
     // Expose invalidation through window for external use if needed
     // This is called when the component needs to clear auth after a 401
-    if (!anchorDomain || !publicKey) return
-  }, [anchorDomain, publicKey])
+    if (!anchorDomain || !publicKey) return;
+  }, [anchorDomain, publicKey]);
 
   return {
     jwt,
     authenticate: handleAuthenticate,
     isAuthenticating,
     error,
-  }
+  };
 }
 
 /**
  * Invalidate the cached JWT for a given anchor/account pair.
  * Use this after receiving a 401 response from the anchor.
  */
-export { invalidateSep10Token as invalidateAnchorAuth }
+export { invalidateSep10Token as invalidateAnchorAuth };

--- a/hooks/useAnchorAuth.ts
+++ b/hooks/useAnchorAuth.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10';
+import { getResolvedAnchorByDomain } from '@/lib/stellar/anchors';
 import type { Sep10Auth } from '@/types';
 
 export interface UseAnchorAuthResult {
@@ -65,7 +66,8 @@ export function useAnchorAuth(
     setError(null);
 
     try {
-      const auth: Sep10Auth = await authenticate(anchorDomain, publicKey);
+      const resolvedAnchor = await getResolvedAnchorByDomain(anchorDomain);
+      const auth: Sep10Auth = await authenticate(resolvedAnchor, publicKey, signal);
 
       // Check if request was cancelled
       if (signal.aborted) {

--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,11 +1,11 @@
-import useSWR from "swr";
-import type { ApiRatesResponse, RateComparison } from "@/types";
-import { useState, useCallback } from "react";
+import useSWR from 'swr';
+import type { ApiRatesResponse, RateComparison } from '@/types';
+import { useState, useCallback } from 'react';
 
 async function fetcher([, corridorId, amount]: [string, string, string]): Promise<RateComparison> {
-  const url = new URL("/api/rates", window.location.origin);
-  url.searchParams.set("corridor", corridorId);
-  url.searchParams.set("amount", amount);
+  const url = new URL('/api/rates', window.location.origin);
+  url.searchParams.set('corridor', corridorId);
+  url.searchParams.set('amount', amount);
 
   const res = await fetch(url.toString());
 
@@ -18,7 +18,6 @@ async function fetcher([, corridorId, amount]: [string, string, string]): Promis
   return data.rates;
 }
 
-
 export interface UseAnchorRatesResult {
   rates: RateComparison | undefined;
   isLoading: boolean;
@@ -27,18 +26,11 @@ export interface UseAnchorRatesResult {
   refreshInflight: boolean;
 }
 
-
-export function useAnchorRates(
-  corridorId: string,
-  amount: string
-): UseAnchorRatesResult {
+export function useAnchorRates(corridorId: string, amount: string): UseAnchorRatesResult {
   const [refreshInflight, setRefreshInflight] = useState(false);
 
-  const { data, error, isLoading, mutate } = useSWR<
-    RateComparison,
-    Error
-  >(
-    corridorId && amount ? ["/api/rates", corridorId, amount] : null,
+  const { data, error, isLoading, mutate } = useSWR<RateComparison, Error>(
+    corridorId && amount ? ['/api/rates', corridorId, amount] : null,
     fetcher,
     {
       refreshInterval: 30_000,

--- a/hooks/useFreighter.ts
+++ b/hooks/useFreighter.ts
@@ -1,9 +1,9 @@
-'use client'
-import { useState, useEffect, useCallback, useRef } from 'react'
-import type { FreighterState } from '@/types'
+'use client';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { FreighterState } from '@/types';
 
-const STORAGE_KEY = 'freighter_connected'
-const POLL_MS = 300
+const STORAGE_KEY = 'freighter_connected';
+const POLL_MS = 300;
 
 const INITIAL_STATE: FreighterState = {
   isInstalled: false,
@@ -11,47 +11,52 @@ const INITIAL_STATE: FreighterState = {
   publicKey: null,
   network: null,
   error: null,
-}
+};
 
 export function useFreighter() {
-  const [state, setState] = useState<FreighterState>(INITIAL_STATE)
-  const mountedRef = useRef(true)
+  const [state, setState] = useState<FreighterState>(INITIAL_STATE);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true
+    mountedRef.current = true;
     return () => {
-      mountedRef.current = false
-    }
-  }, [])
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
 
     async function detect() {
       try {
-        const { isConnected, getAddress, getNetwork } = await import('@stellar/freighter-api')
-        const connResult = await isConnected()
+        const { isConnected, getAddress, getNetwork } = await import('@stellar/freighter-api');
+        const connResult = await isConnected();
 
-        if (cancelled || !mountedRef.current) return
+        if (cancelled || !mountedRef.current) return;
 
         if (connResult.error || !connResult.isConnected) {
           setState((s) => {
             if (s.isConnected) {
-              return { ...s, isInstalled: true, isConnected: false, publicKey: null, network: null }
+              return {
+                ...s,
+                isInstalled: true,
+                isConnected: false,
+                publicKey: null,
+                network: null,
+              };
             }
-            return s.isInstalled ? s : { ...s, isInstalled: true }
-          })
-          return
+            return s.isInstalled ? s : { ...s, isInstalled: true };
+          });
+          return;
         }
 
-        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
-        if (cancelled || !mountedRef.current) return
+        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
+        if (cancelled || !mountedRef.current) return;
 
-        const networkName = netResult.network ?? null
-        const networkError =
-          networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
-        const addr = addrResult as { address?: string; publicKey?: string }
-        const pk = addr.address ?? addr.publicKey ?? null
+        const networkName = netResult.network ?? null;
+        const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
+        const addr = addrResult as { address?: string; publicKey?: string };
+        const pk = addr.address ?? addr.publicKey ?? null;
 
         setState({
           isInstalled: true,
@@ -59,39 +64,38 @@ export function useFreighter() {
           publicKey: pk,
           network: networkName,
           error: networkError,
-        })
+        });
       } catch {
-        if (cancelled || !mountedRef.current) return
-        setState((s) => (s.isInstalled ? { ...s, isInstalled: false } : s))
+        if (cancelled || !mountedRef.current) return;
+        setState((s) => (s.isInstalled ? { ...s, isInstalled: false } : s));
       }
     }
 
-    detect()
-    const interval = setInterval(detect, POLL_MS)
+    detect();
+    const interval = setInterval(detect, POLL_MS);
 
     return () => {
-      cancelled = true
-      clearInterval(interval)
-    }
-  }, [])
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
 
   const connect = useCallback(async () => {
-    setState((s) => ({ ...s, error: null }))
+    setState((s) => ({ ...s, error: null }));
     try {
-      const { requestAccess, getAddress, getNetwork } = await import('@stellar/freighter-api')
-      const accessResult = await requestAccess()
-      if (accessResult.error) throw new Error(String(accessResult.error))
+      const { requestAccess, getAddress, getNetwork } = await import('@stellar/freighter-api');
+      const accessResult = await requestAccess();
+      if (accessResult.error) throw new Error(String(accessResult.error));
 
-      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
-      if (!mountedRef.current) return
+      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
+      if (!mountedRef.current) return;
 
-      const networkName = netResult.network ?? null
-      const networkError =
-        networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
-      const addr = addrResult as { address?: string; publicKey?: string }
+      const networkName = netResult.network ?? null;
+      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
+      const addr = addrResult as { address?: string; publicKey?: string };
 
       try {
-        localStorage.setItem(STORAGE_KEY, 'true')
+        localStorage.setItem(STORAGE_KEY, 'true');
       } catch {
         // SSR / restricted environments
       }
@@ -102,18 +106,17 @@ export function useFreighter() {
         publicKey: addr.address ?? addr.publicKey ?? null,
         network: networkName,
         error: networkError,
-      })
+      });
     } catch (err) {
-      if (!mountedRef.current) return
-      const message =
-        err instanceof Error ? err.message : 'Freighter not detected'
-      setState((s) => ({ ...s, isConnected: false, publicKey: null, error: message }))
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : 'Freighter not detected';
+      setState((s) => ({ ...s, isConnected: false, publicKey: null, error: message }));
     }
-  }, [])
+  }, []);
 
   const disconnect = useCallback(() => {
     try {
-      localStorage.removeItem(STORAGE_KEY)
+      localStorage.removeItem(STORAGE_KEY);
     } catch {
       // SSR / restricted environments
     }
@@ -123,8 +126,8 @@ export function useFreighter() {
       publicKey: null,
       network: null,
       error: null,
-    }))
-  }, [])
+    }));
+  }, []);
 
-  return { ...state, connect, disconnect }
+  return { ...state, connect, disconnect };
 }

--- a/hooks/useWithdrawStatus.ts
+++ b/hooks/useWithdrawStatus.ts
@@ -1,19 +1,30 @@
-import useSWR from 'swr'
-import type { Sep24Transaction, WithdrawStatusValue } from '@/types'
+import useSWR from 'swr';
+import type { Sep24Transaction, WithdrawStatusValue } from '@/types';
 
-const TERMINAL_STATES: WithdrawStatusValue[] = ['completed', 'error', 'refunded', 'no_market', 'too_small', 'too_large']
+const TERMINAL_STATES: WithdrawStatusValue[] = [
+  'completed',
+  'error',
+  'refunded',
+  'no_market',
+  'too_small',
+  'too_large',
+];
 
-async function fetcher([transferServer, transactionId, jwt]: [string, string, string]): Promise<Sep24Transaction> {
+async function fetcher([transferServer, transactionId, jwt]: [
+  string,
+  string,
+  string,
+]): Promise<Sep24Transaction> {
   const res = await fetch(`${transferServer}/transaction?id=${transactionId}`, {
     headers: { Authorization: `Bearer ${jwt}` },
-  })
+  });
 
   if (!res.ok) {
-    throw new Error(`Status poll failed: HTTP ${res.status}`)
+    throw new Error(`Status poll failed: HTTP ${res.status}`);
   }
 
-  const data = (await res.json()) as { transaction?: Record<string, unknown> }
-  const tx = data.transaction ?? {}
+  const data = (await res.json()) as { transaction?: Record<string, unknown> };
+  const tx = data.transaction ?? {};
 
   return {
     id: String(tx['id'] ?? transactionId),
@@ -27,22 +38,22 @@ async function fetcher([transferServer, transactionId, jwt]: [string, string, st
     stellarTransactionId: tx['stellar_transaction_id'] as string | undefined,
     externalTransactionId: tx['external_transaction_id'] as string | undefined,
     refunds: tx['refunds'] as Sep24Transaction['refunds'],
-  }
+  };
 }
 
 export interface UseWithdrawStatusResult {
-  status: WithdrawStatusValue | undefined
-  amountIn: string | undefined
-  amountInAsset: string | undefined
-  amountOut: string | undefined
-  amountOutAsset: string | undefined
-  amountFee: string | undefined
-  stellarTransactionId: string | undefined
-  externalTransactionId: string | undefined
-  refunds: Sep24Transaction['refunds'] | undefined
-  updatedAt: Date | undefined
-  isLoading: boolean
-  error: string | undefined
+  status: WithdrawStatusValue | undefined;
+  amountIn: string | undefined;
+  amountInAsset: string | undefined;
+  amountOut: string | undefined;
+  amountOutAsset: string | undefined;
+  amountFee: string | undefined;
+  stellarTransactionId: string | undefined;
+  externalTransactionId: string | undefined;
+  refunds: Sep24Transaction['refunds'] | undefined;
+  updatedAt: Date | undefined;
+  isLoading: boolean;
+  error: string | undefined;
 }
 
 /**
@@ -58,15 +69,15 @@ export function useWithdrawStatus(
   const key =
     transferServer && transactionId && jwt
       ? ([transferServer, transactionId, jwt] as [string, string, string])
-      : null
+      : null;
 
   const { data, error, isLoading } = useSWR<Sep24Transaction, Error>(key, fetcher, {
     refreshInterval: (latestData: Sep24Transaction | undefined) => {
-      if (!latestData) return 5_000
-      return TERMINAL_STATES.includes(latestData.status) ? 0 : 5_000
+      if (!latestData) return 5_000;
+      return TERMINAL_STATES.includes(latestData.status) ? 0 : 5_000;
     },
     revalidateOnFocus: false,
-  })
+  });
 
   return {
     status: data?.status,
@@ -81,5 +92,5 @@ export function useWithdrawStatus(
     updatedAt: data?.updatedAt,
     isLoading,
     error: error?.message,
-  }
+  };
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -30,8 +30,8 @@ function validateEnv(): void {
   if (missing.length > 0) {
     throw new Error(
       `❌ Missing required environment variables:\n` +
-      missing.map(v => `   - ${v}`).join('\n') +
-      `\n\nPlease check your .env.local file and ensure all variables are set.`
+        missing.map((v) => `   - ${v}`).join('\n') +
+        `\n\nPlease check your .env.local file and ensure all variables are set.`
     );
   }
 
@@ -40,7 +40,7 @@ function validateEnv(): void {
   if (network !== 'mainnet' && network !== 'testnet' && network !== 'futurenet') {
     throw new Error(
       `❌ Invalid NEXT_PUBLIC_STELLAR_NETWORK: "${network}"\n` +
-      `   Must be one of: mainnet, testnet, futurenet`
+        `   Must be one of: mainnet, testnet, futurenet`
     );
   }
 
@@ -50,7 +50,7 @@ function validateEnv(): void {
   } catch {
     throw new Error(
       `❌ Invalid NEXT_PUBLIC_HORIZON_URL: "${horizonUrl}"\n` +
-      `   Must be a valid URL (e.g., https://horizon.stellar.org)`
+        `   Must be a valid URL (e.g., https://horizon.stellar.org)`
     );
   }
 
@@ -58,7 +58,7 @@ function validateEnv(): void {
   if (!/^G[A-Z0-9]{55}$/.test(issuer)) {
     throw new Error(
       `❌ Invalid NEXT_PUBLIC_USDC_ISSUER: "${issuer}"\n` +
-      `   Must be a valid Stellar public key (starts with 'G', 56 characters total)`
+        `   Must be a valid Stellar public key (starts with 'G', 56 characters total)`
     );
   }
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const envSchema = z.object({
   NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['mainnet', 'testnet', 'futurenet'], {
@@ -16,9 +16,9 @@ export const envSchema = z.object({
     .url()
     .optional()
     .default('https://api.stellar.expert/explorer/public'),
-})
+});
 
-export type Env = z.infer<typeof envSchema>
+export type Env = z.infer<typeof envSchema>;
 
 export function parseEnv(): Env {
   const result = envSchema.safeParse({
@@ -27,18 +27,18 @@ export function parseEnv(): Env {
     NEXT_PUBLIC_USDC_ISSUER: process.env.NEXT_PUBLIC_USDC_ISSUER,
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
     NEXT_PUBLIC_STELLAR_EXPERT_URL: process.env.NEXT_PUBLIC_STELLAR_EXPERT_URL,
-  })
+  });
 
   if (!result.success) {
     const lines = result.error.issues.map(
       (issue) => `  ${String(issue.path[0])}: ${issue.message}`
-    )
+    );
     throw new Error(
       `❌ Invalid environment variables:\n${lines.join('\n')}\n\nCheck your .env.local file.`
-    )
+    );
   }
 
-  return result.data
+  return result.data;
 }
 
-export const env = parseEnv()
+export const env = parseEnv();

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['mainnet', 'testnet', 'futurenet'], {
-    errorMap: () => ({ message: 'Must be one of: mainnet, testnet, futurenet' }),
+    error: () => ({ message: 'Must be one of: mainnet, testnet, futurenet' }),
   }),
   NEXT_PUBLIC_HORIZON_URL: z.string().url({
     message: 'Must be a valid URL (e.g. https://horizon.stellar.org)',

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -7,16 +7,16 @@
  * @param currencyCode ISO 4217 currency code (e.g. "NGN", "KES", "BRL")
  */
 export function formatDeliveredAmount(amount: string, currencyCode: string): string {
-  const numeric = parseFloat(amount)
-  if (!isFinite(numeric)) return `${amount} ${currencyCode}`
+  const numeric = parseFloat(amount);
+  if (!isFinite(numeric)) return `${amount} ${currencyCode}`;
 
   try {
     return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency: currencyCode,
       maximumFractionDigits: 2,
-    }).format(numeric)
+    }).format(numeric);
   } catch {
-    return `${currencyCode} ${numeric.toFixed(2)}`
+    return `${currencyCode} ${numeric.toFixed(2)}`;
   }
 }

--- a/lib/intent/envelope.ts
+++ b/lib/intent/envelope.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'crypto'
+import { Keypair } from '@stellar/stellar-sdk'
+import type { SignedIntentEnvelope, OfframpIntent } from '@/types/intent'
+
+// ─── Canonicalization ─────────────────────────────────────────────────────────
+
+/**
+ * Produces a deterministic JSON string from an intent object.
+ * Top-level keys are sorted alphabetically so the same intent always hashes
+ * to the same bytes regardless of insertion order.
+ */
+function canonicalize(intent: OfframpIntent): string {
+  const sorted = Object.fromEntries(
+    Object.entries(intent).sort(([a], [b]) => a.localeCompare(b))
+  )
+  return JSON.stringify(sorted)
+}
+
+// ─── Build (client-side) ─────────────────────────────────────────────────────
+
+/**
+ * Creates a signed envelope from an off-ramp intent using the caller's Stellar
+ * keypair. Call this on the client before POSTing to `/api/intent/offramp`.
+ *
+ * Steps:
+ *   1. Canonicalize intent (sorted keys → JSON).
+ *   2. SHA-256 hash the canonical bytes.
+ *   3. Ed25519 sign the hash bytes with `keypair`.
+ *   4. Return the assembled envelope.
+ */
+export function buildEnvelope(intent: OfframpIntent, keypair: Keypair): SignedIntentEnvelope {
+  const canonical = canonicalize(intent)
+  const hashBytes = createHash('sha256').update(canonical).digest()
+
+  return {
+    intent,
+    hash: hashBytes.toString('hex'),
+    signature: Buffer.from(keypair.sign(hashBytes)).toString('base64'),
+    publicKey: keypair.publicKey(),
+  }
+}
+
+// ─── Verify (server-side) ────────────────────────────────────────────────────
+
+/**
+ * Verifies a signed envelope on the server. Returns `true` only when:
+ *   - The hash field matches the SHA-256 of the canonicalized intent.
+ *   - The signature is a valid Ed25519 signature over the hash bytes by publicKey.
+ *
+ * Any error (bad key, malformed base64, wrong network) returns `false` rather
+ * than throwing so callers can produce a clean 401 without a stack trace leak.
+ */
+export function verifyEnvelope(envelope: SignedIntentEnvelope): boolean {
+  try {
+    const canonical = canonicalize(envelope.intent)
+    const hashBytes = createHash('sha256').update(canonical).digest()
+
+    if (hashBytes.toString('hex') !== envelope.hash) return false
+
+    const kp = Keypair.fromPublicKey(envelope.publicKey)
+    const sigBytes = Buffer.from(envelope.signature, 'base64')
+
+    return kp.verify(hashBytes, sigBytes)
+  } catch {
+    return false
+  }
+}

--- a/lib/intent/envelope.ts
+++ b/lib/intent/envelope.ts
@@ -1,67 +1,105 @@
-import { createHash } from 'crypto'
-import { Keypair } from '@stellar/stellar-sdk'
-import type { SignedIntentEnvelope, OfframpIntent } from '@/types/intent'
+import { createHash } from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
+import type { SignedIntentEnvelope, OfframpIntent } from '@/types/intent';
 
 // ─── Canonicalization ─────────────────────────────────────────────────────────
 
-/**
- * Produces a deterministic JSON string from an intent object.
- * Top-level keys are sorted alphabetically so the same intent always hashes
- * to the same bytes regardless of insertion order.
- */
-function canonicalize(intent: OfframpIntent): string {
-  const sorted = Object.fromEntries(
-    Object.entries(intent).sort(([a], [b]) => a.localeCompare(b))
-  )
-  return JSON.stringify(sorted)
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortKeys(v)])
+    );
+  }
+  return value;
 }
 
-// ─── Build (client-side) ─────────────────────────────────────────────────────
+/**
+ * Produces a deterministic JSON string from an intent object.
+ * Keys are sorted recursively so the same intent always hashes to the same
+ * bytes regardless of insertion order or nesting depth.
+ */
+function canonicalize(intent: OfframpIntent): string {
+  return JSON.stringify(sortKeys(intent));
+}
+
+// ─── Build (client-side, Freighter) ──────────────────────────────────────────
 
 /**
- * Creates a signed envelope from an off-ramp intent using the caller's Stellar
- * keypair. Call this on the client before POSTing to `/api/intent/offramp`.
+ * Creates a signed envelope from an off-ramp intent using the user's Freighter
+ * wallet. The private key never leaves the extension.
  *
  * Steps:
- *   1. Canonicalize intent (sorted keys → JSON).
- *   2. SHA-256 hash the canonical bytes.
- *   3. Ed25519 sign the hash bytes with `keypair`.
+ *   1. Canonicalize intent (sorted keys, recursively → JSON).
+ *   2. SHA-256 hash via Web Crypto API (browser-compatible).
+ *   3. Ed25519-sign the canonical string via Freighter signMessage.
  *   4. Return the assembled envelope.
  */
-export function buildEnvelope(intent: OfframpIntent, keypair: Keypair): SignedIntentEnvelope {
-  const canonical = canonicalize(intent)
-  const hashBytes = createHash('sha256').update(canonical).digest()
+export async function buildEnvelope(intent: OfframpIntent): Promise<SignedIntentEnvelope> {
+  const canonical = canonicalize(intent);
+
+  // Hash using the Web Crypto API — works in browser and Node.js 20+.
+  const encoder = new TextEncoder();
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(canonical));
+  const hash = Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  // Sign the canonical JSON via Freighter — private key stays in the extension.
+  const { signMessage } = await import('@stellar/freighter-api');
+  const result = await signMessage(canonical);
+
+  if (result.error) {
+    throw new Error(`Freighter signing failed: ${result.error.message}`);
+  }
+  if (!result.signedMessage) {
+    throw new Error('Freighter returned an empty signature');
+  }
+
+  const sigBytes =
+    typeof result.signedMessage === 'string'
+      ? Buffer.from(result.signedMessage, 'base64')
+      : Buffer.from(result.signedMessage);
 
   return {
     intent,
-    hash: hashBytes.toString('hex'),
-    signature: Buffer.from(keypair.sign(hashBytes)).toString('base64'),
-    publicKey: keypair.publicKey(),
-  }
+    hash,
+    signature: sigBytes.toString('base64'),
+    publicKey: result.signerAddress,
+  };
 }
 
 // ─── Verify (server-side) ────────────────────────────────────────────────────
 
 /**
  * Verifies a signed envelope on the server. Returns `true` only when:
+ *   - envelope.publicKey matches intent.publicKey (prevents key substitution).
  *   - The hash field matches the SHA-256 of the canonicalized intent.
- *   - The signature is a valid Ed25519 signature over the hash bytes by publicKey.
+ *   - The signature is a valid Ed25519 signature over the canonical JSON bytes.
  *
- * Any error (bad key, malformed base64, wrong network) returns `false` rather
- * than throwing so callers can produce a clean 401 without a stack trace leak.
+ * Any error (bad key, malformed base64, key mismatch) returns `false` rather
+ * than throwing so callers produce a clean 401 without a stack trace leak.
  */
 export function verifyEnvelope(envelope: SignedIntentEnvelope): boolean {
   try {
-    const canonical = canonicalize(envelope.intent)
-    const hashBytes = createHash('sha256').update(canonical).digest()
+    // Prevent key substitution: the signing key must be the intent's publicKey.
+    if (envelope.publicKey !== envelope.intent.publicKey) return false;
 
-    if (hashBytes.toString('hex') !== envelope.hash) return false
+    const canonical = canonicalize(envelope.intent);
 
-    const kp = Keypair.fromPublicKey(envelope.publicKey)
-    const sigBytes = Buffer.from(envelope.signature, 'base64')
+    // Verify the hash field matches the re-derived hash.
+    const hashBytes = createHash('sha256').update(canonical).digest();
+    if (hashBytes.toString('hex') !== envelope.hash) return false;
 
-    return kp.verify(hashBytes, sigBytes)
+    // Verify the Ed25519 signature over the canonical JSON bytes —
+    // matching what Freighter signs via signMessage(canonical).
+    const kp = Keypair.fromPublicKey(envelope.publicKey);
+    const sigBytes = Buffer.from(envelope.signature, 'base64');
+
+    return kp.verify(Buffer.from(canonical, 'utf8'), sigBytes);
   } catch {
-    return false
+    return false;
   }
 }

--- a/lib/stellar/anchors.ts
+++ b/lib/stellar/anchors.ts
@@ -28,6 +28,12 @@ export function getAnchorById(id: string): Anchor {
  * Resolves SEP-1 details for the anchor with the given ID.
  * Throws if the anchor is unknown or TOML resolution fails.
  */
+export async function getResolvedAnchorByDomain(homeDomain: string): Promise<ResolvedAnchor> {
+  const anchor = ANCHORS.find((a) => a.homeDomain === homeDomain);
+  if (!anchor) throw new Error(`No anchor found for domain "${homeDomain}"`);
+  return getResolvedAnchorById(anchor.id);
+}
+
 export async function getResolvedAnchorById(id: string): Promise<ResolvedAnchor> {
   const anchor = getAnchorById(id);
   const { resolveToml } = await import('./sep1');

--- a/lib/stellar/anchors.ts
+++ b/lib/stellar/anchors.ts
@@ -1,11 +1,10 @@
 // Anchor and corridor data lives in constants/anchors.ts — the single source of truth.
 // This module re-exports that data and adds SEP-1 resolution helpers that belong
 // in lib/stellar (network calls, dynamic imports) rather than in constants.
-export * from '@/constants/anchors'
+export * from '@/constants/anchors';
 
-import { ANCHORS, CORRIDORS } from '@/constants/anchors'
-import type { Anchor, Corridor, ResolvedAnchor, Sep1TomlData } from '@/types'
-
+import { ANCHORS, CORRIDORS } from '@/constants/anchors';
+import type { Anchor, Corridor, ResolvedAnchor } from '@/types';
 
 // ─── Lookup helpers ───────────────────────────────────────────────────────────
 
@@ -18,13 +17,11 @@ import type { Anchor, Corridor, ResolvedAnchor, Sep1TomlData } from '@/types'
  * Throws a descriptive error if the ID is not found.
  */
 export function getAnchorById(id: string): Anchor {
-  const anchor = ANCHORS.find((a) => a.id === id)
+  const anchor = ANCHORS.find((a) => a.id === id);
   if (!anchor) {
-    throw new Error(
-      `Unknown anchor: "${id}". Valid IDs: ${ANCHORS.map((a) => a.id).join(', ')}`
-    )
+    throw new Error(`Unknown anchor: "${id}". Valid IDs: ${ANCHORS.map((a) => a.id).join(', ')}`);
   }
-  return anchor
+  return anchor;
 }
 
 /**
@@ -32,11 +29,11 @@ export function getAnchorById(id: string): Anchor {
  * Throws if the anchor is unknown or TOML resolution fails.
  */
 export async function getResolvedAnchorById(id: string): Promise<ResolvedAnchor> {
-  const anchor = getAnchorById(id)
-  const { resolveToml } = await import('./sep1')
-  const result = await resolveToml(anchor.homeDomain)
-  if (!result.ok) throw new Error(result.error)
-  return { ...anchor, ...result.data }
+  const anchor = getAnchorById(id);
+  const { resolveToml } = await import('./sep1');
+  const result = await resolveToml(anchor.homeDomain);
+  if (!result.ok) throw new Error(result.error);
+  return { ...anchor, ...result.data };
 }
 
 /**
@@ -44,7 +41,7 @@ export async function getResolvedAnchorById(id: string): Promise<ResolvedAnchor>
  * Returns an empty array if no anchors support the corridor.
  */
 export function getAnchorsByCorridorId(corridorId: string): Anchor[] {
-  return ANCHORS.filter((a) => a.corridors.includes(corridorId))
+  return ANCHORS.filter((a) => a.corridors.includes(corridorId));
 }
 
 /**
@@ -52,29 +49,29 @@ export function getAnchorsByCorridorId(corridorId: string): Anchor[] {
  * Failed anchors are omitted so callers can continue with the live subset.
  */
 export async function discoverAnchorsForCorridor(corridorId: string): Promise<ResolvedAnchor[]> {
-  const { resolveToml } = await import('./sep1')
-  const corridorAnchors = ANCHORS.filter((anchor) => anchor.corridors.includes(corridorId))
+  const { resolveToml } = await import('./sep1');
+  const corridorAnchors = ANCHORS.filter((anchor) => anchor.corridors.includes(corridorId));
 
   const results = await Promise.allSettled(
     corridorAnchors.map(async (anchor): Promise<ResolvedAnchor> => {
-      const result = await resolveToml(anchor.homeDomain)
-      if (!result.ok) throw new Error(result.error)
-      const sep1 = result.data
+      const result = await resolveToml(anchor.homeDomain);
+      if (!result.ok) throw new Error(result.error);
+      const sep1 = result.data;
       if (!sep1.TRANSFER_SERVER_SEP0024 || !sep1.WEB_AUTH_ENDPOINT) {
-        throw new Error(`Anchor "${anchor.id}" does not support SEP-24 or SEP-10.`)
+        throw new Error(`Anchor "${anchor.id}" does not support SEP-24 or SEP-10.`);
       }
       return {
         ...anchor,
         ...sep1,
-      }
+      };
     })
-  )
+  );
 
   return results
     .filter((result): result is PromiseFulfilledResult<ResolvedAnchor> => {
-      return result.status === 'fulfilled'
+      return result.status === 'fulfilled';
     })
-    .map((result) => result.value)
+    .map((result) => result.value);
 }
 
 /**
@@ -82,13 +79,13 @@ export async function discoverAnchorsForCorridor(corridorId: string): Promise<Re
  * Throws a descriptive error if the ID is not found.
  */
 export function getCorridorById(id: string): Corridor {
-  const corridor = CORRIDORS.find((c) => c.id === id)
+  const corridor = CORRIDORS.find((c) => c.id === id);
   if (!corridor) {
     throw new Error(
       `Unknown corridor: "${id}". Valid IDs: ${CORRIDORS.map((c) => c.id).join(', ')}`
-    )
+    );
   }
-  return corridor
+  return corridor;
 }
 
 /**
@@ -96,5 +93,5 @@ export function getCorridorById(id: string): Corridor {
  * Used to validate query parameters in API routes.
  */
 export function isValidCorridorId(id: string): boolean {
-  return CORRIDORS.some((c) => c.id === id)
+  return CORRIDORS.some((c) => c.id === id);
 }

--- a/lib/stellar/errors.ts
+++ b/lib/stellar/errors.ts
@@ -3,8 +3,8 @@
  */
 export class WalletError extends Error {
   constructor(message: string) {
-    super(message)
-    this.name = 'WalletError'
+    super(message);
+    this.name = 'WalletError';
   }
 }
 
@@ -13,8 +13,8 @@ export class WalletError extends Error {
  */
 export class UserRejectedError extends WalletError {
   constructor() {
-    super('User rejected the request')
-    this.name = 'UserRejectedError'
+    super('User rejected the request');
+    this.name = 'UserRejectedError';
   }
 }
 
@@ -24,8 +24,8 @@ export class UserRejectedError extends WalletError {
  */
 export class NetworkError extends WalletError {
   constructor(message: string) {
-    super(message)
-    this.name = 'NetworkError'
+    super(message);
+    this.name = 'NetworkError';
   }
 }
 
@@ -34,8 +34,8 @@ export class NetworkError extends WalletError {
  */
 export class ConnectionError extends WalletError {
   constructor(message: string) {
-    super(message)
-    this.name = 'ConnectionError'
+    super(message);
+    this.name = 'ConnectionError';
   }
 }
 
@@ -44,8 +44,8 @@ export class ConnectionError extends WalletError {
  */
 export class UnknownWalletError extends WalletError {
   constructor(message: string) {
-    super(message)
-    this.name = 'UnknownWalletError'
+    super(message);
+    this.name = 'UnknownWalletError';
   }
 }
 
@@ -54,16 +54,16 @@ export class UnknownWalletError extends WalletError {
  * response formats into a consistent shape.
  */
 export class SepError extends Error {
-  readonly code: string
-  readonly httpStatus: number
-  readonly raw: unknown
+  readonly code: string;
+  readonly httpStatus: number;
+  readonly raw: unknown;
 
   constructor(message: string, code: string, httpStatus: number, raw: unknown) {
-    super(message)
-    this.name = 'SepError'
-    this.code = code
-    this.httpStatus = httpStatus
-    this.raw = raw
+    super(message);
+    this.name = 'SepError';
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.raw = raw;
   }
 }
 
@@ -73,36 +73,40 @@ export class SepError extends Error {
  * object, missing/empty fields, and malformed/non-object values.
  */
 export function parseSepErrorBody(body: unknown, httpStatus: number): SepError {
-  const fallback = `SEP error: HTTP ${httpStatus}`
-  let message = fallback
-  let code = `HTTP_${httpStatus}`
+  const fallback = `SEP error: HTTP ${httpStatus}`;
+  let message = fallback;
+  let code = `HTTP_${httpStatus}`;
 
   if (typeof body === 'string' && body.trim().length > 0) {
-    message = body.trim()
+    message = body.trim();
   } else if (body !== null && body !== undefined && typeof body === 'object') {
-    const obj = body as Record<string, unknown>
+    const obj = body as Record<string, unknown>;
 
     if (typeof obj['error'] === 'string' && obj['error'].trim().length > 0) {
       // JSON API: { error: "...", code?: "..." }
-      message = obj['error'].trim()
+      message = obj['error'].trim();
       if (typeof obj['code'] === 'string' && obj['code'].trim().length > 0) {
-        code = obj['code'].trim()
+        code = obj['code'].trim();
       }
-    } else if (obj['error'] !== null && obj['error'] !== undefined && typeof obj['error'] === 'object') {
+    } else if (
+      obj['error'] !== null &&
+      obj['error'] !== undefined &&
+      typeof obj['error'] === 'object'
+    ) {
       // Nested: { error: { message: "...", code?: "..." } }
-      const nested = obj['error'] as Record<string, unknown>
+      const nested = obj['error'] as Record<string, unknown>;
       if (typeof nested['message'] === 'string' && nested['message'].trim().length > 0) {
-        message = nested['message'].trim()
+        message = nested['message'].trim();
       }
       if (typeof nested['code'] === 'string' && nested['code'].trim().length > 0) {
-        code = nested['code'].trim()
+        code = nested['code'].trim();
       }
     } else if (typeof obj['detail'] === 'string' && obj['detail'].trim().length > 0) {
-      message = obj['detail'].trim()
+      message = obj['detail'].trim();
     } else if (typeof obj['message'] === 'string' && obj['message'].trim().length > 0) {
-      message = obj['message'].trim()
+      message = obj['message'].trim();
     }
   }
 
-  return new SepError(message, code, httpStatus, body)
+  return new SepError(message, code, httpStatus, body);
 }

--- a/lib/stellar/estimatedRates.ts
+++ b/lib/stellar/estimatedRates.ts
@@ -14,9 +14,6 @@
  */
 
 /** @deprecated See module-level JSDoc. */
-export function getEstimatedRate(
-  _corridorId: string,
-  _amount: string
-): null {
-  return null
+export function getEstimatedRate(_corridorId: string, _amount: string): null {
+  return null;
 }

--- a/lib/stellar/horizon.ts
+++ b/lib/stellar/horizon.ts
@@ -6,14 +6,14 @@ import {
   Operation,
   Memo,
   BASE_FEE,
-} from '@stellar/stellar-sdk'
-import { HORIZON_URL } from '@/constants'
-import type { SwapRoute, StellarAsset } from '@/types'
-import { UserRejectedError } from './errors'
+} from '@stellar/stellar-sdk';
+import { HORIZON_URL } from '@/constants';
+import type { SwapRoute, StellarAsset } from '@/types';
+import { UserRejectedError } from './errors';
 
-export const horizonServer = new Horizon.Server(HORIZON_URL)
+export const horizonServer = new Horizon.Server(HORIZON_URL);
 
-const MAX_FEE_STROOPS = 10_000
+const MAX_FEE_STROOPS = 10_000;
 
 // ─── Account loading ──────────────────────────────────────────────────────────
 
@@ -23,26 +23,26 @@ const MAX_FEE_STROOPS = 10_000
  */
 export async function fetchAccount(publicKey: string): Promise<Horizon.AccountResponse> {
   try {
-    return await horizonServer.loadAccount(publicKey)
+    return await horizonServer.loadAccount(publicKey);
   } catch (err) {
-    const horizonErr = err as { response?: { status?: number } }
+    const horizonErr = err as { response?: { status?: number } };
     if (horizonErr?.response?.status === 404) {
-      throw new Error('Account does not exist on the Stellar network')
+      throw new Error('Account does not exist on the Stellar network');
     }
-    throw err
+    throw err;
   }
 }
 
 // ─── Payment builder ──────────────────────────────────────────────────────────
 
 export interface BuildWithdrawPaymentParams {
-  sourcePublicKey: string
-  anchorAccount: string
-  amount: string
-  memo: string
-  memoType: string
-  assetCode: string
-  assetIssuer: string
+  sourcePublicKey: string;
+  anchorAccount: string;
+  amount: string;
+  memo: string;
+  memoType: string;
+  assetCode: string;
+  assetIssuer: string;
 }
 
 /**
@@ -53,23 +53,23 @@ export interface BuildWithdrawPaymentParams {
 export async function buildWithdrawPayment(
   params: BuildWithdrawPaymentParams
 ): Promise<ReturnType<TransactionBuilder['build']>> {
-  const { sourcePublicKey, anchorAccount, amount, memo, memoType, assetCode, assetIssuer } = params
+  const { sourcePublicKey, anchorAccount, amount, memo, memoType, assetCode, assetIssuer } = params;
 
-  const account = await fetchAccount(sourcePublicKey)
-  const asset = new Asset(assetCode, assetIssuer)
+  const account = await fetchAccount(sourcePublicKey);
+  const asset = new Asset(assetCode, assetIssuer);
 
-  let recommendedFee = parseInt(BASE_FEE, 10)
+  let recommendedFee = parseInt(BASE_FEE, 10);
   try {
-    recommendedFee = await horizonServer.fetchBaseFee()
+    recommendedFee = await horizonServer.fetchBaseFee();
   } catch {
     // fall back to BASE_FEE
   }
-  const fee = Math.min(recommendedFee, MAX_FEE_STROOPS).toString()
+  const fee = Math.min(recommendedFee, MAX_FEE_STROOPS).toString();
 
   const builder = new TransactionBuilder(account, {
     fee,
     networkPassphrase: Networks.PUBLIC,
-  }).setTimeout(180)
+  }).setTimeout(180);
 
   builder.addOperation(
     Operation.payment({
@@ -77,20 +77,20 @@ export async function buildWithdrawPayment(
       asset,
       amount,
     })
-  )
+  );
 
   // Apply memo from SEP-24 transaction record
   if (memo) {
     if (memoType === 'hash') {
-      builder.addMemo(Memo.hash(memo))
+      builder.addMemo(Memo.hash(memo));
     } else if (memoType === 'id') {
-      builder.addMemo(Memo.id(memo))
+      builder.addMemo(Memo.id(memo));
     } else {
-      builder.addMemo(Memo.text(memo))
+      builder.addMemo(Memo.text(memo));
     }
   }
 
-  return builder.build()
+  return builder.build();
 }
 
 // ─── Sign and submit ──────────────────────────────────────────────────────────
@@ -102,40 +102,40 @@ export async function buildWithdrawPayment(
 export async function signAndSubmitPayment(
   transaction: ReturnType<TransactionBuilder['build']>
 ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
-  const { signTransaction } = await import('@stellar/freighter-api')
+  const { signTransaction } = await import('@stellar/freighter-api');
 
-  const xdr = transaction.toXDR()
-  const signResult = await signTransaction(xdr, { networkPassphrase: Networks.PUBLIC })
+  const xdr = transaction.toXDR();
+  const signResult = await signTransaction(xdr, { networkPassphrase: Networks.PUBLIC });
 
   if (signResult.error) {
-    throw new UserRejectedError()
+    throw new UserRejectedError();
   }
 
-  const { TransactionBuilder: TB } = await import('@stellar/stellar-sdk')
-  const signedTx = TB.fromXDR(signResult.signedTxXdr, Networks.PUBLIC)
+  const { TransactionBuilder: TB } = await import('@stellar/stellar-sdk');
+  const signedTx = TB.fromXDR(signResult.signedTxXdr, Networks.PUBLIC);
 
   try {
-    return await horizonServer.submitTransaction(signedTx)
+    return await horizonServer.submitTransaction(signedTx);
   } catch (err) {
     const horizonErr = err as {
-      response?: { data?: { extras?: { result_codes?: Record<string, string[]> } } }
-    }
-    const codes = horizonErr?.response?.data?.extras?.result_codes
+      response?: { data?: { extras?: { result_codes?: Record<string, string[]> } } };
+    };
+    const codes = horizonErr?.response?.data?.extras?.result_codes;
     if (codes) {
       const summary = Object.entries(codes)
         .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
-        .join(' | ')
-      throw new Error(`Transaction failed: ${summary}`)
+        .join(' | ');
+      throw new Error(`Transaction failed: ${summary}`);
     }
-    throw err
+    throw err;
   }
 }
 
 // ─── SDEX path finding (existing) ────────────────────────────────────────────
 
 export interface OrderBookData {
-  bids: Array<{ price: number; amount: number }>
-  asks: Array<{ price: number; amount: number }>
+  bids: Array<{ price: number; amount: number }>;
+  asks: Array<{ price: number; amount: number }>;
 }
 
 export async function getOrderBook(
@@ -161,9 +161,9 @@ export async function getOrderBook(
             : ({ code: buyingAssetCode, issuer: buyingIssuer ?? '' } as Parameters<
                 typeof horizonServer.orderbook
               >[1])
-        )
+        );
 
-  const book = await selling.call()
+  const book = await selling.call();
 
   return {
     bids: (book.bids as Array<{ price: string; amount: string }>).slice(0, 10).map((b) => ({
@@ -174,7 +174,7 @@ export async function getOrderBook(
       price: parseFloat(a.price),
       amount: parseFloat(a.amount),
     })),
-  }
+  };
 }
 
 export async function getStrictSendPaths(
@@ -182,50 +182,50 @@ export async function getStrictSendPaths(
   fromAmount: number,
   toAssets: StellarAsset[]
 ): Promise<SwapRoute[]> {
-  const url = new URL(`${HORIZON_URL}/paths/strict-send`)
-  url.searchParams.set('source_amount', fromAmount.toString())
+  const url = new URL(`${HORIZON_URL}/paths/strict-send`);
+  url.searchParams.set('source_amount', fromAmount.toString());
 
   if (fromAsset.issuer) {
-    url.searchParams.set('source_asset_type', 'credit_alphanum4')
-    url.searchParams.set('source_asset_code', fromAsset.code)
-    url.searchParams.set('source_asset_issuer', fromAsset.issuer)
+    url.searchParams.set('source_asset_type', 'credit_alphanum4');
+    url.searchParams.set('source_asset_code', fromAsset.code);
+    url.searchParams.set('source_asset_issuer', fromAsset.issuer);
   } else {
-    url.searchParams.set('source_asset_type', 'native')
+    url.searchParams.set('source_asset_type', 'native');
   }
 
   toAssets.forEach((a) => {
     if (a.issuer) {
-      url.searchParams.append('destination_assets', `${a.code}:${a.issuer}`)
+      url.searchParams.append('destination_assets', `${a.code}:${a.issuer}`);
     } else {
-      url.searchParams.append('destination_assets', 'native')
+      url.searchParams.append('destination_assets', 'native');
     }
-  })
+  });
 
-  const res = await fetch(url.toString())
-  if (!res.ok) throw new Error(`Horizon paths error: ${res.status}`)
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`Horizon paths error: ${res.status}`);
   const data = (await res.json()) as {
     _embedded: {
       records: Array<{
-        source_amount: string
-        destination_amount: string
-        path: Array<{ asset_code?: string; asset_issuer?: string; asset_type: string }>
-        source_asset_code?: string
-        source_asset_issuer?: string
-        destination_asset_code?: string
-        destination_asset_issuer?: string
-      }>
-    }
-  }
+        source_amount: string;
+        destination_amount: string;
+        path: Array<{ asset_code?: string; asset_issuer?: string; asset_type: string }>;
+        source_asset_code?: string;
+        source_asset_issuer?: string;
+        destination_asset_code?: string;
+        destination_asset_issuer?: string;
+      }>;
+    };
+  };
 
-  const toAsset = toAssets[0]
+  const toAsset = toAssets[0];
   return data._embedded.records.map((r, i) => {
-    const toAmt = parseFloat(r.destination_amount)
-    const fromAmt = parseFloat(r.source_amount)
+    const toAmt = parseFloat(r.destination_amount);
+    const fromAmt = parseFloat(r.source_amount);
     const intermediates: StellarAsset[] = r.path.map((p) => ({
       code: p.asset_code ?? 'XLM',
       issuer: p.asset_issuer,
       name: p.asset_code ?? 'XLM',
-    }))
+    }));
 
     return {
       routeId: `sdex-${i}`,
@@ -240,6 +240,6 @@ export async function getStrictSendPaths(
       path: [fromAsset, ...intermediates, toAsset],
       estimatedTime: '< 5 seconds',
       lastUpdated: new Date(),
-    }
-  })
+    };
+  });
 }

--- a/lib/stellar/horizon.ts
+++ b/lib/stellar/horizon.ts
@@ -218,12 +218,13 @@ export async function getStrictSendPaths(
   };
 
   const toAsset = toAssets[0];
+  if (!toAsset) return [];
   return data._embedded.records.map((r, i) => {
     const toAmt = parseFloat(r.destination_amount);
     const fromAmt = parseFloat(r.source_amount);
     const intermediates: StellarAsset[] = r.path.map((p) => ({
       code: p.asset_code ?? 'XLM',
-      issuer: p.asset_issuer,
+      ...(p.asset_issuer ? { issuer: p.asset_issuer } : {}),
       name: p.asset_code ?? 'XLM',
     }));
 

--- a/lib/stellar/jwt-cache.ts
+++ b/lib/stellar/jwt-cache.ts
@@ -1,54 +1,54 @@
-import type { Sep10Auth } from '@/types'
+import type { Sep10Auth } from '@/types';
 
-const DEFAULT_CAPACITY = 32
+const DEFAULT_CAPACITY = 32;
 
-const cache = new Map<string, Sep10Auth>()
-let capacity = DEFAULT_CAPACITY
+const cache = new Map<string, Sep10Auth>();
+let capacity = DEFAULT_CAPACITY;
 
 function key(anchorDomain: string, publicKey: string): string {
-  return `${anchorDomain}::${publicKey}`
+  return `${anchorDomain}::${publicKey}`;
 }
 
 function evictIfOverCapacity(): void {
   while (cache.size > capacity) {
-    const oldest = cache.keys().next().value
-    if (oldest === undefined) break
-    cache.delete(oldest)
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
   }
 }
 
 export function getCachedJwt(anchorDomain: string, publicKey: string): Sep10Auth | undefined {
-  const k = key(anchorDomain, publicKey)
-  const entry = cache.get(k)
-  if (!entry) return undefined
+  const k = key(anchorDomain, publicKey);
+  const entry = cache.get(k);
+  if (!entry) return undefined;
 
   if (entry.expiresAt.getTime() <= Date.now()) {
-    cache.delete(k)
-    return undefined
+    cache.delete(k);
+    return undefined;
   }
 
   // Move to end → most-recently-used
-  cache.delete(k)
-  cache.set(k, entry)
-  return entry
+  cache.delete(k);
+  cache.set(k, entry);
+  return entry;
 }
 
 export function setCachedJwt(entry: Sep10Auth): void {
-  const k = key(entry.anchorDomain, entry.publicKey)
-  if (cache.has(k)) cache.delete(k)
-  cache.set(k, entry)
-  evictIfOverCapacity()
+  const k = key(entry.anchorDomain, entry.publicKey);
+  if (cache.has(k)) cache.delete(k);
+  cache.set(k, entry);
+  evictIfOverCapacity();
 }
 
 export function invalidateCachedJwt(anchorDomain: string, publicKey: string): void {
-  cache.delete(key(anchorDomain, publicKey))
+  cache.delete(key(anchorDomain, publicKey));
 }
 
 export function clearJwtCache(): void {
-  cache.clear()
+  cache.clear();
 }
 
 export function setJwtCacheCapacity(n: number): void {
-  capacity = Math.max(1, n)
-  evictIfOverCapacity()
+  capacity = Math.max(1, n);
+  evictIfOverCapacity();
 }

--- a/lib/stellar/sep1.ts
+++ b/lib/stellar/sep1.ts
@@ -1,73 +1,71 @@
-import { StellarToml } from '@stellar/stellar-sdk'
-import type { ResolvedAnchor, Sep1TomlData } from '@/types'
-import { ANCHORS } from './anchors'
+import { StellarToml } from '@stellar/stellar-sdk';
+import type { ResolvedAnchor, Sep1TomlData } from '@/types';
+import { ANCHORS } from './anchors';
 
 // ─── Result type ──────────────────────────────────────────────────────────────
 
-export type TomlResult =
-  | { ok: true; data: Sep1TomlData }
-  | { ok: false; error: string }
+export type TomlResult = { ok: true; data: Sep1TomlData } | { ok: false; error: string };
 
 // ─── In-memory cache ──────────────────────────────────────────────────────────
 
-const TTL_MS = 15 * 60 * 1000 // 15 minutes
+const TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 interface CacheEntry {
-  data: Sep1TomlData
-  expiresAt: number
+  data: Sep1TomlData;
+  expiresAt: number;
 }
 
-const cache = new Map<string, CacheEntry>()
+const cache = new Map<string, CacheEntry>();
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 function normalizeDomain(domain: string): string {
-  const normalized = domain.trim().toLowerCase()
+  const normalized = domain.trim().toLowerCase();
 
   if (!normalized) {
-    throw new Error('Anchor domain is required')
+    throw new Error('Anchor domain is required');
   }
 
-  return normalized
+  return normalized;
 }
 
 function getString(raw: Record<string, unknown>, key: string): string | null {
-  const value = raw[key]
-  return typeof value === 'string' && value.trim().length > 0 ? value : null
+  const value = raw[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getCurrencies(raw: Record<string, unknown>): Sep1TomlData['CURRENCIES'] {
-  const currencies = raw['CURRENCIES']
+  const currencies = raw['CURRENCIES'];
   if (!Array.isArray(currencies)) {
-    return []
+    return [];
   }
 
   return currencies.flatMap((currency) => {
     if (!isRecord(currency) || typeof currency['code'] !== 'string') {
-      return []
+      return [];
     }
 
     const parsed: Sep1TomlData['CURRENCIES'][number] = {
       code: currency['code'],
-    }
+    };
 
     if (typeof currency['issuer'] === 'string') {
-      parsed.issuer = currency['issuer']
+      parsed.issuer = currency['issuer'];
     }
 
-    return [parsed]
-  })
+    return [parsed];
+  });
 }
 
 function toSep1TomlData(domain: string, raw: Record<string, unknown>): Sep1TomlData {
-  const transferServer = getString(raw, 'TRANSFER_SERVER_SEP0024')
-  const webAuthEndpoint = getString(raw, 'WEB_AUTH_ENDPOINT')
-  const signingKey = getString(raw, 'SIGNING_KEY')
-  const quoteServer = getString(raw, 'ANCHOR_QUOTE_SERVER')
+  const transferServer = getString(raw, 'TRANSFER_SERVER_SEP0024');
+  const webAuthEndpoint = getString(raw, 'WEB_AUTH_ENDPOINT');
+  const signingKey = getString(raw, 'SIGNING_KEY');
+  const quoteServer = getString(raw, 'ANCHOR_QUOTE_SERVER');
 
   return {
     domain,
@@ -83,7 +81,7 @@ function toSep1TomlData(domain: string, raw: Record<string, unknown>): Sep1TomlD
       sep38: Boolean(quoteServer),
       sep12: Boolean(signingKey),
     },
-  }
+  };
 }
 
 function requireTomlField(
@@ -92,16 +90,16 @@ function requireTomlField(
   field: 'TRANSFER_SERVER_SEP0024' | 'WEB_AUTH_ENDPOINT',
   protocolName: string
 ): string {
-  const value = toml[field]
+  const value = toml[field];
 
   if (!value) {
     throw new Error(
       `Missing ${field} in stellar.toml for "${domain}". ` +
         `This anchor does not support ${protocolName}.`
-    )
+    );
   }
 
-  return value
+  return value;
 }
 
 /**
@@ -109,26 +107,26 @@ function requireTomlField(
  * Results are cached in memory for 15 minutes. Failed resolutions are not cached.
  */
 export async function resolveAnchor(domain: string): Promise<Sep1TomlData> {
-  const cacheKey = normalizeDomain(domain)
-  const cached = cache.get(cacheKey)
+  const cacheKey = normalizeDomain(domain);
+  const cached = cache.get(cacheKey);
 
   if (cached && cached.expiresAt > Date.now()) {
-    return cached.data
+    return cached.data;
   }
 
   try {
-    const raw = (await StellarToml.Resolver.resolve(cacheKey)) as Record<string, unknown>
-    const data = toSep1TomlData(cacheKey, raw)
+    const raw = (await StellarToml.Resolver.resolve(cacheKey)) as Record<string, unknown>;
+    const data = toSep1TomlData(cacheKey, raw);
 
-    cache.set(cacheKey, { data, expiresAt: Date.now() + TTL_MS })
-    return data
+    cache.set(cacheKey, { data, expiresAt: Date.now() + TTL_MS });
+    return data;
   } catch (err) {
-    cache.delete(cacheKey)
+    cache.delete(cacheKey);
     throw new Error(
       `Failed to resolve stellar.toml for "${cacheKey}": ${
         err instanceof Error ? err.message : String(err)
       }`
-    )
+    );
   }
 }
 
@@ -141,10 +139,10 @@ export async function resolveAnchor(domain: string): Promise<Sep1TomlData> {
  */
 export async function resolveToml(domain: string): Promise<TomlResult> {
   try {
-    const data = await resolveAnchor(domain)
-    return { ok: true, data }
+    const data = await resolveAnchor(domain);
+    return { ok: true, data };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -152,16 +150,16 @@ export async function resolveToml(domain: string): Promise<TomlResult> {
  * Returns the SEP-24 transfer server URL for the given anchor domain.
  */
 export async function getTransferServer(domain: string): Promise<string> {
-  const toml = await resolveAnchor(domain)
-  return requireTomlField(domain, toml, 'TRANSFER_SERVER_SEP0024', 'SEP-24')
+  const toml = await resolveAnchor(domain);
+  return requireTomlField(domain, toml, 'TRANSFER_SERVER_SEP0024', 'SEP-24');
 }
 
 /**
  * Returns the SEP-10 web auth endpoint URL for the given anchor domain.
  */
 export async function getWebAuthEndpoint(domain: string): Promise<string> {
-  const toml = await resolveAnchor(domain)
-  return requireTomlField(domain, toml, 'WEB_AUTH_ENDPOINT', 'SEP-10 authentication')
+  const toml = await resolveAnchor(domain);
+  return requireTomlField(domain, toml, 'WEB_AUTH_ENDPOINT', 'SEP-10 authentication');
 }
 
 /**
@@ -171,29 +169,30 @@ export async function getWebAuthEndpoint(domain: string): Promise<string> {
 export async function resolveAllAnchors(): Promise<Record<string, ResolvedAnchor>> {
   const results = await Promise.allSettled(
     ANCHORS.map((anchor) => resolveAnchor(anchor.homeDomain).then((data) => ({ anchor, data })))
-  )
+  );
 
-  const resolved: Record<string, ResolvedAnchor> = {}
+  const resolved: Record<string, ResolvedAnchor> = {};
 
   for (const result of results) {
     if (result.status === 'fulfilled') {
-      resolved[result.value.anchor.id] = { ...result.value.anchor, ...result.value.data }
+      resolved[result.value.anchor.id] = { ...result.value.anchor, ...result.value.data };
     } else {
-      console.warn('[sep1] resolveAllAnchors failure:', result.reason)
+      // eslint-disable-next-line no-console
+      console.warn('[sep1] resolveAllAnchors failure:', result.reason);
     }
   }
 
-  return resolved
+  return resolved;
 }
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
 /** Exposed for testing only — clears the in-memory TOML cache. */
 export function _clearTomlCache(): void {
-  cache.clear()
+  cache.clear();
 }
 
 /** Exposed for testing only — injects a pre-validated cache entry. */
 export function _seedTomlCache(domain: string, data: Sep1TomlData): void {
-  cache.set(domain, { data, expiresAt: Date.now() + TTL_MS })
+  cache.set(domain, { data, expiresAt: Date.now() + TTL_MS });
 }

--- a/lib/stellar/sep10.ts
+++ b/lib/stellar/sep10.ts
@@ -1,23 +1,22 @@
-import { Networks, TransactionBuilder } from '@stellar/stellar-sdk'
-import type { Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk'
-import { getWebAuthEndpoint } from './sep1'
-import { getCachedJwt, setCachedJwt, invalidateCachedJwt } from './jwt-cache'
-import type { ResolvedAnchor, Sep10Auth } from '@/types'
-import { UserRejectedError } from './errors'
+import { Networks, TransactionBuilder } from '@stellar/stellar-sdk';
+import type { Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk';
+import { getCachedJwt, setCachedJwt, invalidateCachedJwt } from './jwt-cache';
+import type { ResolvedAnchor, Sep10Auth } from '@/types';
+import { UserRejectedError } from './errors';
 
-export { invalidateCachedJwt, getCachedJwt } from './jwt-cache'
+export { invalidateCachedJwt, getCachedJwt } from './jwt-cache';
 
 // ─── Typed errors ─────────────────────────────────────────────────────────────
 
-export type ChallengeErrorCode = 'FETCH_FAILED' | 'MISSING_FIELD' | 'WRONG_NETWORK' | 'INVALID_XDR'
+export type ChallengeErrorCode = 'FETCH_FAILED' | 'MISSING_FIELD' | 'WRONG_NETWORK' | 'INVALID_XDR';
 
 export class ChallengeError extends Error {
   constructor(
     message: string,
     public readonly code: ChallengeErrorCode
   ) {
-    super(message)
-    this.name = 'ChallengeError'
+    super(message);
+    this.name = 'ChallengeError';
   }
 }
 
@@ -26,37 +25,37 @@ export class Sep10AuthError extends Error {
     message: string,
     public readonly status: number
   ) {
-    super(message)
-    this.name = 'Sep10AuthError'
+    super(message);
+    this.name = 'Sep10AuthError';
   }
 }
 
 // ─── Challenge types ──────────────────────────────────────────────────────────
 
 export interface Sep10Challenge {
-  transaction: string
-  network_passphrase: string
-  parsed: Transaction | FeeBumpTransaction
+  transaction: string;
+  network_passphrase: string;
+  parsed: Transaction | FeeBumpTransaction;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function decodeJwtExp(token: string): number {
-  const parts = token.split('.')
+  const parts = token.split('.');
   if (parts.length !== 3) {
-    throw new Error('Invalid JWT: expected 3 dot-separated segments')
+    throw new Error('Invalid JWT: expected 3 dot-separated segments');
   }
-  const base64 = (parts[1] as string).replace(/-/g, '+').replace(/_/g, '/')
-  let payload: Record<string, unknown>
+  const base64 = (parts[1] as string).replace(/-/g, '+').replace(/_/g, '/');
+  let payload: Record<string, unknown>;
   try {
-    payload = JSON.parse(atob(base64)) as Record<string, unknown>
+    payload = JSON.parse(atob(base64)) as Record<string, unknown>;
   } catch {
-    throw new Error('JWT payload could not be decoded')
+    throw new Error('JWT payload could not be decoded');
   }
   if (typeof payload['exp'] !== 'number') {
-    throw new Error('JWT is missing a numeric "exp" claim')
+    throw new Error('JWT is missing a numeric "exp" claim');
   }
-  return payload['exp']
+  return payload['exp'];
 }
 
 // ─── fetchSep10Challenge ──────────────────────────────────────────────────────
@@ -66,63 +65,63 @@ export async function fetchSep10Challenge(
   publicKey: string,
   homeDomain: string
 ): Promise<Sep10Challenge> {
-  const url = new URL(webAuthEndpoint)
-  url.searchParams.set('account', publicKey)
-  url.searchParams.set('home_domain', homeDomain)
+  const url = new URL(webAuthEndpoint);
+  url.searchParams.set('account', publicKey);
+  url.searchParams.set('home_domain', homeDomain);
 
-  let res: Response
+  let res: Response;
   try {
-    res = await fetch(url.toString())
+    res = await fetch(url.toString());
   } catch (err) {
     throw new ChallengeError(
       `Network error fetching challenge from ${webAuthEndpoint}: ${String(err)}`,
       'FETCH_FAILED'
-    )
+    );
   }
 
   if (!res.ok) {
     throw new ChallengeError(
       `Challenge fetch failed: HTTP ${res.status} from ${webAuthEndpoint}`,
       'FETCH_FAILED'
-    )
+    );
   }
 
-  const data = (await res.json()) as Record<string, unknown>
+  const data = (await res.json()) as Record<string, unknown>;
 
-  const transaction = data['transaction']
+  const transaction = data['transaction'];
   if (!transaction || typeof transaction !== 'string') {
     throw new ChallengeError(
       `Missing "transaction" field in challenge response from ${webAuthEndpoint}`,
       'MISSING_FIELD'
-    )
+    );
   }
 
-  const network_passphrase = data['network_passphrase']
+  const network_passphrase = data['network_passphrase'];
   if (!network_passphrase || typeof network_passphrase !== 'string') {
     throw new ChallengeError(
       `Missing "network_passphrase" field in challenge response from ${webAuthEndpoint}`,
       'MISSING_FIELD'
-    )
+    );
   }
 
   if (network_passphrase !== Networks.PUBLIC) {
     throw new ChallengeError(
       `Challenge is for wrong network: "${network_passphrase}". Expected Stellar mainnet.`,
       'WRONG_NETWORK'
-    )
+    );
   }
 
-  let parsed: Transaction | FeeBumpTransaction
+  let parsed: Transaction | FeeBumpTransaction;
   try {
-    parsed = TransactionBuilder.fromXDR(transaction, network_passphrase)
+    parsed = TransactionBuilder.fromXDR(transaction, network_passphrase);
   } catch {
     throw new ChallengeError(
       `Challenge XDR is not parseable from ${webAuthEndpoint}`,
       'INVALID_XDR'
-    )
+    );
   }
 
-  return { transaction, network_passphrase, parsed }
+  return { transaction, network_passphrase, parsed };
 }
 
 // ─── Challenge fetch ──────────────────────────────────────────────────────────
@@ -131,35 +130,35 @@ export async function fetchChallenge(
   webAuthEndpoint: string,
   publicKey: string
 ): Promise<{ transaction: string; network_passphrase: string }> {
-  const url = new URL(webAuthEndpoint)
-  url.searchParams.set('account', publicKey)
+  const url = new URL(webAuthEndpoint);
+  url.searchParams.set('account', publicKey);
 
-  const res = await fetch(url.toString())
+  const res = await fetch(url.toString());
   if (!res.ok) {
-    throw new Error(`Challenge fetch failed: HTTP ${res.status} from ${webAuthEndpoint}`)
+    throw new Error(`Challenge fetch failed: HTTP ${res.status} from ${webAuthEndpoint}`);
   }
 
-  const data = (await res.json()) as Record<string, unknown>
+  const data = (await res.json()) as Record<string, unknown>;
 
-  const transaction = data['transaction']
+  const transaction = data['transaction'];
   if (!transaction || typeof transaction !== 'string') {
-    throw new Error(`Missing "transaction" field in challenge response from ${webAuthEndpoint}`)
+    throw new Error(`Missing "transaction" field in challenge response from ${webAuthEndpoint}`);
   }
 
-  const network_passphrase = data['network_passphrase']
+  const network_passphrase = data['network_passphrase'];
   if (!network_passphrase || typeof network_passphrase !== 'string') {
     throw new Error(
       `Missing "network_passphrase" field in challenge response from ${webAuthEndpoint}`
-    )
+    );
   }
 
   if (network_passphrase !== Networks.PUBLIC) {
     throw new Error(
       `Challenge is for wrong network: "${network_passphrase}". Expected Stellar mainnet.`
-    )
+    );
   }
 
-  return { transaction, network_passphrase }
+  return { transaction, network_passphrase };
 }
 
 // ─── Challenge signing ────────────────────────────────────────────────────────
@@ -168,14 +167,14 @@ export async function signChallenge(
   challengeXdr: string,
   networkPassphrase: string
 ): Promise<string> {
-  const { signTransaction } = await import('@stellar/freighter-api')
-  const result = await signTransaction(challengeXdr, { networkPassphrase })
+  const { signTransaction } = await import('@stellar/freighter-api');
+  const result = await signTransaction(challengeXdr, { networkPassphrase });
 
   if (result.error) {
-    throw new UserRejectedError()
+    throw new UserRejectedError();
   }
 
-  return result.signedTxXdr
+  return result.signedTxXdr;
 }
 
 // ─── JWT exchange ─────────────────────────────────────────────────────────────
@@ -188,51 +187,48 @@ export async function submitChallenge(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ transaction: signedXdr }),
-  })
+  });
 
   if (!res.ok) {
     throw new Sep10AuthError(
       `JWT exchange failed: HTTP ${res.status} from ${webAuthEndpoint}`,
       res.status
-    )
+    );
   }
 
-  const data = (await res.json()) as Record<string, unknown>
-  const token = data['token']
+  const data = (await res.json()) as Record<string, unknown>;
+  const token = data['token'];
 
   if (!token || typeof token !== 'string') {
-    throw new Error(`Missing "token" field in JWT response from ${webAuthEndpoint}`)
+    throw new Error(`Missing "token" field in JWT response from ${webAuthEndpoint}`);
   }
 
-  const exp = decodeJwtExp(token)
-  const nowSeconds = Math.floor(Date.now() / 1000)
+  const exp = decodeJwtExp(token);
+  const nowSeconds = Math.floor(Date.now() / 1000);
   if (exp <= nowSeconds) {
-    throw new Error(`JWT has already expired (exp: ${exp})`)
+    throw new Error(`JWT has already expired (exp: ${exp})`);
   }
 
-  return { token, expiresAt: new Date(exp * 1000) }
+  return { token, expiresAt: new Date(exp * 1000) };
 }
 
 // ─── Full auth orchestrator ───────────────────────────────────────────────────
 
-export async function authenticate(
-  anchor: ResolvedAnchor,
-  publicKey: string
-): Promise<Sep10Auth> {
-  const cached = getCachedJwt(anchor.homeDomain, publicKey)
-  if (cached) return cached
+export async function authenticate(anchor: ResolvedAnchor, publicKey: string): Promise<Sep10Auth> {
+  const cached = getCachedJwt(anchor.homeDomain, publicKey);
+  if (cached) return cached;
 
-  const webAuthEndpoint = anchor.WEB_AUTH_ENDPOINT
+  const webAuthEndpoint = anchor.WEB_AUTH_ENDPOINT;
   if (!webAuthEndpoint || !anchor.capabilities.sep10) {
-    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-10 authentication.`)
+    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-10 authentication.`);
   }
-  const { transaction, network_passphrase } = await fetchChallenge(webAuthEndpoint, publicKey)
-  const signedXdr = await signChallenge(transaction, network_passphrase)
-  const { token: jwt, expiresAt } = await submitChallenge(webAuthEndpoint, signedXdr)
+  const { transaction, network_passphrase } = await fetchChallenge(webAuthEndpoint, publicKey);
+  const signedXdr = await signChallenge(transaction, network_passphrase);
+  const { token: jwt, expiresAt } = await submitChallenge(webAuthEndpoint, signedXdr);
 
-  const auth: Sep10Auth = { jwt, anchorDomain: anchor.homeDomain, publicKey, expiresAt }
-  setCachedJwt(auth)
-  return auth
+  const auth: Sep10Auth = { jwt, anchorDomain: anchor.homeDomain, publicKey, expiresAt };
+  setCachedJwt(auth);
+  return auth;
 }
 
 /**
@@ -241,5 +237,5 @@ export async function authenticate(
  * re-runs the full sign flow.
  */
 export function invalidateSep10Token(anchorDomain: string, publicKey: string): void {
-  invalidateCachedJwt(anchorDomain, publicKey)
+  invalidateCachedJwt(anchorDomain, publicKey);
 }

--- a/lib/stellar/sep24-status-map.ts
+++ b/lib/stellar/sep24-status-map.ts
@@ -1,4 +1,4 @@
-import type { WithdrawStatus, WithdrawStatusValue } from '@/types'
+import type { WithdrawStatus, WithdrawStatusValue } from '@/types';
 
 /**
  * Maps every raw SEP-24 anchor status string to the canonical WithdrawStatus enum.
@@ -22,9 +22,9 @@ export const STATUS_MAP: Record<WithdrawStatusValue, WithdrawStatus> = {
   too_small: 'error',
   too_large: 'error',
   error: 'error',
-}
+};
 
 /** Converts a raw anchor status string into the canonical WithdrawStatus. */
 export function mapToCanonical(raw: WithdrawStatusValue): WithdrawStatus {
-  return STATUS_MAP[raw]
+  return STATUS_MAP[raw];
 }

--- a/lib/stellar/sep24.ts
+++ b/lib/stellar/sep24.ts
@@ -1,8 +1,17 @@
-import { SepError, parseSepErrorBody } from './errors'
-import { getTransferServer } from './sep1'
-import { getAnchorsByCorridorId, getCorridorById } from './anchors'
-import { computeTotalReceived } from '@/lib/utils'
-import type { Sep24FeeParams, AnchorRate, RateComparison, Sep24WithdrawRequest, Sep24WithdrawResponse, Sep24Transaction, WithdrawStatusValue, ResolvedAnchor } from '@/types'
+import { SepError, parseSepErrorBody } from './errors';
+import { getTransferServer } from './sep1';
+import { getAnchorsByCorridorId, getCorridorById } from './anchors';
+import { computeTotalReceived } from '@/lib/utils';
+import type {
+  Sep24FeeParams,
+  AnchorRate,
+  RateComparison,
+  Sep24WithdrawRequest,
+  Sep24WithdrawResponse,
+  Sep24Transaction,
+  WithdrawStatusValue,
+  ResolvedAnchor,
+} from '@/types';
 
 // ─── Transaction polling ──────────────────────────────────────────────────────
 
@@ -14,7 +23,7 @@ export const TERMINAL_STATES: ReadonlySet<WithdrawStatusValue> = new Set([
   'no_market',
   'too_small',
   'too_large',
-])
+]);
 
 const KNOWN_STATUSES = new Set<WithdrawStatusValue>([
   'incomplete',
@@ -31,13 +40,13 @@ const KNOWN_STATUSES = new Set<WithdrawStatusValue>([
   'no_market',
   'too_small',
   'too_large',
-])
+]);
 
 function normalizeStatus(raw: unknown): WithdrawStatusValue {
   if (typeof raw === 'string' && KNOWN_STATUSES.has(raw as WithdrawStatusValue)) {
-    return raw as WithdrawStatusValue
+    return raw as WithdrawStatusValue;
   }
-  return 'pending_external'
+  return 'pending_external';
 }
 
 /**
@@ -51,15 +60,16 @@ export async function getSep24Transaction(
 ): Promise<Sep24Transaction> {
   const res = await fetch(`${transferServer}/transaction?id=${transactionId}`, {
     headers: { Authorization: `Bearer ${jwt}` },
-  })
+  });
 
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
-    throw parseSepErrorBody(body, res.status)
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
+    throw parseSepErrorBody(body, res.status);
   }
 
-  const data = (await res.json()) as { transaction?: Record<string, unknown> }
-  const tx = data.transaction ?? {}
+  const data = (await res.json()) as { transaction?: Record<string, unknown> };
+  const tx = data.transaction ?? {};
 
   return {
     id: String(tx['id'] ?? transactionId),
@@ -68,45 +78,52 @@ export async function getSep24Transaction(
     ...(tx['amount_in'] !== undefined && { amountIn: tx['amount_in'] as string }),
     ...(tx['amount_in_asset'] !== undefined && { amountInAsset: tx['amount_in_asset'] as string }),
     ...(tx['amount_out'] !== undefined && { amountOut: tx['amount_out'] as string }),
-    ...(tx['amount_out_asset'] !== undefined && { amountOutAsset: tx['amount_out_asset'] as string }),
-    ...(tx['amount_fee'] !== undefined || (tx['fee_details'] as { total?: string })?.total !== undefined) && { 
-      amountFee: (tx['amount_fee'] ?? (tx['fee_details'] as { total?: string })?.total) as string 
-    },
-    ...(tx['stellar_transaction_id'] !== undefined && { stellarTransactionId: tx['stellar_transaction_id'] as string }),
-    ...(tx['external_transaction_id'] !== undefined && { externalTransactionId: tx['external_transaction_id'] as string }),
-  }
+    ...(tx['amount_out_asset'] !== undefined && {
+      amountOutAsset: tx['amount_out_asset'] as string,
+    }),
+    ...((tx['amount_fee'] !== undefined ||
+      (tx['fee_details'] as { total?: string })?.total !== undefined) && {
+      amountFee: (tx['amount_fee'] ?? (tx['fee_details'] as { total?: string })?.total) as string,
+    }),
+    ...(tx['stellar_transaction_id'] !== undefined && {
+      stellarTransactionId: tx['stellar_transaction_id'] as string,
+    }),
+    ...(tx['external_transaction_id'] !== undefined && {
+      externalTransactionId: tx['external_transaction_id'] as string,
+    }),
+  };
 }
 
 // ─── Typed errors ─────────────────────────────────────────────────────────────
 
 export class Sep24WithdrawError extends Error {
-  readonly status: number
-  readonly anchorBody: unknown
+  readonly status: number;
+  readonly anchorBody: unknown;
 
   constructor(status: number, anchorBody: unknown, transferServer: string) {
-    super(`Withdraw initiation failed: HTTP ${status} from ${transferServer}`)
-    this.name = 'Sep24WithdrawError'
-    this.status = status
-    this.anchorBody = anchorBody
+    super(`Withdraw initiation failed: HTTP ${status} from ${transferServer}`);
+    this.name = 'Sep24WithdrawError';
+    this.status = status;
+    this.anchorBody = anchorBody;
   }
 }
 
 export class AnchorRateError extends Error {
-  readonly anchorId: string
+  readonly anchorId: string;
 
   constructor(anchorId: string, message: string) {
-    super(message)
-    this.name = 'AnchorRateError'
-    this.anchorId = anchorId
+    super(message);
+    this.name = 'AnchorRateError';
+    this.anchorId = anchorId;
   }
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function parseRate(raw: unknown): number {
-  if (raw === undefined || raw === null) return 0
-  const num = Number(String(raw).replace(/,/g, ''))
-  return Number.isFinite(num) ? num : 0
+  if (raw === undefined || raw === null) return 0;
+  const num = Number(String(raw).replace(/,/g, ''));
+  return Number.isFinite(num) ? num : 0;
 }
 
 /**
@@ -119,26 +136,27 @@ export function resolveAssetParams(
   assetCode: string,
   assetIssuer?: string
 ): Record<string, string> {
-  const fullAsset = assetCode === 'XLM' && !assetIssuer ? 'stellar:native' : `stellar:${assetCode}:${assetIssuer}`
+  const fullAsset =
+    assetCode === 'XLM' && !assetIssuer ? 'stellar:native' : `stellar:${assetCode}:${assetIssuer}`;
   if (info && info[operation] && info[operation][fullAsset]) {
-    return { asset: fullAsset }
+    return { asset: fullAsset };
   }
-  const params: Record<string, string> = { asset_code: assetCode }
-  if (assetIssuer) params.asset_issuer = assetIssuer
-  return params
+  const params: Record<string, string> = { asset_code: assetCode };
+  if (assetIssuer) params.asset_issuer = assetIssuer;
+  return params;
 }
 
 // ─── GET /fee (low-level, takes transferServer directly) ─────────────────────
 
-export type Sep24FeeResult = { ok: true; fee: number } | { ok: false; reason: 'unsupported' }
+export type Sep24FeeResult = { ok: true; fee: number } | { ok: false; reason: 'unsupported' };
 
 async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
-  const controller = new AbortController()
-  const id = setTimeout(() => controller.abort(), ms)
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), ms);
   try {
-    return await fetch(url, { signal: controller.signal })
+    return await fetch(url, { signal: controller.signal });
   } finally {
-    clearTimeout(id)
+    clearTimeout(id);
   }
 }
 
@@ -148,67 +166,68 @@ async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
  * Returns { ok: false, reason: 'unsupported' } for 404s without throwing.
  */
 export async function getSep24Fee(params: {
-  transferServer: string
-  assetCode: string
-  assetIssuer: string
-  amount: string
-  type: string
+  transferServer: string;
+  assetCode: string;
+  assetIssuer: string;
+  amount: string;
+  type: string;
 }): Promise<Sep24FeeResult> {
-  const url = new URL(`${params.transferServer}/fee`)
-  url.searchParams.set('operation', 'withdraw')
-  
-  const info = await getSep24Info(params.transferServer).catch(() => null)
-  const assetParams = resolveAssetParams(info, 'withdraw', params.assetCode, params.assetIssuer)
+  const url = new URL(`${params.transferServer}/fee`);
+  url.searchParams.set('operation', 'withdraw');
+
+  const info = await getSep24Info(params.transferServer).catch(() => null);
+  const assetParams = resolveAssetParams(info, 'withdraw', params.assetCode, params.assetIssuer);
   for (const [k, v] of Object.entries(assetParams)) {
-    url.searchParams.set(k, v)
+    url.searchParams.set(k, v);
   }
 
-  url.searchParams.set('amount', params.amount)
-  url.searchParams.set('type', params.type)
-  const urlStr = url.toString()
+  url.searchParams.set('amount', params.amount);
+  url.searchParams.set('type', params.type);
+  const urlStr = url.toString();
 
-  let res: Response
+  let res: Response;
   try {
-    res = await fetchWithTimeout(urlStr, 5_000)
+    res = await fetchWithTimeout(urlStr, 5_000);
   } catch {
-    res = await fetchWithTimeout(urlStr, 5_000)
+    res = await fetchWithTimeout(urlStr, 5_000);
   }
 
-  if (res.status === 404) return { ok: false, reason: 'unsupported' }
+  if (res.status === 404) return { ok: false, reason: 'unsupported' };
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
-    throw parseSepErrorBody(body, res.status)
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
+    throw parseSepErrorBody(body, res.status);
   }
 
-  const data = (await res.json()) as Record<string, unknown>
-  const fee = Number(data['fee'])
-  return Number.isFinite(fee) ? { ok: true, fee } : { ok: false, reason: 'unsupported' }
+  const data = (await res.json()) as Record<string, unknown>;
+  const fee = Number(data['fee']);
+  return Number.isFinite(fee) ? { ok: true, fee } : { ok: false, reason: 'unsupported' };
 }
 
 // ─── GET /info (with 5-minute in-memory cache) ────────────────────────────────
 
 export interface Sep24AssetInfo {
-  enabled: boolean
-  min_amount?: number
-  max_amount?: number
-  fee_fixed?: number
-  fee_percent?: number
-  authentication_required?: boolean
+  enabled: boolean;
+  min_amount?: number;
+  max_amount?: number;
+  fee_fixed?: number;
+  fee_percent?: number;
+  authentication_required?: boolean;
 }
 
 export interface Sep24InfoResponse {
-  deposit: Record<string, Sep24AssetInfo>
-  withdraw: Record<string, Sep24AssetInfo>
-  fee: { enabled: boolean; authentication_required?: boolean }
-  transaction: { enabled: boolean; authentication_required?: boolean }
-  transactions: { enabled: boolean; authentication_required?: boolean }
+  deposit: Record<string, Sep24AssetInfo>;
+  withdraw: Record<string, Sep24AssetInfo>;
+  fee: { enabled: boolean; authentication_required?: boolean };
+  transaction: { enabled: boolean; authentication_required?: boolean };
+  transactions: { enabled: boolean; authentication_required?: boolean };
 }
 
-const INFO_CACHE = new Map<string, { data: Sep24InfoResponse; expiresAt: number }>()
-const INFO_CACHE_TTL_MS = 5 * 60 * 1_000
+const INFO_CACHE = new Map<string, { data: Sep24InfoResponse; expiresAt: number }>();
+const INFO_CACHE_TTL_MS = 5 * 60 * 1_000;
 
 export function _clearInfoCache(): void {
-  INFO_CACHE.clear()
+  INFO_CACHE.clear();
 }
 
 /**
@@ -216,27 +235,38 @@ export function _clearInfoCache(): void {
  * Results are cached per transfer server for 5 minutes.
  */
 export async function getSep24Info(transferServer: string): Promise<Sep24InfoResponse> {
-  const cached = INFO_CACHE.get(transferServer)
-  if (cached && cached.expiresAt > Date.now()) return cached.data
+  const cached = INFO_CACHE.get(transferServer);
+  if (cached && cached.expiresAt > Date.now()) return cached.data;
 
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test' && !process.env.TEST_SEP24_INFO) {
-    return { deposit: {}, withdraw: {}, fee: { enabled: true }, transaction: { enabled: true }, transactions: { enabled: true } } as Sep24InfoResponse;
+  if (
+    typeof process !== 'undefined' &&
+    process.env.NODE_ENV === 'test' &&
+    !process.env.TEST_SEP24_INFO
+  ) {
+    return {
+      deposit: {},
+      withdraw: {},
+      fee: { enabled: true },
+      transaction: { enabled: true },
+      transactions: { enabled: true },
+    } as Sep24InfoResponse;
   }
 
-  const res = await fetch(`${transferServer}/info`)
+  const res = await fetch(`${transferServer}/info`);
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
     throw new SepError(
       `Failed to fetch /info from ${transferServer}: HTTP ${res.status}`,
       `INFO_FETCH_FAILED`,
       res.status,
-      body,
-    )
+      body
+    );
   }
 
-  const data = (await res.json()) as Sep24InfoResponse
-  INFO_CACHE.set(transferServer, { data, expiresAt: Date.now() + INFO_CACHE_TTL_MS })
-  return data
+  const data = (await res.json()) as Sep24InfoResponse;
+  INFO_CACHE.set(transferServer, { data, expiresAt: Date.now() + INFO_CACHE_TTL_MS });
+  return data;
 }
 
 // ─── Fee fetching ─────────────────────────────────────────────────────────────
@@ -248,61 +278,67 @@ export async function getSep24Info(transferServer: string): Promise<Sep24InfoRes
 export async function fetchAnchorFee(
   params: Sep24FeeParams
 ): Promise<{ fee: string; anchorDomain: string; exchangeRate: number }> {
-  const transferServer = await getTransferServer(params.anchorDomain)
+  const transferServer = await getTransferServer(params.anchorDomain);
   if (!transferServer) {
-    throw new Error(`Anchor "${params.anchorDomain}" does not support SEP-24.`)
+    throw new Error(`Anchor "${params.anchorDomain}" does not support SEP-24.`);
   }
 
-  const url = new URL(`${transferServer}/fee`)
-  url.searchParams.set('operation', params.operation)
+  const url = new URL(`${transferServer}/fee`);
+  url.searchParams.set('operation', params.operation);
 
-  const info = await getSep24Info(transferServer).catch(() => null)
-  const assetParams = resolveAssetParams(info, params.operation, params.assetCode, params.assetIssuer)
+  const info = await getSep24Info(transferServer).catch(() => null);
+  const assetParams = resolveAssetParams(
+    info,
+    params.operation,
+    params.assetCode,
+    params.assetIssuer
+  );
   for (const [k, v] of Object.entries(assetParams)) {
-    url.searchParams.set(k, v)
+    url.searchParams.set(k, v);
   }
 
-  url.searchParams.set('amount', params.amount)
-  url.searchParams.set('type', params.type)
+  url.searchParams.set('amount', params.amount);
+  url.searchParams.set('type', params.type);
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
 
-  let res: Response
+  let res: Response;
   try {
-    res = await fetch(url.toString(), { signal: controller.signal })
+    res = await fetch(url.toString(), { signal: controller.signal });
   } catch (err) {
     if ((err as Error).name === 'AbortError') {
-      throw new Error(`Request to ${params.anchorDomain} timed out after 10 seconds`)
+      throw new Error(`Request to ${params.anchorDomain} timed out after 10 seconds`);
     }
-    throw err
+    throw err;
   } finally {
-    clearTimeout(timeout)
+    clearTimeout(timeout);
   }
 
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
     throw new SepError(
       `HTTP ${res.status} from ${params.anchorDomain} fee endpoint`,
       `FEE_FETCH_FAILED`,
       res.status,
-      body,
-    )
+      body
+    );
   }
 
-  const data = (await res.json()) as Record<string, unknown>
+  const data = (await res.json()) as Record<string, unknown>;
 
-  const fee = data['fee']
+  const fee = data['fee'];
   if (fee === undefined || fee === null || isNaN(Number(fee))) {
     throw new Error(
       `Invalid fee response from ${params.anchorDomain}: missing or non-numeric "fee" field`
-    )
+    );
   }
 
-  const rateRaw = data['price'] ?? data['exchange_rate'] ?? data['rate']
-  const exchangeRate = parseRate(rateRaw)
+  const rateRaw = data['price'] ?? data['exchange_rate'] ?? data['rate'];
+  const exchangeRate = parseRate(rateRaw);
 
-  return { fee: String(fee), anchorDomain: params.anchorDomain, exchangeRate }
+  return { fee: String(fee), anchorDomain: params.anchorDomain, exchangeRate };
 }
 
 /**
@@ -313,8 +349,8 @@ export async function fetchAllAnchorFees(
   amount: string,
   corridorId: string
 ): Promise<PromiseSettledResult<AnchorRate>[]> {
-  const anchors = getAnchorsByCorridorId(corridorId)
-  const corridor = getCorridorById(corridorId)
+  const anchors = getAnchorsByCorridorId(corridorId);
+  const corridor = getCorridorById(corridorId);
 
   return Promise.allSettled(
     anchors.map(async (anchor): Promise<AnchorRate> => {
@@ -325,16 +361,16 @@ export async function fetchAllAnchorFees(
         assetIssuer: anchor.assetIssuer,
         amount,
         type: 'bank_account',
-      })
+      });
 
-      const feeNum = Number(fee)
-      const amountNum = Number(amount)
+      const feeNum = Number(fee);
+      const amountNum = Number(amount);
 
       if (exchangeRate <= 0) {
         throw new AnchorRateError(
           anchor.id,
           `${anchor.name} returned a zero or missing exchange rate for ${corridor.to} — rate cannot be derived`
-        )
+        );
       }
 
       return {
@@ -347,9 +383,9 @@ export async function fetchAllAnchorFees(
         totalReceived: computeTotalReceived(amountNum, feeNum, 0, exchangeRate),
         source: 'sep24-fee' as const,
         updatedAt: new Date(),
-      }
+      };
     })
-  )
+  );
 }
 
 /**
@@ -362,15 +398,15 @@ export function computeRateComparison(
 ): RateComparison {
   const rates = results
     .filter((r): r is PromiseFulfilledResult<AnchorRate> => r.status === 'fulfilled')
-    .map((r) => r.value)
+    .map((r) => r.value);
 
   if (rates.length === 0) {
-    return { corridorId, rates: [], bestRateId: '' }
+    return { corridorId, rates: [], bestRateId: '' };
   }
 
-  const best = rates.reduce((a, b) => ((b.totalReceived ?? 0) > (a.totalReceived ?? 0) ? b : a))
+  const best = rates.reduce((a, b) => ((b.totalReceived ?? 0) > (a.totalReceived ?? 0) ? b : a));
 
-  return { corridorId, rates, bestRateId: best.anchorId }
+  return { corridorId, rates, bestRateId: best.anchorId };
 }
 
 // ─── Withdraw interactive flow ────────────────────────────────────────────────
@@ -383,15 +419,15 @@ export async function initiateWithdraw(
   anchor: ResolvedAnchor,
   params: Sep24WithdrawRequest
 ): Promise<Sep24WithdrawResponse> {
-  const { jwt, assetCode, assetIssuer, amount, account } = params
-  const transferServer = anchor.TRANSFER_SERVER_SEP0024
+  const { jwt, assetCode, assetIssuer, amount, account } = params;
+  const transferServer = anchor.TRANSFER_SERVER_SEP0024;
 
   if (!transferServer || !anchor.capabilities.sep24) {
-    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-24 withdrawals.`)
+    throw new Error(`Anchor "${anchor.homeDomain}" does not support SEP-24 withdrawals.`);
   }
 
-  const info = await getSep24Info(transferServer).catch(() => null)
-  const assetParams = resolveAssetParams(info, 'withdraw', assetCode, assetIssuer)
+  const info = await getSep24Info(transferServer).catch(() => null);
+  const assetParams = resolveAssetParams(info, 'withdraw', assetCode, assetIssuer);
 
   const res = await fetch(`${transferServer}/transactions/withdraw/interactive`, {
     method: 'POST',
@@ -405,35 +441,36 @@ export async function initiateWithdraw(
       account,
       lang: 'en',
     }),
-  })
+  });
 
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
-    throw new Sep24WithdrawError(res.status, body, transferServer)
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
+    throw new Sep24WithdrawError(res.status, body, transferServer);
   }
 
-  const data = (await res.json()) as Record<string, unknown>
+  const data = (await res.json()) as Record<string, unknown>;
 
   if (data['type'] !== 'interactive_customer_info_needed') {
     throw new Error(
       `Unexpected response type from anchor: "${data['type']}". ` +
         `Expected "interactive_customer_info_needed".`
-    )
+    );
   }
 
   if (!data['url'] || typeof data['url'] !== 'string') {
-    throw new Error('Anchor withdraw response is missing the "url" field')
+    throw new Error('Anchor withdraw response is missing the "url" field');
   }
 
   if (!data['id'] || typeof data['id'] !== 'string') {
-    throw new Error('Anchor withdraw response is missing the "id" field')
+    throw new Error('Anchor withdraw response is missing the "id" field');
   }
 
   return {
     type: 'interactive_customer_info_needed',
     url: data['url'] as string,
     id: data['id'] as string,
-  }
+  };
 }
 
 /**
@@ -443,49 +480,49 @@ export async function initiateWithdraw(
  */
 export function openWithdrawPopup(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const width = 600
-    const height = 700
-    const left = Math.round(window.screen.width / 2 - width / 2)
-    const top = Math.round(window.screen.height / 2 - height / 2)
+    const width = 600;
+    const height = 700;
+    const left = Math.round(window.screen.width / 2 - width / 2);
+    const top = Math.round(window.screen.height / 2 - height / 2);
 
     const popup = window.open(
       url,
       'stellar_anchor_kyc',
       `width=${width},height=${height},left=${left},top=${top}`
-    )
+    );
 
     if (!popup) {
-      reject(new Error('Failed to open popup. Check that popups are not blocked.'))
-      return
+      reject(new Error('Failed to open popup. Check that popups are not blocked.'));
+      return;
     }
 
-    let resolved = false
+    let resolved = false;
 
     const onMessage = (event: MessageEvent) => {
       if (event.data?.type === 'stellar_transaction_created') {
-        cleanup()
-        resolve(event.data.transaction_id as string)
+        cleanup();
+        resolve(event.data.transaction_id as string);
       } else if (event.data?.type === 'stellar_cancel') {
-        cleanup()
-        reject(new Error('User cancelled the transaction'))
+        cleanup();
+        reject(new Error('User cancelled the transaction'));
       }
-    }
+    };
 
     const pollInterval = setInterval(() => {
       if (popup.closed && !resolved) {
-        cleanup()
-        reject(new Error('Popup was closed'))
+        cleanup();
+        reject(new Error('Popup was closed'));
       }
-    }, 500)
+    }, 500);
 
     function cleanup() {
-      resolved = true
-      clearInterval(pollInterval)
-      window.removeEventListener('message', onMessage)
+      resolved = true;
+      clearInterval(pollInterval);
+      window.removeEventListener('message', onMessage);
     }
 
-    window.addEventListener('message', onMessage)
-  })
+    window.addEventListener('message', onMessage);
+  });
 }
 
 /**
@@ -499,30 +536,31 @@ export async function getWithdrawTransactionRecord(
 ): Promise<{ withdrawAnchorAccount: string; memo: string; memoType: string }> {
   const res = await fetch(`${transferServer}/transaction?id=${transactionId}`, {
     headers: { Authorization: `Bearer ${jwt}` },
-  })
+  });
 
   if (!res.ok) {
-    const body: unknown = typeof res.json === 'function' ? await res.json().catch(() => null) : null
+    const body: unknown =
+      typeof res.json === 'function' ? await res.json().catch(() => null) : null;
     throw new SepError(
       `Failed to fetch transaction record: HTTP ${res.status}`,
       `TRANSACTION_RECORD_FAILED`,
       res.status,
-      body,
-    )
+      body
+    );
   }
 
-  const data = (await res.json()) as { transaction?: Record<string, unknown> }
-  const tx = data.transaction
+  const data = (await res.json()) as { transaction?: Record<string, unknown> };
+  const tx = data.transaction;
 
   if (!tx?.['withdraw_anchor_account'] || typeof tx['withdraw_anchor_account'] !== 'string') {
     throw new Error(
       `Transaction record is missing "withdraw_anchor_account". Cannot build payment.`
-    )
+    );
   }
 
   return {
     withdrawAnchorAccount: tx['withdraw_anchor_account'] as string,
     memo: (tx['memo'] as string) ?? '',
     memoType: (tx['memo_type'] as string) ?? 'text',
-  }
+  };
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,9 +8,9 @@ export function computeTotalReceived(
   feePercent: number,
   exchangeRate: number
 ): number {
-  const afterFlat = Math.max(0, amount - fee)
-  const afterPercent = afterFlat * (1 - feePercent / 100)
-  return afterPercent * exchangeRate
+  const afterFlat = Math.max(0, amount - fee);
+  const afterPercent = afterFlat * (1 - feePercent / 100);
+  return afterPercent * exchangeRate;
 }
 
 /**
@@ -23,9 +23,9 @@ export function formatCurrency(amount: number, currencyCode: string): string {
       style: 'currency',
       currency: currencyCode,
       maximumFractionDigits: 2,
-    }).format(amount)
+    }).format(amount);
   } catch {
-    return `${currencyCode} ${amount.toFixed(2)}`
+    return `${currencyCode} ${amount.toFixed(2)}`;
   }
 }
 
@@ -34,8 +34,8 @@ export function formatCurrency(amount: number, currencyCode: string): string {
  * e.g. formatRate(1580, 'USDC', 'NGN') → '1 USDC = 1,580 NGN'
  */
 export function formatRate(rate: number, from: string, to: string): string {
-  const formatted = new Intl.NumberFormat('en-US', { maximumFractionDigits: 4 }).format(rate)
-  return `1 ${from} = ${formatted} ${to}`
+  const formatted = new Intl.NumberFormat('en-US', { maximumFractionDigits: 4 }).format(rate);
+  return `1 ${from} = ${formatted} ${to}`;
 }
 
 /**
@@ -43,19 +43,19 @@ export function formatRate(rate: number, from: string, to: string): string {
  * e.g. 'just now', '2 minutes ago', '1 hour ago'
  */
 export function timeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
 
-  if (seconds < 10) return 'just now'
-  if (seconds < 60) return `${seconds} seconds ago`
+  if (seconds < 10) return 'just now';
+  if (seconds < 60) return `${seconds} seconds ago`;
 
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return minutes === 1 ? '1 minute ago' : `${minutes} minutes ago`
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return minutes === 1 ? '1 minute ago' : `${minutes} minutes ago`;
 
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return hours === 1 ? '1 hour ago' : `${hours} hours ago`
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
 
-  const days = Math.floor(hours / 24)
-  return days === 1 ? '1 day ago' : `${days} days ago`
+  const days = Math.floor(hours / 24);
+  return days === 1 ? '1 day ago' : `${days} days ago`;
 }
 
 /**
@@ -63,20 +63,20 @@ export function timeAgo(date: Date): string {
  * e.g. 'GABCD...WXYZ' (first 4 + last 4 characters)
  */
 export function truncatePublicKey(key: string): string {
-  if (key.length <= 8) return key
-  return `${key.slice(0, 4)}...${key.slice(-4)}`
+  if (key.length <= 8) return key;
+  return `${key.slice(0, 4)}...${key.slice(-4)}`;
 }
 
 /**
  * Returns true if the given date is in the past.
  */
 export function isExpired(expiresAt: Date): boolean {
-  return expiresAt.getTime() < Date.now()
+  return expiresAt.getTime() < Date.now();
 }
 
 /**
  * Returns a promise that resolves after the given number of milliseconds.
  */
 export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@commitlint/cli": "^21.0.2",
+        "@commitlint/config-conventional": "^21.0.2",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -34,6 +37,7 @@
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.7.0",
         "jsdom": "^29.0.2",
+        "lint-staged": "^17.0.7",
         "msw": "^2.13.2",
         "prettier": "^3.8.2",
         "tailwindcss": "^4",
@@ -373,6 +377,471 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.2.tgz",
+      "integrity": "sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^21.0.1",
+        "@commitlint/lint": "^21.0.2",
+        "@commitlint/load": "^21.0.2",
+        "@commitlint/read": "^21.0.2",
+        "@commitlint/types": "^21.0.1",
+        "tinyexec": "^1.0.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.2.tgz",
+      "integrity": "sha512-P/ZRhryQmkj0Z0dY9FOoRwe3xkwJyyAdtXwt01NT2kuZttcG2CNYp1q5Ci3u+nDT2jcbJRw2kt13Czl1qKNPfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz",
+      "integrity": "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz",
+      "integrity": "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "es-toolkit": "^1.46.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz",
+      "integrity": "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.2.tgz",
+      "integrity": "sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.2.tgz",
+      "integrity": "sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^21.0.2",
+        "@commitlint/parse": "^21.0.2",
+        "@commitlint/rules": "^21.0.2",
+        "@commitlint/types": "^21.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.2.tgz",
+      "integrity": "sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
+        "is-plain-obj": "^4.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz",
+      "integrity": "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.2.tgz",
+      "integrity": "sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.2.tgz",
+      "integrity": "sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^21.0.2",
+        "@commitlint/types": "^21.0.1",
+        "git-raw-commits": "^5.0.0",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz",
+      "integrity": "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "es-toolkit": "^1.46.0",
+        "global-directory": "^5.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.2.tgz",
+      "integrity": "sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^21.0.1",
+        "@commitlint/message": "^21.0.2",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz",
+      "integrity": "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^6.3.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@conventional-changelog/git-client/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1651,6 +2120,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -1963,6 +2448,35 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3322,6 +3836,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3381,6 +3911,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -3857,6 +4394,85 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3956,12 +4572,66 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3982,6 +4652,51 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cross-spawn": {
@@ -4218,6 +4933,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4271,6 +4999,39 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -4453,6 +5214,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4933,6 +5705,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
@@ -5025,6 +5804,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -5245,6 +6041,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5313,6 +6122,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5324,6 +6150,22 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globals": {
@@ -5585,6 +6427,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5617,6 +6469,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -5884,6 +6743,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -6178,6 +7060,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6529,6 +7418,145 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged": {
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
+      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6551,6 +7579,144 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6621,6 +7787,19 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6664,6 +7843,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -7043,6 +8235,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7131,6 +8339,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -7202,6 +8429,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7528,6 +8801,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
@@ -7545,6 +8835,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -7960,6 +9257,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8020,6 +9363,16 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -8316,9 +9669,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9470,6 +10823,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.0.2",
+    "@commitlint/config-conventional": "^21.0.2",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -54,6 +57,7 @@
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.7.0",
     "jsdom": "^29.0.2",
+    "lint-staged": "^17.0.7",
     "msw": "^2.13.2",
     "prettier": "^3.8.2",
     "tailwindcss": "^4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  ...(process.env.CI ? { workers: 1 } : {}),
   reporter: 'html',
   use: {
     baseURL: process.env.BASE_URL ?? 'http://localhost:3000',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -23,4 +23,4 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
-})
+});

--- a/scripts/create-milestones.mjs
+++ b/scripts/create-milestones.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 // scripts/create-milestones.mjs
 //
 // Create (or update) the canonical Stellar Intel milestone set via the GitHub
@@ -27,18 +28,15 @@ const MILESTONES = [
   },
   {
     title: 'v1.1 Hardening',
-    description:
-      'SEP-38 quoting, replay protection, error surfaces, telemetry. Issues #071–#110.',
+    description: 'SEP-38 quoting, replay protection, error surfaces, telemetry. Issues #071–#110.',
   },
   {
     title: 'v1.2 Router + Seeds',
-    description:
-      'Multi-anchor solver, seeded rate data, composite scoring. Issues #111–#140.',
+    description: 'Multi-anchor solver, seeded rate data, composite scoring. Issues #111–#140.',
   },
   {
     title: 'v1.3 Polish',
-    description:
-      'UI polish, accessibility, bundle budget, release gate for v1. Issues #141–#150.',
+    description: 'UI polish, accessibility, bundle budget, release gate for v1. Issues #141–#150.',
   },
   {
     title: 'v2 Observable',
@@ -52,8 +50,7 @@ const MILESTONES = [
   },
   {
     title: 'v4 Universal',
-    description:
-      'SDK + MCP GA + embeddable widget for third-party wallets and dapps.',
+    description: 'SDK + MCP GA + embeddable widget for third-party wallets and dapps.',
   },
   {
     title: 'v5 Institutional',

--- a/tests/WalletButton.spec.tsx
+++ b/tests/WalletButton.spec.tsx
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { WalletButton } from '@/components/ui/WalletButton'
-import * as useFreighterModule from '@/hooks/useFreighter'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WalletButton } from '@/components/ui/WalletButton';
+import * as useFreighterModule from '@/hooks/useFreighter';
 
-vi.mock('@/hooks/useFreighter')
+vi.mock('@/hooks/useFreighter');
 
-const mockUseFreighter = vi.mocked(useFreighterModule.useFreighter)
+const mockUseFreighter = vi.mocked(useFreighterModule.useFreighter);
 
 const base = {
   isInstalled: false,
@@ -15,49 +15,49 @@ const base = {
   error: null,
   connect: vi.fn(),
   disconnect: vi.fn(),
-}
+};
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => vi.clearAllMocks());
 
 // ─── State 1: not-detected ────────────────────────────────────────────────────
 
 describe('WalletButton — not-detected state', () => {
   it('renders "Install Freighter" when the extension is not installed', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
-    render(<WalletButton />)
-    expect(screen.getByText('Install Freighter')).toBeInTheDocument()
-  })
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false });
+    render(<WalletButton />);
+    expect(screen.getByText('Install Freighter')).toBeInTheDocument();
+  });
 
   it('"Install Freighter" is a link to freighter.app', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
-    render(<WalletButton />)
-    const link = screen.getByRole('link', { name: 'Install Freighter' })
-    expect(link).toHaveAttribute('href', 'https://freighter.app')
-  })
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false });
+    render(<WalletButton />);
+    const link = screen.getByRole('link', { name: 'Install Freighter' });
+    expect(link).toHaveAttribute('href', 'https://freighter.app');
+  });
 
   it('does not render "Connect Wallet" in not-detected state', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
-    render(<WalletButton />)
-    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument()
-  })
-})
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false });
+    render(<WalletButton />);
+    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument();
+  });
+});
 
 // ─── State 2: disconnected ────────────────────────────────────────────────────
 
 describe('WalletButton — disconnected state', () => {
   it('renders "Connect Wallet" when installed but not connected', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false })
-    render(<WalletButton />)
-    expect(screen.getByText('Connect Wallet')).toBeInTheDocument()
-  })
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false });
+    render(<WalletButton />);
+    expect(screen.getByText('Connect Wallet')).toBeInTheDocument();
+  });
 
   it('clicking "Connect Wallet" calls connect()', () => {
-    const connect = vi.fn()
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false, connect })
-    render(<WalletButton />)
-    fireEvent.click(screen.getByText('Connect Wallet'))
-    expect(connect).toHaveBeenCalledOnce()
-  })
+    const connect = vi.fn();
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false, connect });
+    render(<WalletButton />);
+    fireEvent.click(screen.getByText('Connect Wallet'));
+    expect(connect).toHaveBeenCalledOnce();
+  });
 
   it('shows an error message when the hook exposes one', () => {
     mockUseFreighter.mockReturnValue({
@@ -65,17 +65,17 @@ describe('WalletButton — disconnected state', () => {
       isInstalled: true,
       isConnected: false,
       error: 'Connection rejected',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('Connection rejected')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('Connection rejected')).toBeInTheDocument();
+  });
 
   it('does not render "Install Freighter" in disconnected state', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false })
-    render(<WalletButton />)
-    expect(screen.queryByText('Install Freighter')).not.toBeInTheDocument()
-  })
-})
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false });
+    render(<WalletButton />);
+    expect(screen.queryByText('Install Freighter')).not.toBeInTheDocument();
+  });
+});
 
 // ─── State 3: wrong-network ───────────────────────────────────────────────────
 
@@ -87,10 +87,10 @@ describe('WalletButton — wrong-network state', () => {
       isConnected: true,
       network: 'TESTNET',
       publicKey: 'GABCDEF',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('Wrong network')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('Wrong network')).toBeInTheDocument();
+  });
 
   it('shows "Mainnet required" as the target network label', () => {
     mockUseFreighter.mockReturnValue({
@@ -98,10 +98,10 @@ describe('WalletButton — wrong-network state', () => {
       isInstalled: true,
       isConnected: true,
       network: 'TESTNET',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('Mainnet required')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('Mainnet required')).toBeInTheDocument();
+  });
 
   it('renders a "How to switch" link', () => {
     mockUseFreighter.mockReturnValue({
@@ -109,10 +109,10 @@ describe('WalletButton — wrong-network state', () => {
       isInstalled: true,
       isConnected: true,
       network: 'FUTURENET',
-    })
-    render(<WalletButton />)
-    expect(screen.getByRole('link', { name: 'How to switch' })).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByRole('link', { name: 'How to switch' })).toBeInTheDocument();
+  });
 
   it('does not render the public key in wrong-network state', () => {
     mockUseFreighter.mockReturnValue({
@@ -121,11 +121,11 @@ describe('WalletButton — wrong-network state', () => {
       isConnected: true,
       network: 'TESTNET',
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
-    })
-    render(<WalletButton />)
-    expect(screen.queryByText('GABC...6789')).not.toBeInTheDocument()
-  })
-})
+    });
+    render(<WalletButton />);
+    expect(screen.queryByText('GABC...6789')).not.toBeInTheDocument();
+  });
+});
 
 // ─── State 4: connected ───────────────────────────────────────────────────────
 
@@ -137,10 +137,10 @@ describe('WalletButton — connected state', () => {
       isConnected: true,
       network: 'PUBLIC',
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('GABC...6789')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('GABC...6789')).toBeInTheDocument();
+  });
 
   it('renders the "Mainnet" badge', () => {
     mockUseFreighter.mockReturnValue({
@@ -149,10 +149,10 @@ describe('WalletButton — connected state', () => {
       isConnected: true,
       network: 'PUBLIC',
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('Mainnet')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('Mainnet')).toBeInTheDocument();
+  });
 
   it('does not render "Wrong network" when correctly connected', () => {
     mockUseFreighter.mockReturnValue({
@@ -161,10 +161,10 @@ describe('WalletButton — connected state', () => {
       isConnected: true,
       network: 'PUBLIC',
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
-    })
-    render(<WalletButton />)
-    expect(screen.queryByText('Wrong network')).not.toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.queryByText('Wrong network')).not.toBeInTheDocument();
+  });
 
   it('does not render "Connect Wallet" when connected', () => {
     mockUseFreighter.mockReturnValue({
@@ -173,8 +173,8 @@ describe('WalletButton — connected state', () => {
       isConnected: true,
       network: 'PUBLIC',
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
-    })
-    render(<WalletButton />)
-    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument()
-  })
-})
+    });
+    render(<WalletButton />);
+    expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument();
+  });
+});

--- a/tests/anchors-discovery.spec.ts
+++ b/tests/anchors-discovery.spec.ts
@@ -1,46 +1,46 @@
-import { StellarToml } from '@stellar/stellar-sdk'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { discoverAnchorsForCorridor } from '@/lib/stellar/anchors'
-import { _clearTomlCache } from '@/lib/stellar/sep1'
+import { StellarToml } from '@stellar/stellar-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { discoverAnchorsForCorridor } from '@/lib/stellar/anchors';
+import { _clearTomlCache } from '@/lib/stellar/sep1';
 
 const tomlFor = (domain: string) => ({
   TRANSFER_SERVER_SEP0024: `https://${domain}/sep24`,
   WEB_AUTH_ENDPOINT: `https://${domain}/auth`,
   SIGNING_KEY: 'GABCDEF',
   CURRENCIES: [{ code: 'USDC' }],
-})
+});
 
 beforeEach(() => {
-  _clearTomlCache()
-  vi.restoreAllMocks()
-})
+  _clearTomlCache();
+  vi.restoreAllMocks();
+});
 
 describe('discoverAnchorsForCorridor', () => {
   it('returns successful usdc-ngn anchor resolutions with populated endpoints', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockImplementation((domain) => {
       if (domain === 'stellar.moneygram.com') {
-        return Promise.reject(new Error('not available'))
+        return Promise.reject(new Error('not available'));
       }
 
-      return Promise.resolve(tomlFor(String(domain)) as never)
-    })
+      return Promise.resolve(tomlFor(String(domain)) as never);
+    });
 
-    const result = await discoverAnchorsForCorridor('usdc-ngn')
-    const ids = result.map((anchor) => anchor.id)
+    const result = await discoverAnchorsForCorridor('usdc-ngn');
+    const ids = result.map((anchor) => anchor.id);
 
-    expect(ids).toEqual(['cowrie'])
+    expect(ids).toEqual(['cowrie']);
     expect(result).toEqual([
       expect.objectContaining({
         id: 'cowrie',
         TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
         WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
       }),
-    ])
-  })
+    ]);
+  });
 
   it('omits failed anchors instead of throwing', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('timeout'))
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('timeout'));
 
-    await expect(discoverAnchorsForCorridor('usdc-ngn')).resolves.toEqual([])
-  })
-})
+    await expect(discoverAnchorsForCorridor('usdc-ngn')).resolves.toEqual([]);
+  });
+});

--- a/tests/components/AmountInput.test.tsx
+++ b/tests/components/AmountInput.test.tsx
@@ -1,50 +1,50 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { AmountInput } from '@/components/ui/AmountInput'
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AmountInput } from '@/components/ui/AmountInput';
 
 describe('AmountInput', () => {
   it('calls onChange with the typed value', async () => {
-    vi.useFakeTimers()
-    const onChange = vi.fn()
-    render(<AmountInput value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '100' } })
-    
-    vi.advanceTimersByTime(250)
-    expect(onChange).toHaveBeenCalledWith('100')
-    vi.useRealTimers()
-  })
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    render(<AmountInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '100' } });
+
+    vi.advanceTimersByTime(250);
+    expect(onChange).toHaveBeenCalledWith('100');
+    vi.useRealTimers();
+  });
 
   it('does not call onChange for negative values', () => {
-    const onChange = vi.fn()
-    render(<AmountInput value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '-10' } })
-    expect(onChange).not.toHaveBeenCalled()
-  })
+    const onChange = vi.fn();
+    render(<AmountInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '-10' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
 
   it('renders the USDC label', () => {
-    render(<AmountInput value="100" onChange={vi.fn()} />)
-    expect(screen.getByText('USDC')).toBeInTheDocument()
-  })
+    render(<AmountInput value="100" onChange={vi.fn()} />);
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+  });
 
   it('renders the helper text', () => {
-    render(<AmountInput value="100" onChange={vi.fn()} />)
-    expect(screen.getByText(/Enter the amount of USDC/)).toBeInTheDocument()
-  })
-})
+    render(<AmountInput value="100" onChange={vi.fn()} />);
+    expect(screen.getByText(/Enter the amount of USDC/)).toBeInTheDocument();
+  });
+});
 
 describe('CorridorSelector', () => {
   it('renders all seven corridors as option elements', async () => {
-    const { CorridorSelector } = await import('@/components/ui/CorridorSelector')
-    render(<CorridorSelector value="usdc-ngn" onChange={vi.fn()} />)
-    const options = screen.getAllByRole('option')
-    expect(options).toHaveLength(7)
-  })
+    const { CorridorSelector } = await import('@/components/ui/CorridorSelector');
+    render(<CorridorSelector value="usdc-ngn" onChange={vi.fn()} />);
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(7);
+  });
 
   it('fires onChange with "usdc-ghs" when Ghana is selected', async () => {
-    const { CorridorSelector } = await import('@/components/ui/CorridorSelector')
-    const onChange = vi.fn()
-    render(<CorridorSelector value="usdc-ngn" onChange={onChange} />)
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'usdc-ghs' } })
-    expect(onChange).toHaveBeenCalledWith('usdc-ghs')
-  })
-})
+    const { CorridorSelector } = await import('@/components/ui/CorridorSelector');
+    const onChange = vi.fn();
+    render(<CorridorSelector value="usdc-ngn" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'usdc-ghs' } });
+    expect(onChange).toHaveBeenCalledWith('usdc-ghs');
+  });
+});

--- a/tests/components/ExecuteDrawer.test.tsx
+++ b/tests/components/ExecuteDrawer.test.tsx
@@ -1,49 +1,49 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { ExecuteDrawer } from '@/components/offramp/ExecuteDrawer'
-import type { AnchorRate } from '@/types'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ExecuteDrawer } from '@/components/offramp/ExecuteDrawer';
+import type { AnchorRate } from '@/types';
 
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 
 vi.mock('@/lib/stellar/sep10', () => ({
   authenticate: vi.fn(),
-}))
+}));
 
 vi.mock('@/lib/stellar/sep24', () => ({
   initiateWithdraw: vi.fn(),
   openWithdrawPopup: vi.fn(),
   getWithdrawTransactionRecord: vi.fn(),
-}))
+}));
 
 vi.mock('@/lib/stellar/sep1', () => ({
   getTransferServer: vi.fn(),
-}))
+}));
 
 vi.mock('@/lib/stellar/anchors', () => ({
   getAnchorById: vi.fn(),
   getResolvedAnchorById: vi.fn(),
-}))
+}));
 
 vi.mock('@/lib/stellar/horizon', () => ({
   buildWithdrawPayment: vi.fn(),
   signAndSubmitPayment: vi.fn(),
-}))
+}));
 
-import * as sep10 from '@/lib/stellar/sep10'
-import * as sep24 from '@/lib/stellar/sep24'
-import * as sep1 from '@/lib/stellar/sep1'
-import * as anchors from '@/lib/stellar/anchors'
-import * as horizon from '@/lib/stellar/horizon'
+import * as sep10 from '@/lib/stellar/sep10';
+import * as sep24 from '@/lib/stellar/sep24';
+import * as sep1 from '@/lib/stellar/sep1';
+import * as anchors from '@/lib/stellar/anchors';
+import * as horizon from '@/lib/stellar/horizon';
 
-const mockAuthenticate = vi.mocked(sep10.authenticate)
-const mockInitiateWithdraw = vi.mocked(sep24.initiateWithdraw)
-const mockOpenWithdrawPopup = vi.mocked(sep24.openWithdrawPopup)
-const mockGetWithdrawTransactionRecord = vi.mocked(sep24.getWithdrawTransactionRecord)
-const mockGetTransferServer = vi.mocked(sep1.getTransferServer)
-const mockGetAnchorById = vi.mocked(anchors.getAnchorById)
-const mockGetResolvedAnchorById = vi.mocked(anchors.getResolvedAnchorById)
-const mockBuildWithdrawPayment = vi.mocked(horizon.buildWithdrawPayment)
-const mockSignAndSubmitPayment = vi.mocked(horizon.signAndSubmitPayment)
+const mockAuthenticate = vi.mocked(sep10.authenticate);
+const mockInitiateWithdraw = vi.mocked(sep24.initiateWithdraw);
+const mockOpenWithdrawPopup = vi.mocked(sep24.openWithdrawPopup);
+const mockGetWithdrawTransactionRecord = vi.mocked(sep24.getWithdrawTransactionRecord);
+const _mockGetTransferServer = vi.mocked(sep1.getTransferServer);
+const mockGetAnchorById = vi.mocked(anchors.getAnchorById);
+const mockGetResolvedAnchorById = vi.mocked(anchors.getResolvedAnchorById);
+const mockBuildWithdrawPayment = vi.mocked(horizon.buildWithdrawPayment);
+const mockSignAndSubmitPayment = vi.mocked(horizon.signAndSubmitPayment);
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -57,7 +57,7 @@ const RATE: AnchorRate = {
   totalReceived: 154840,
   source: 'sep24-fee' as const,
   updatedAt: new Date(),
-}
+};
 
 const ANCHOR = {
   id: 'cowrie',
@@ -66,7 +66,7 @@ const ANCHOR = {
   corridors: ['usdc-ngn'],
   assetCode: 'USDC',
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-}
+};
 
 const RESOLVED_ANCHOR = {
   ...ANCHOR,
@@ -74,109 +74,145 @@ const RESOLVED_ANCHOR = {
   WEB_AUTH_ENDPOINT: 'https://auth.cowrie.exchange',
   SIGNING_KEY: 'G...',
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
-}
+};
 
-const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789';
 
 const AUTH = {
   jwt: 'test.jwt.token',
   anchorDomain: 'cowrie.exchange',
   publicKey: PUBLIC_KEY,
   expiresAt: new Date(Date.now() + 86400_000),
-}
+};
 
 beforeEach(() => {
-  vi.clearAllMocks()
-  mockGetAnchorById.mockReturnValue(ANCHOR)
-  mockGetResolvedAnchorById.mockResolvedValue(RESOLVED_ANCHOR)
-  mockAuthenticate.mockResolvedValue(AUTH)
+  vi.clearAllMocks();
+  mockGetAnchorById.mockReturnValue(ANCHOR);
+  mockGetResolvedAnchorById.mockResolvedValue(RESOLVED_ANCHOR);
+  mockAuthenticate.mockResolvedValue(AUTH);
   mockInitiateWithdraw.mockResolvedValue({
     type: 'interactive_customer_info_needed',
     url: 'https://anchor.example/kyc',
     id: 'txn-abc-123',
-  })
-  mockOpenWithdrawPopup.mockResolvedValue('txn-abc-123')
+  });
+  mockOpenWithdrawPopup.mockResolvedValue('txn-abc-123');
   mockGetWithdrawTransactionRecord.mockResolvedValue({
     withdrawAnchorAccount: 'GANCHOR123',
     memo: 'TEST_MEMO',
     memoType: 'text',
-  })
-  mockBuildWithdrawPayment.mockResolvedValue({} as never)
-  mockSignAndSubmitPayment.mockResolvedValue({ hash: 'abc123txhash' } as never)
-})
+  });
+  mockBuildWithdrawPayment.mockResolvedValue({} as never);
+  mockSignAndSubmitPayment.mockResolvedValue({ hash: 'abc123txhash' } as never);
+});
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('ExecuteDrawer', () => {
   it('renders the dialog shell but no anchor name when rate is null', () => {
     render(
-      <ExecuteDrawer rate={null} amount="100" publicKey={PUBLIC_KEY} onClose={vi.fn()} onExecuteStarted={vi.fn()} />
-    )
-    expect(screen.queryByRole('dialog')).toBeInTheDocument()
+      <ExecuteDrawer
+        rate={null}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={vi.fn()}
+        onExecuteStarted={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('dialog')).toBeInTheDocument();
     // No anchor-specific content should appear
-    expect(screen.queryByText('Cowrie')).not.toBeInTheDocument()
-    expect(screen.queryByText('100 USDC')).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText('Cowrie')).not.toBeInTheDocument();
+    expect(screen.queryByText('100 USDC')).not.toBeInTheDocument();
+  });
 
   it('shows the anchor name and transaction summary when a rate is provided', () => {
     render(
-      <ExecuteDrawer rate={RATE} amount="100" publicKey={PUBLIC_KEY} onClose={vi.fn()} onExecuteStarted={vi.fn()} />
-    )
-    expect(screen.getByText(/Cowrie/)).toBeInTheDocument()
-    expect(screen.getByText('100 USDC')).toBeInTheDocument()
-    expect(screen.getByText('Start Off-ramp')).toBeInTheDocument()
-  })
+      <ExecuteDrawer
+        rate={RATE}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={vi.fn()}
+        onExecuteStarted={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Cowrie/)).toBeInTheDocument();
+    expect(screen.getByText('100 USDC')).toBeInTheDocument();
+    expect(screen.getByText('Start Off-ramp')).toBeInTheDocument();
+  });
 
   it('runs through the full happy path and shows the tx hash', async () => {
     render(
-      <ExecuteDrawer rate={RATE} amount="100" publicKey={PUBLIC_KEY} onClose={vi.fn()} onExecuteStarted={vi.fn()} />
-    )
+      <ExecuteDrawer
+        rate={RATE}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={vi.fn()}
+        onExecuteStarted={vi.fn()}
+      />
+    );
 
-    fireEvent.click(screen.getByText('Start Off-ramp'))
+    fireEvent.click(screen.getByText('Start Off-ramp'));
 
-    await waitFor(() => expect(screen.getByText('Transaction submitted')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Transaction submitted')).toBeInTheDocument());
 
-    expect(mockAuthenticate).toHaveBeenCalledWith(RESOLVED_ANCHOR, PUBLIC_KEY)
-    expect(mockInitiateWithdraw).toHaveBeenCalledWith(RESOLVED_ANCHOR, expect.anything())
-    expect(mockOpenWithdrawPopup).toHaveBeenCalledWith('https://anchor.example/kyc')
-    expect(mockBuildWithdrawPayment).toHaveBeenCalled()
-    expect(mockSignAndSubmitPayment).toHaveBeenCalled()
-    expect(screen.getByText('abc123txhash')).toBeInTheDocument()
-  })
+    expect(mockAuthenticate).toHaveBeenCalledWith(RESOLVED_ANCHOR, PUBLIC_KEY);
+    expect(mockInitiateWithdraw).toHaveBeenCalledWith(RESOLVED_ANCHOR, expect.anything());
+    expect(mockOpenWithdrawPopup).toHaveBeenCalledWith('https://anchor.example/kyc');
+    expect(mockBuildWithdrawPayment).toHaveBeenCalled();
+    expect(mockSignAndSubmitPayment).toHaveBeenCalled();
+    expect(screen.getByText('abc123txhash')).toBeInTheDocument();
+  });
 
   it('shows the error message and a Try Again button when authentication fails', async () => {
-    mockAuthenticate.mockRejectedValue(new Error('SEP-10 challenge failed'))
+    mockAuthenticate.mockRejectedValue(new Error('SEP-10 challenge failed'));
 
     render(
-      <ExecuteDrawer rate={RATE} amount="100" publicKey={PUBLIC_KEY} onClose={vi.fn()} onExecuteStarted={vi.fn()} />
-    )
+      <ExecuteDrawer
+        rate={RATE}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={vi.fn()}
+        onExecuteStarted={vi.fn()}
+      />
+    );
 
-    fireEvent.click(screen.getByText('Start Off-ramp'))
+    fireEvent.click(screen.getByText('Start Off-ramp'));
 
-    await waitFor(() => expect(screen.getByText('SEP-10 challenge failed')).toBeInTheDocument())
-    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument()
-  })
+    await waitFor(() => expect(screen.getByText('SEP-10 challenge failed')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+  });
 
   it('shows the error when the user cancels the KYC popup', async () => {
-    mockOpenWithdrawPopup.mockRejectedValue(new Error('User cancelled the transaction'))
+    mockOpenWithdrawPopup.mockRejectedValue(new Error('User cancelled the transaction'));
 
     render(
-      <ExecuteDrawer rate={RATE} amount="100" publicKey={PUBLIC_KEY} onClose={vi.fn()} onExecuteStarted={vi.fn()} />
-    )
+      <ExecuteDrawer
+        rate={RATE}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={vi.fn()}
+        onExecuteStarted={vi.fn()}
+      />
+    );
 
-    fireEvent.click(screen.getByText('Start Off-ramp'))
+    fireEvent.click(screen.getByText('Start Off-ramp'));
 
     await waitFor(() =>
       expect(screen.getByText('User cancelled the transaction')).toBeInTheDocument()
-    )
-  })
+    );
+  });
 
   it('calls onClose when the X button is clicked in idle state', () => {
-    const onClose = vi.fn()
+    const onClose = vi.fn();
     render(
-      <ExecuteDrawer rate={RATE} amount="100" publicKey={PUBLIC_KEY} onClose={onClose} onExecuteStarted={vi.fn()} />
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-    expect(onClose).toHaveBeenCalledOnce()
-  })
-})
+      <ExecuteDrawer
+        rate={RATE}
+        amount="100"
+        publicKey={PUBLIC_KEY}
+        onClose={onClose}
+        onExecuteStarted={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/components/ExecuteDrawer.test.tsx
+++ b/tests/components/ExecuteDrawer.test.tsx
@@ -73,6 +73,12 @@ const RESOLVED_ANCHOR = {
   TRANSFER_SERVER_SEP0024: 'https://transfer.cowrie.exchange',
   WEB_AUTH_ENDPOINT: 'https://auth.cowrie.exchange',
   SIGNING_KEY: 'G...',
+  domain: 'cowrie.exchange',
+  ANCHOR_QUOTE_SERVER: null,
+  NETWORK_PASSPHRASE: null,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 };
 

--- a/tests/components/RateTable.test.tsx
+++ b/tests/components/RateTable.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { RateTable } from '@/components/offramp/RateTable'
-import type { RateComparison, AnchorRate } from '@/types'
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RateTable } from '@/components/offramp/RateTable';
+import type { RateComparison, AnchorRate } from '@/types';
 
 const makeRate = (anchorId: string, totalReceived: number): AnchorRate => ({
   anchorId,
@@ -13,37 +13,37 @@ const makeRate = (anchorId: string, totalReceived: number): AnchorRate => ({
   totalReceived,
   source: 'sep24-fee' as const,
   updatedAt: new Date(),
-})
+});
 
 const mockRates: RateComparison = {
   corridorId: 'usdc-ngn',
   bestRateId: 'cowrie',
   rates: [makeRate('cowrie', 154840), makeRate('flutterwave', 153260)],
-}
+};
 
 describe('RateTable', () => {
   it('renders three skeleton rows when isLoading is true', () => {
     const { container } = render(
       <RateTable rates={undefined} isLoading={true} error={undefined} onSelectAnchor={vi.fn()} />
-    )
-    const animatedDivs = container.querySelectorAll('.animate-pulse')
-    expect(animatedDivs.length).toBe(15) // 3 rows × 5 cells each
-  })
+    );
+    const animatedDivs = container.querySelectorAll('.animate-pulse');
+    expect(animatedDivs.length).toBe(15); // 3 rows × 5 cells each
+  });
 
   it('renders the correct number of data rows from a RateComparison with two anchors', () => {
     render(
       <RateTable rates={mockRates} isLoading={false} error={undefined} onSelectAnchor={vi.fn()} />
-    )
-    const buttons = screen.getAllByRole('button', { name: 'Off-ramp' })
-    expect(buttons).toHaveLength(2)
-  })
+    );
+    const buttons = screen.getAllByRole('button', { name: 'Off-ramp' });
+    expect(buttons).toHaveLength(2);
+  });
 
   it('the best rate row includes the "Best Rate" badge', () => {
     render(
       <RateTable rates={mockRates} isLoading={false} error={undefined} onSelectAnchor={vi.fn()} />
-    )
-    expect(screen.getByText('Best Rate')).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByText('Best Rate')).toBeInTheDocument();
+  });
 
   it('the error state renders the error message string', () => {
     render(
@@ -53,25 +53,30 @@ describe('RateTable', () => {
         error="Failed to fetch rates"
         onSelectAnchor={vi.fn()}
       />
-    )
-    expect(screen.getByText('Failed to fetch rates')).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByText('Failed to fetch rates')).toBeInTheDocument();
+  });
 
   it('clicking the "Off-ramp" button calls onSelectAnchor with the correct AnchorRate', () => {
-    const onSelectAnchor = vi.fn()
+    const onSelectAnchor = vi.fn();
     render(
-      <RateTable rates={mockRates} isLoading={false} error={undefined} onSelectAnchor={onSelectAnchor} />
-    )
-    const buttons = screen.getAllByRole('button', { name: 'Off-ramp' })
-    fireEvent.click(buttons[0])
-    expect(onSelectAnchor).toHaveBeenCalledWith(mockRates.rates[0])
-  })
+      <RateTable
+        rates={mockRates}
+        isLoading={false}
+        error={undefined}
+        onSelectAnchor={onSelectAnchor}
+      />
+    );
+    const buttons = screen.getAllByRole('button', { name: 'Off-ramp' });
+    fireEvent.click(buttons[0]);
+    expect(onSelectAnchor).toHaveBeenCalledWith(mockRates.rates[0]);
+  });
 
   it('renders the empty state message when rates array is empty', () => {
-    const emptyRates: RateComparison = { ...mockRates, rates: [], bestRateId: '' }
+    const emptyRates: RateComparison = { ...mockRates, rates: [], bestRateId: '' };
     render(
       <RateTable rates={emptyRates} isLoading={false} error={undefined} onSelectAnchor={vi.fn()} />
-    )
-    expect(screen.getByText('No rates available for this corridor.')).toBeInTheDocument()
-  })
-})
+    );
+    expect(screen.getByText('No rates available for this corridor.')).toBeInTheDocument();
+  });
+});

--- a/tests/components/StatusTracker.test.tsx
+++ b/tests/components/StatusTracker.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { StatusTracker } from '@/components/offramp/StatusTracker'
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusTracker } from '@/components/offramp/StatusTracker';
 
 const BASE_PROPS = {
   transactionId: 'txn-abc-123',
@@ -11,62 +11,50 @@ const BASE_PROPS = {
   stellarTransactionId: undefined,
   isLoading: false,
   error: undefined,
-} as const
+} as const;
 
 describe('StatusTracker', () => {
   it('renders the transaction ID', () => {
-    render(<StatusTracker {...BASE_PROPS} />)
-    expect(screen.getByText('txn-abc-123')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} />);
+    expect(screen.getByText('txn-abc-123')).toBeInTheDocument();
+  });
 
   it('shows "Fetching status…" when isLoading is true and status is undefined', () => {
-    render(<StatusTracker {...BASE_PROPS} isLoading={true} />)
-    expect(screen.getByText('Fetching status…')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} isLoading={true} />);
+    expect(screen.getByText('Fetching status…')).toBeInTheDocument();
+  });
 
   it('shows "Completed" label when status is completed', () => {
-    render(<StatusTracker {...BASE_PROPS} status="completed" />)
-    expect(screen.getByText('Completed')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="completed" />);
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
 
   it('shows "Awaiting your payment" for pending_user_transfer_start status', () => {
-    render(<StatusTracker {...BASE_PROPS} status="pending_user_transfer_start" />)
-    expect(screen.getByText('Awaiting your payment')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="pending_user_transfer_start" />);
+    expect(screen.getByText('Awaiting your payment')).toBeInTheDocument();
+  });
 
   it('shows completion celebration banner with localized amount when completed', () => {
-    render(
-      <StatusTracker
-        {...BASE_PROPS}
-        status="completed"
-        amountIn="100"
-        amountOut="154840"
-      />
-    )
-    expect(screen.getByText('Delivered')).toBeInTheDocument()
+    render(<StatusTracker {...BASE_PROPS} status="completed" amountIn="100" amountOut="154840" />);
+    expect(screen.getByText('Delivered')).toBeInTheDocument();
     // The formatted amount should contain the numeric value
-    expect(screen.getByText(/154,840|154840/)).toBeInTheDocument()
+    expect(screen.getByText(/154,840|154840/)).toBeInTheDocument();
     // The raw amount detail row should not be shown when completed
-    expect(screen.queryByText('You receive')).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText('You receive')).not.toBeInTheDocument();
+  });
 
   it('shows amount details when status is not completed', () => {
     render(
-      <StatusTracker
-        {...BASE_PROPS}
-        status="pending_external"
-        amountIn="100"
-        amountOut="154840"
-      />
-    )
-    expect(screen.getByText('100 USDC')).toBeInTheDocument()
-    expect(screen.getByText('You receive')).toBeInTheDocument()
-  })
+      <StatusTracker {...BASE_PROPS} status="pending_external" amountIn="100" amountOut="154840" />
+    );
+    expect(screen.getByText('100 USDC')).toBeInTheDocument();
+    expect(screen.getByText('You receive')).toBeInTheDocument();
+  });
 
   it('shows the error message when error is provided', () => {
-    render(<StatusTracker {...BASE_PROPS} error="Status poll failed: HTTP 401" />)
-    expect(screen.getByText('Status poll failed: HTTP 401')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} error="Status poll failed: HTTP 401" />);
+    expect(screen.getByText('Status poll failed: HTTP 401')).toBeInTheDocument();
+  });
 
   it('shows the stellar transaction ID (truncated) when provided', () => {
     render(
@@ -75,17 +63,17 @@ describe('StatusTracker', () => {
         status="completed"
         stellarTransactionId="abc123def456789012345678"
       />
-    )
-    expect(screen.getByText(/abc123def456789/)).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByText(/abc123def456789/)).toBeInTheDocument();
+  });
 
   it('shows "Live" indicator when status is not terminal', () => {
-    render(<StatusTracker {...BASE_PROPS} status="pending_anchor" />)
-    expect(screen.getByText('Live')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="pending_anchor" />);
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
 
   it('hides "Live" indicator when status is completed', () => {
-    render(<StatusTracker {...BASE_PROPS} status="completed" />)
-    expect(screen.queryByText('Live')).not.toBeInTheDocument()
-  })
-})
+    render(<StatusTracker {...BASE_PROPS} status="completed" />);
+    expect(screen.queryByText('Live')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/WalletButton.test.tsx
+++ b/tests/components/WalletButton.test.tsx
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { WalletButton } from '@/components/ui/WalletButton'
-import * as useFreighterModule from '@/hooks/useFreighter'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WalletButton } from '@/components/ui/WalletButton';
+import * as useFreighterModule from '@/hooks/useFreighter';
 
-vi.mock('@/hooks/useFreighter')
+vi.mock('@/hooks/useFreighter');
 
-const mockUseFreighter = vi.mocked(useFreighterModule.useFreighter)
+const mockUseFreighter = vi.mocked(useFreighterModule.useFreighter);
 
 const base = {
   isInstalled: false,
@@ -15,30 +15,30 @@ const base = {
   error: null,
   connect: vi.fn(),
   disconnect: vi.fn(),
-}
+};
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => vi.clearAllMocks());
 
 describe('WalletButton', () => {
   it('renders "Install Freighter" when isInstalled is false', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false })
-    render(<WalletButton />)
-    expect(screen.getByText('Install Freighter')).toBeInTheDocument()
-  })
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: false });
+    render(<WalletButton />);
+    expect(screen.getByText('Install Freighter')).toBeInTheDocument();
+  });
 
   it('renders "Connect Wallet" button when installed but not connected', () => {
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false })
-    render(<WalletButton />)
-    expect(screen.getByText('Connect Wallet')).toBeInTheDocument()
-  })
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false });
+    render(<WalletButton />);
+    expect(screen.getByText('Connect Wallet')).toBeInTheDocument();
+  });
 
   it('clicking "Connect Wallet" calls the connect() function', () => {
-    const connect = vi.fn()
-    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false, connect })
-    render(<WalletButton />)
-    fireEvent.click(screen.getByText('Connect Wallet'))
-    expect(connect).toHaveBeenCalledOnce()
-  })
+    const connect = vi.fn();
+    mockUseFreighter.mockReturnValue({ ...base, isInstalled: true, isConnected: false, connect });
+    render(<WalletButton />);
+    fireEvent.click(screen.getByText('Connect Wallet'));
+    expect(connect).toHaveBeenCalledOnce();
+  });
 
   it('renders the truncated public key when connected', () => {
     mockUseFreighter.mockReturnValue({
@@ -47,11 +47,11 @@ describe('WalletButton', () => {
       isConnected: true,
       publicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789',
       network: 'PUBLIC',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('GABC...6789')).toBeInTheDocument()
-    expect(screen.getByText('Mainnet')).toBeInTheDocument()
-  })
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('GABC...6789')).toBeInTheDocument();
+    expect(screen.getByText('Mainnet')).toBeInTheDocument();
+  });
 
   it('renders the error message when the hook exposes an error', () => {
     mockUseFreighter.mockReturnValue({
@@ -59,8 +59,8 @@ describe('WalletButton', () => {
       isInstalled: true,
       isConnected: false,
       error: 'Please switch Freighter to Mainnet',
-    })
-    render(<WalletButton />)
-    expect(screen.getByText('Please switch Freighter to Mainnet')).toBeInTheDocument()
-  })
-})
+    });
+    render(<WalletButton />);
+    expect(screen.getByText('Please switch Freighter to Mainnet')).toBeInTheDocument();
+  });
+});

--- a/tests/compute-total.spec.ts
+++ b/tests/compute-total.spec.ts
@@ -1,23 +1,34 @@
-import { describe, it, expect } from 'vitest'
-import fc from 'fast-check'
-import { computeTotalReceived } from '@/lib/utils'
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { computeTotalReceived } from '@/lib/utils';
 
 describe('computeTotalReceived - Property-Based Tests', () => {
   // Generators with realistic constraints for fiat/crypto amounts
-  const amountArb = fc.double({ min: 0, max: 1_000_000, noNaN: true, noDefaultInfinity: true })
-  const feeArb = fc.double({ min: 0, max: 100_000, noNaN: true, noDefaultInfinity: true })
-  const feePercentArb = fc.double({ min: 0, max: 100, noNaN: true, noDefaultInfinity: true })
-  const exchangeRateArb = fc.double({ min: 0.01, max: 1_000_000, noNaN: true, noDefaultInfinity: true })
+  const amountArb = fc.double({ min: 0, max: 1_000_000, noNaN: true, noDefaultInfinity: true });
+  const feeArb = fc.double({ min: 0, max: 100_000, noNaN: true, noDefaultInfinity: true });
+  const feePercentArb = fc.double({ min: 0, max: 100, noNaN: true, noDefaultInfinity: true });
+  const exchangeRateArb = fc.double({
+    min: 0.01,
+    max: 1_000_000,
+    noNaN: true,
+    noDefaultInfinity: true,
+  });
 
   it('total received is always non-negative', () => {
     fc.assert(
-      fc.property(amountArb, feeArb, feePercentArb, exchangeRateArb, (amount, fee, feePercent, rate) => {
-        const result = computeTotalReceived(amount, fee, feePercent, rate)
-        expect(result).toBeGreaterThanOrEqual(0)
-      }),
+      fc.property(
+        amountArb,
+        feeArb,
+        feePercentArb,
+        exchangeRateArb,
+        (amount, fee, feePercent, rate) => {
+          const result = computeTotalReceived(amount, fee, feePercent, rate);
+          expect(result).toBeGreaterThanOrEqual(0);
+        }
+      ),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('total received decreases as flat fee increases', () => {
     fc.assert(
@@ -28,16 +39,21 @@ describe('computeTotalReceived - Property-Based Tests', () => {
         exchangeRateArb,
         (amount, baseFee, feePercent, rate) => {
           // Ensure baseFee is within a reasonable range relative to amount
-          const normalizedFee = Math.min(baseFee, amount)
-          const result1 = computeTotalReceived(amount, normalizedFee, feePercent, rate)
-          const result2 = computeTotalReceived(amount, Math.max(0, normalizedFee - 0.01), feePercent, rate)
+          const normalizedFee = Math.min(baseFee, amount);
+          const result1 = computeTotalReceived(amount, normalizedFee, feePercent, rate);
+          const result2 = computeTotalReceived(
+            amount,
+            Math.max(0, normalizedFee - 0.01),
+            feePercent,
+            rate
+          );
           // result1 should be <= result2 (higher fee = lower received)
-          expect(result1).toBeLessThanOrEqual(result2 + 1e-10) // Small epsilon for floating point
+          expect(result1).toBeLessThanOrEqual(result2 + 1e-10); // Small epsilon for floating point
         }
       ),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('total received decreases as percent fee increases', () => {
     fc.assert(
@@ -48,16 +64,21 @@ describe('computeTotalReceived - Property-Based Tests', () => {
         exchangeRateArb,
         (amount, fee, baseFeePercent, rate) => {
           // Ensure feePercent stays within [0, 100]
-          const normalizedPercent = Math.min(baseFeePercent, 100)
-          const result1 = computeTotalReceived(amount, fee, normalizedPercent, rate)
-          const result2 = computeTotalReceived(amount, fee, Math.max(0, normalizedPercent - 0.01), rate)
+          const normalizedPercent = Math.min(baseFeePercent, 100);
+          const result1 = computeTotalReceived(amount, fee, normalizedPercent, rate);
+          const result2 = computeTotalReceived(
+            amount,
+            fee,
+            Math.max(0, normalizedPercent - 0.01),
+            rate
+          );
           // result1 should be <= result2 (higher percent fee = lower received)
-          expect(result1).toBeLessThanOrEqual(result2 + 1e-10) // Small epsilon for floating point
+          expect(result1).toBeLessThanOrEqual(result2 + 1e-10); // Small epsilon for floating point
         }
       ),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('total received increases with higher exchange rate', () => {
     fc.assert(
@@ -67,37 +88,37 @@ describe('computeTotalReceived - Property-Based Tests', () => {
         feePercentArb,
         exchangeRateArb,
         (amount, fee, feePercent, baseRate) => {
-          const rate1 = baseRate
-          const rate2 = baseRate + 1
-          const result1 = computeTotalReceived(amount, fee, feePercent, rate1)
-          const result2 = computeTotalReceived(amount, fee, feePercent, rate2)
+          const rate1 = baseRate;
+          const rate2 = baseRate + 1;
+          const result1 = computeTotalReceived(amount, fee, feePercent, rate1);
+          const result2 = computeTotalReceived(amount, fee, feePercent, rate2);
           // Higher rate should yield higher or equal result (monotonically increasing)
-          expect(result2).toBeGreaterThanOrEqual(result1)
+          expect(result2).toBeGreaterThanOrEqual(result1);
         }
       ),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('zero amount always returns zero', () => {
     fc.assert(
       fc.property(feeArb, feePercentArb, exchangeRateArb, (fee, feePercent, rate) => {
-        const result = computeTotalReceived(0, fee, feePercent, rate)
-        expect(result).toBe(0)
+        const result = computeTotalReceived(0, fee, feePercent, rate);
+        expect(result).toBe(0);
       }),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('no fees returns amount multiplied by exchange rate', () => {
     fc.assert(
       fc.property(amountArb, exchangeRateArb, (amount, rate) => {
-        const result = computeTotalReceived(amount, 0, 0, rate)
-        expect(result).toBeCloseTo(amount * rate, 9)
+        const result = computeTotalReceived(amount, 0, 0, rate);
+        expect(result).toBeCloseTo(amount * rate, 9);
       }),
       { numRuns: 1000 }
-    )
-  })
+    );
+  });
 
   it('flat fee cannot exceed received amount', () => {
     fc.assert(
@@ -107,13 +128,13 @@ describe('computeTotalReceived - Property-Based Tests', () => {
         feePercentArb,
         exchangeRateArb,
         (amount, fee, feePercent, rate) => {
-          const result = computeTotalReceived(amount, fee, feePercent, rate)
+          const result = computeTotalReceived(amount, fee, feePercent, rate);
           // The before-exchange result should not exceed amount * (1 - feePercent/100)
-          const maxPossible = amount * (1 - feePercent / 100) * rate
-          expect(result).toBeLessThanOrEqual(maxPossible + 1e-10)
+          const maxPossible = amount * (1 - feePercent / 100) * rate;
+          expect(result).toBeLessThanOrEqual(maxPossible + 1e-10);
         }
       ),
       { numRuns: 1000 }
-    )
-  })
-})
+    );
+  });
+});

--- a/tests/e2e/keyboard-nav.spec.ts
+++ b/tests/e2e/keyboard-nav.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * #195 [#104] keyboard-only navigation
+ *
+ * Verifies the /offramp page is fully operable using keyboard only.
+ * All interactions use page.keyboard — no mouse events are dispatched.
+ * Every interactive element must expose a visible focus indicator.
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('[#104] keyboard-only navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/offramp')
+    await page.waitForLoadState('networkidle')
+  })
+
+  // ── Tab order: first stop ───────────────────────────────────────────────────
+
+  test('first Tab lands on a visible, focusable wallet element', async ({ page }) => {
+    await page.keyboard.press('Tab')
+
+    const focused = page.locator(':focus')
+    await expect(focused).toBeVisible()
+
+    const tag = await focused.evaluate((el) => el.tagName.toLowerCase())
+    expect(['a', 'button']).toContain(tag)
+  })
+
+  // ── CorridorSelector ────────────────────────────────────────────────────────
+
+  test('Tab reaches CorridorSelector and ArrowDown changes corridor', async ({ page }) => {
+    const select = page.locator('select').first()
+
+    let reached = false
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('Tab')
+      if (await select.evaluate((el) => el === document.activeElement)) {
+        reached = true
+        break
+      }
+    }
+
+    expect(reached, 'CorridorSelector select should be reachable by Tab').toBe(true)
+    await expect(select).toBeFocused()
+
+    const before = await select.inputValue()
+    await page.keyboard.press('ArrowDown')
+    const after = await select.inputValue()
+    // Value must be a valid corridor id and may have changed
+    expect(after).toMatch(/^usdc-/)
+    // Different corridor selected (or wrapped around — either is valid)
+    void before // suppress unused warning; change may or may not occur on single press
+  })
+
+  // ── AmountInput ─────────────────────────────────────────────────────────────
+
+  test('AmountInput is Tab-reachable and accepts keyboard typing', async ({ page }) => {
+    const input = page.getByLabel('Amount (USDC)')
+    await input.focus()
+
+    await expect(input).toBeFocused()
+
+    await page.keyboard.press('Control+A')
+    await page.keyboard.type('350')
+    await expect(input).toHaveValue('350')
+  })
+
+  test('AmountInput focus ring is visible while focused', async ({ page }) => {
+    const input = page.getByLabel('Amount (USDC)')
+    await input.focus()
+
+    // Tailwind focus:ring-2 produces a box-shadow; outline-none suppresses default outline
+    const hasFocusIndicator = await input.evaluate((el) => {
+      const style = window.getComputedStyle(el)
+      return style.boxShadow !== 'none' && style.boxShadow !== ''
+    })
+    expect(hasFocusIndicator).toBe(true)
+  })
+
+  // ── Amount suggestion chips ─────────────────────────────────────────────────
+
+  test('$50 chip is Tab-reachable and activatable with Enter', async ({ page }) => {
+    const chip = page.getByRole('button', { name: '$50' })
+    await chip.focus()
+
+    await expect(chip).toBeFocused()
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('50')
+  })
+
+  test('$100 chip updates amount without mouse', async ({ page }) => {
+    const chip = page.getByRole('button', { name: '$100' })
+    await chip.focus()
+    await page.keyboard.press('Space')
+
+    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('100')
+  })
+
+  // ── Rate table ──────────────────────────────────────────────────────────────
+
+  test('Off-ramp buttons in rate table are Tab-reachable', async ({ page }) => {
+    // Wait up to 15 s for rates to load; skip if API is unavailable in test env
+    const offRampBtn = page.getByRole('button', { name: /off-ramp/i }).first()
+    const appeared = await offRampBtn
+      .waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false)
+
+    if (!appeared) {
+      test.skip()
+      return
+    }
+
+    await offRampBtn.focus()
+    await expect(offRampBtn).toBeFocused()
+
+    // Focus ring present (focus:ring-2 class)
+    const hasFocusIndicator = await offRampBtn.evaluate((el) => {
+      const style = window.getComputedStyle(el)
+      return style.boxShadow !== 'none' && style.boxShadow !== ''
+    })
+    expect(hasFocusIndicator).toBe(true)
+  })
+
+  // ── Full traversal — press-only, no mouse ──────────────────────────────────
+
+  test('full Tab-order traversal uses no mouse events — at least 4 distinct stops', async ({
+    page,
+  }) => {
+    const stops = new Set<string>()
+
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('Tab')
+
+      const label = await page.evaluate(() => {
+        const el = document.activeElement
+        if (!el || el === document.body) return null
+        return (
+          el.getAttribute('aria-label') ??
+          (el as HTMLElement).innerText?.replace(/\s+/g, ' ').trim().slice(0, 40) ??
+          el.tagName
+        )
+      })
+
+      if (label) stops.add(label)
+    }
+
+    expect(stops.size, `Expected ≥4 distinct focus stops, got: ${[...stops].join(', ')}`).toBeGreaterThanOrEqual(4)
+  })
+
+  test('no element traps focus — Tab always advances', async ({ page }) => {
+    const sequence: string[] = []
+
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('Tab')
+      const tag = await page.evaluate(() => document.activeElement?.tagName ?? 'NONE')
+      sequence.push(tag)
+    }
+
+    // Verify we never stall on body (which would indicate a focus trap or broken tab stop)
+    const bodyOnlyRun = sequence.every((t) => t === 'BODY')
+    expect(bodyOnlyRun).toBe(false)
+  })
+})

--- a/tests/e2e/keyboard-nav.spec.ts
+++ b/tests/e2e/keyboard-nav.spec.ts
@@ -5,160 +5,163 @@
  * All interactions use page.keyboard — no mouse events are dispatched.
  * Every interactive element must expose a visible focus indicator.
  */
-import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test';
 
 test.describe('[#104] keyboard-only navigation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/offramp')
-    await page.waitForLoadState('networkidle')
-  })
+    await page.goto('/offramp');
+    await page.waitForLoadState('networkidle');
+  });
 
   // ── Tab order: first stop ───────────────────────────────────────────────────
 
   test('first Tab lands on a visible, focusable wallet element', async ({ page }) => {
-    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab');
 
-    const focused = page.locator(':focus')
-    await expect(focused).toBeVisible()
+    const focused = page.locator(':focus');
+    await expect(focused).toBeVisible();
 
-    const tag = await focused.evaluate((el) => el.tagName.toLowerCase())
-    expect(['a', 'button']).toContain(tag)
-  })
+    const tag = await focused.evaluate((el) => el.tagName.toLowerCase());
+    expect(['a', 'button']).toContain(tag);
+  });
 
   // ── CorridorSelector ────────────────────────────────────────────────────────
 
   test('Tab reaches CorridorSelector and ArrowDown changes corridor', async ({ page }) => {
-    const select = page.locator('select').first()
+    const select = page.locator('select').first();
 
-    let reached = false
+    let reached = false;
     for (let i = 0; i < 12; i++) {
-      await page.keyboard.press('Tab')
+      await page.keyboard.press('Tab');
       if (await select.evaluate((el) => el === document.activeElement)) {
-        reached = true
-        break
+        reached = true;
+        break;
       }
     }
 
-    expect(reached, 'CorridorSelector select should be reachable by Tab').toBe(true)
-    await expect(select).toBeFocused()
+    expect(reached, 'CorridorSelector select should be reachable by Tab').toBe(true);
+    await expect(select).toBeFocused();
 
-    const before = await select.inputValue()
-    await page.keyboard.press('ArrowDown')
-    const after = await select.inputValue()
+    const before = await select.inputValue();
+    await page.keyboard.press('ArrowDown');
+    const after = await select.inputValue();
     // Value must be a valid corridor id and may have changed
-    expect(after).toMatch(/^usdc-/)
+    expect(after).toMatch(/^usdc-/);
     // Different corridor selected (or wrapped around — either is valid)
-    void before // suppress unused warning; change may or may not occur on single press
-  })
+    void before; // suppress unused warning; change may or may not occur on single press
+  });
 
   // ── AmountInput ─────────────────────────────────────────────────────────────
 
   test('AmountInput is Tab-reachable and accepts keyboard typing', async ({ page }) => {
-    const input = page.getByLabel('Amount (USDC)')
-    await input.focus()
+    const input = page.getByLabel('Amount (USDC)');
+    await input.focus();
 
-    await expect(input).toBeFocused()
+    await expect(input).toBeFocused();
 
-    await page.keyboard.press('Control+A')
-    await page.keyboard.type('350')
-    await expect(input).toHaveValue('350')
-  })
+    await page.keyboard.press('Control+A');
+    await page.keyboard.type('350');
+    await expect(input).toHaveValue('350');
+  });
 
   test('AmountInput focus ring is visible while focused', async ({ page }) => {
-    const input = page.getByLabel('Amount (USDC)')
-    await input.focus()
+    const input = page.getByLabel('Amount (USDC)');
+    await input.focus();
 
     // Tailwind focus:ring-2 produces a box-shadow; outline-none suppresses default outline
     const hasFocusIndicator = await input.evaluate((el) => {
-      const style = window.getComputedStyle(el)
-      return style.boxShadow !== 'none' && style.boxShadow !== ''
-    })
-    expect(hasFocusIndicator).toBe(true)
-  })
+      const style = window.getComputedStyle(el);
+      return style.boxShadow !== 'none' && style.boxShadow !== '';
+    });
+    expect(hasFocusIndicator).toBe(true);
+  });
 
   // ── Amount suggestion chips ─────────────────────────────────────────────────
 
   test('$50 chip is Tab-reachable and activatable with Enter', async ({ page }) => {
-    const chip = page.getByRole('button', { name: '$50' })
-    await chip.focus()
+    const chip = page.getByRole('button', { name: '$50' });
+    await chip.focus();
 
-    await expect(chip).toBeFocused()
-    await page.keyboard.press('Enter')
+    await expect(chip).toBeFocused();
+    await page.keyboard.press('Enter');
 
-    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('50')
-  })
+    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('50');
+  });
 
   test('$100 chip updates amount without mouse', async ({ page }) => {
-    const chip = page.getByRole('button', { name: '$100' })
-    await chip.focus()
-    await page.keyboard.press('Space')
+    const chip = page.getByRole('button', { name: '$100' });
+    await chip.focus();
+    await page.keyboard.press('Space');
 
-    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('100')
-  })
+    await expect(page.getByLabel('Amount (USDC)')).toHaveValue('100');
+  });
 
   // ── Rate table ──────────────────────────────────────────────────────────────
 
   test('Off-ramp buttons in rate table are Tab-reachable', async ({ page }) => {
     // Wait up to 15 s for rates to load; skip if API is unavailable in test env
-    const offRampBtn = page.getByRole('button', { name: /off-ramp/i }).first()
+    const offRampBtn = page.getByRole('button', { name: /off-ramp/i }).first();
     const appeared = await offRampBtn
       .waitFor({ state: 'visible', timeout: 15_000 })
       .then(() => true)
-      .catch(() => false)
+      .catch(() => false);
 
     if (!appeared) {
-      test.skip()
-      return
+      test.skip();
+      return;
     }
 
-    await offRampBtn.focus()
-    await expect(offRampBtn).toBeFocused()
+    await offRampBtn.focus();
+    await expect(offRampBtn).toBeFocused();
 
     // Focus ring present (focus:ring-2 class)
     const hasFocusIndicator = await offRampBtn.evaluate((el) => {
-      const style = window.getComputedStyle(el)
-      return style.boxShadow !== 'none' && style.boxShadow !== ''
-    })
-    expect(hasFocusIndicator).toBe(true)
-  })
+      const style = window.getComputedStyle(el);
+      return style.boxShadow !== 'none' && style.boxShadow !== '';
+    });
+    expect(hasFocusIndicator).toBe(true);
+  });
 
   // ── Full traversal — press-only, no mouse ──────────────────────────────────
 
   test('full Tab-order traversal uses no mouse events — at least 4 distinct stops', async ({
     page,
   }) => {
-    const stops = new Set<string>()
+    const stops = new Set<string>();
 
     for (let i = 0; i < 20; i++) {
-      await page.keyboard.press('Tab')
+      await page.keyboard.press('Tab');
 
       const label = await page.evaluate(() => {
-        const el = document.activeElement
-        if (!el || el === document.body) return null
+        const el = document.activeElement;
+        if (!el || el === document.body) return null;
         return (
           el.getAttribute('aria-label') ??
           (el as HTMLElement).innerText?.replace(/\s+/g, ' ').trim().slice(0, 40) ??
           el.tagName
-        )
-      })
+        );
+      });
 
-      if (label) stops.add(label)
+      if (label) stops.add(label);
     }
 
-    expect(stops.size, `Expected ≥4 distinct focus stops, got: ${[...stops].join(', ')}`).toBeGreaterThanOrEqual(4)
-  })
+    expect(
+      stops.size,
+      `Expected ≥4 distinct focus stops, got: ${[...stops].join(', ')}`
+    ).toBeGreaterThanOrEqual(4);
+  });
 
   test('no element traps focus — Tab always advances', async ({ page }) => {
-    const sequence: string[] = []
+    const sequence: string[] = [];
 
     for (let i = 0; i < 12; i++) {
-      await page.keyboard.press('Tab')
-      const tag = await page.evaluate(() => document.activeElement?.tagName ?? 'NONE')
-      sequence.push(tag)
+      await page.keyboard.press('Tab');
+      const tag = await page.evaluate(() => document.activeElement?.tagName ?? 'NONE');
+      sequence.push(tag);
     }
 
     // Verify we never stall on body (which would indicate a focus trap or broken tab stop)
-    const bodyOnlyRun = sequence.every((t) => t === 'BODY')
-    expect(bodyOnlyRun).toBe(false)
-  })
-})
+    const bodyOnlyRun = sequence.every((t) => t === 'BODY');
+    expect(bodyOnlyRun).toBe(false);
+  });
+});

--- a/tests/e2e/no-freighter.spec.ts
+++ b/tests/e2e/no-freighter.spec.ts
@@ -15,152 +15,156 @@
  * branch and leaving `isInstalled === false`. This causes WalletButton to
  * render the "Install Freighter" anchor instead of "Connect Wallet".
  */
-import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test';
 
 // Inject before any page scripts run
 const stubFreighterMissing = () => {
   // Remove any Freighter browser extension globals
-  ;(window as any).freighter = undefined
-  ;(window as any).__stellarFreighter = undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).freighter = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).__stellarFreighter = undefined;
 
   // Patch webpack module cache once it exists so that @stellar/freighter-api's
   // isConnected always throws. This triggers useFreighter's catch → isInstalled
   // stays false → WalletButton renders install guidance.
   function patchWebpackCache() {
     const cache =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__webpack_module_cache__ ??
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).__next_f ?? // Next.js flight cache (app router)
-      null
+      null;
 
-    if (!cache || typeof cache !== 'object') return
+    if (!cache || typeof cache !== 'object') return;
 
     for (const id of Object.keys(cache)) {
-      const mod = (cache as Record<string, { exports?: Record<string, unknown> }>)[id]
+      const mod = (cache as Record<string, { exports?: Record<string, unknown> }>)[id];
       if (mod?.exports && typeof mod.exports['isConnected'] === 'function') {
         mod.exports['isConnected'] = async () => {
-          throw new Error('Freighter extension not installed (stubbed)')
-        }
+          throw new Error('Freighter extension not installed (stubbed)');
+        };
       }
     }
   }
 
   // Attempt immediately then retry after hydration
-  patchWebpackCache()
-  setTimeout(patchWebpackCache, 50)
-  setTimeout(patchWebpackCache, 300)
-  setTimeout(patchWebpackCache, 800)
-}
+  patchWebpackCache();
+  setTimeout(patchWebpackCache, 50);
+  setTimeout(patchWebpackCache, 300);
+  setTimeout(patchWebpackCache, 800);
+};
 
 test.describe('[#106] Freighter not installed', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(stubFreighterMissing)
-  })
+    await page.addInitScript(stubFreighterMissing);
+  });
 
   // ── Install guidance renders ────────────────────────────────────────────────
 
   test('install guidance is shown — Install Freighter link or Connect Wallet button', async ({
     page,
   }) => {
-    await page.goto('/offramp')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/offramp');
+    await page.waitForLoadState('networkidle');
 
-    const installLink = page.getByRole('link', { name: /install freighter/i })
-    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+    const installLink = page.getByRole('link', { name: /install freighter/i });
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i });
 
-    const showsInstall = await installLink.isVisible().catch(() => false)
-    const showsConnect = await connectBtn.isVisible().catch(() => false)
+    const showsInstall = await installLink.isVisible().catch(() => false);
+    const showsConnect = await connectBtn.isVisible().catch(() => false);
 
     expect(
       showsInstall || showsConnect,
       'Expected either "Install Freighter" link or "Connect Wallet" button to be visible'
-    ).toBe(true)
+    ).toBe(true);
 
     // When the install link is present, verify it points to freighter.app
     if (showsInstall) {
-      await expect(installLink).toHaveAttribute('href', 'https://freighter.app')
-      await expect(installLink).toHaveAttribute('target', '_blank')
-      await expect(installLink).toHaveAttribute('rel', /noopener/)
+      await expect(installLink).toHaveAttribute('href', 'https://freighter.app');
+      await expect(installLink).toHaveAttribute('target', '_blank');
+      await expect(installLink).toHaveAttribute('rel', /noopener/);
     }
-  })
+  });
 
   test('"Install Freighter" link is shown when stub forces isInstalled === false', async ({
     page,
   }) => {
     // Override any lazy-loaded module by also intercepting Next.js chunks
     await page.route('**/_next/static/chunks/**', async (route) => {
-      const response = await route.fetch()
-      const text = await response.text()
+      const response = await route.fetch();
+      const text = await response.text();
 
       // If this chunk contains the freighter isConnected export, patch it to throw
       if (text.includes('isConnected') && text.includes('freighter')) {
         const patched = text.replace(
           /(\bisConnected\b\s*[:=]\s*(?:async\s+)?function\s*\([^)]*\)\s*\{)/g,
           '$1 throw new Error("Freighter not installed (chunk stub)");'
-        )
+        );
         await route.fulfill({
           response,
           body: patched,
           contentType: response.headers()['content-type'] ?? 'application/javascript',
-        })
-        return
+        });
+        return;
       }
 
-      await route.fulfill({ response })
-    })
+      await route.fulfill({ response });
+    });
 
-    await page.goto('/offramp')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/offramp');
+    await page.waitForLoadState('networkidle');
 
     // In headless Chrome without the extension the hook's catch fires;
     // WalletButton must show install guidance rather than crashing.
-    const installLink = page.getByRole('link', { name: /install freighter/i })
-    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+    const installLink = page.getByRole('link', { name: /install freighter/i });
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i });
 
     const showsGuidance =
       (await installLink.isVisible().catch(() => false)) ||
-      (await connectBtn.isVisible().catch(() => false))
+      (await connectBtn.isVisible().catch(() => false));
 
-    expect(showsGuidance).toBe(true)
-  })
+    expect(showsGuidance).toBe(true);
+  });
 
   // ── No crash ────────────────────────────────────────────────────────────────
 
   test('page does not crash when Freighter is absent', async ({ page }) => {
-    const errors: string[] = []
-    page.on('pageerror', (err) => errors.push(err.message))
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
 
-    await page.goto('/offramp')
-    await page.waitForTimeout(3_000)
+    await page.goto('/offramp');
+    await page.waitForTimeout(3_000);
 
-    expect(errors, `Unexpected JS errors: ${errors.join('; ')}`).toHaveLength(0)
-  })
+    expect(errors, `Unexpected JS errors: ${errors.join('; ')}`).toHaveLength(0);
+  });
 
   // ── Page remains functional ─────────────────────────────────────────────────
 
   test('offramp page renders corridor selector and amount input without Freighter', async ({
     page,
   }) => {
-    await page.goto('/offramp')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/offramp');
+    await page.waitForLoadState('networkidle');
 
-    await expect(page.getByRole('heading', { name: /off-ramp comparator/i })).toBeVisible()
-    await expect(page.locator('select').first()).toBeVisible()
-    await expect(page.getByLabel('Amount (USDC)')).toBeVisible()
-  })
+    await expect(page.getByRole('heading', { name: /off-ramp comparator/i })).toBeVisible();
+    await expect(page.locator('select').first()).toBeVisible();
+    await expect(page.getByLabel('Amount (USDC)')).toBeVisible();
+  });
 
   test('wallet guidance element is keyboard-reachable when Freighter is absent', async ({
     page,
   }) => {
-    await page.goto('/offramp')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/offramp');
+    await page.waitForLoadState('networkidle');
 
-    const installLink = page.getByRole('link', { name: /install freighter/i })
-    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+    const installLink = page.getByRole('link', { name: /install freighter/i });
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i });
 
-    const showsInstall = await installLink.isVisible().catch(() => false)
-    const target = showsInstall ? installLink : connectBtn
+    const showsInstall = await installLink.isVisible().catch(() => false);
+    const target = showsInstall ? installLink : connectBtn;
 
-    await target.focus()
-    await expect(target).toBeFocused()
-  })
-})
+    await target.focus();
+    await expect(target).toBeFocused();
+  });
+});

--- a/tests/e2e/no-freighter.spec.ts
+++ b/tests/e2e/no-freighter.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * #197 [#106] Freighter not installed
+ *
+ * Verifies the /offramp UX when the Freighter browser extension is absent.
+ *
+ * Strategy
+ * --------
+ * The `useFreighter` hook dynamically imports `@stellar/freighter-api` and
+ * calls `isConnected()`. When the extension is missing the bundled module
+ * either throws or returns a not-connected result. In both paths the hook
+ * must NOT crash the page — it must surface install guidance.
+ *
+ * We use addInitScript to patch webpack's module cache so that the
+ * freighter-api's `isConnected` function throws, forcing the hook's catch
+ * branch and leaving `isInstalled === false`. This causes WalletButton to
+ * render the "Install Freighter" anchor instead of "Connect Wallet".
+ */
+import { test, expect } from '@playwright/test'
+
+// Inject before any page scripts run
+const stubFreighterMissing = () => {
+  // Remove any Freighter browser extension globals
+  ;(window as any).freighter = undefined
+  ;(window as any).__stellarFreighter = undefined
+
+  // Patch webpack module cache once it exists so that @stellar/freighter-api's
+  // isConnected always throws. This triggers useFreighter's catch → isInstalled
+  // stays false → WalletButton renders install guidance.
+  function patchWebpackCache() {
+    const cache =
+      (window as any).__webpack_module_cache__ ??
+      (window as any).__next_f ?? // Next.js flight cache (app router)
+      null
+
+    if (!cache || typeof cache !== 'object') return
+
+    for (const id of Object.keys(cache)) {
+      const mod = (cache as Record<string, { exports?: Record<string, unknown> }>)[id]
+      if (mod?.exports && typeof mod.exports['isConnected'] === 'function') {
+        mod.exports['isConnected'] = async () => {
+          throw new Error('Freighter extension not installed (stubbed)')
+        }
+      }
+    }
+  }
+
+  // Attempt immediately then retry after hydration
+  patchWebpackCache()
+  setTimeout(patchWebpackCache, 50)
+  setTimeout(patchWebpackCache, 300)
+  setTimeout(patchWebpackCache, 800)
+}
+
+test.describe('[#106] Freighter not installed', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(stubFreighterMissing)
+  })
+
+  // ── Install guidance renders ────────────────────────────────────────────────
+
+  test('install guidance is shown — Install Freighter link or Connect Wallet button', async ({
+    page,
+  }) => {
+    await page.goto('/offramp')
+    await page.waitForLoadState('networkidle')
+
+    const installLink = page.getByRole('link', { name: /install freighter/i })
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+
+    const showsInstall = await installLink.isVisible().catch(() => false)
+    const showsConnect = await connectBtn.isVisible().catch(() => false)
+
+    expect(
+      showsInstall || showsConnect,
+      'Expected either "Install Freighter" link or "Connect Wallet" button to be visible'
+    ).toBe(true)
+
+    // When the install link is present, verify it points to freighter.app
+    if (showsInstall) {
+      await expect(installLink).toHaveAttribute('href', 'https://freighter.app')
+      await expect(installLink).toHaveAttribute('target', '_blank')
+      await expect(installLink).toHaveAttribute('rel', /noopener/)
+    }
+  })
+
+  test('"Install Freighter" link is shown when stub forces isInstalled === false', async ({
+    page,
+  }) => {
+    // Override any lazy-loaded module by also intercepting Next.js chunks
+    await page.route('**/_next/static/chunks/**', async (route) => {
+      const response = await route.fetch()
+      const text = await response.text()
+
+      // If this chunk contains the freighter isConnected export, patch it to throw
+      if (text.includes('isConnected') && text.includes('freighter')) {
+        const patched = text.replace(
+          /(\bisConnected\b\s*[:=]\s*(?:async\s+)?function\s*\([^)]*\)\s*\{)/g,
+          '$1 throw new Error("Freighter not installed (chunk stub)");'
+        )
+        await route.fulfill({
+          response,
+          body: patched,
+          contentType: response.headers()['content-type'] ?? 'application/javascript',
+        })
+        return
+      }
+
+      await route.fulfill({ response })
+    })
+
+    await page.goto('/offramp')
+    await page.waitForLoadState('networkidle')
+
+    // In headless Chrome without the extension the hook's catch fires;
+    // WalletButton must show install guidance rather than crashing.
+    const installLink = page.getByRole('link', { name: /install freighter/i })
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+
+    const showsGuidance =
+      (await installLink.isVisible().catch(() => false)) ||
+      (await connectBtn.isVisible().catch(() => false))
+
+    expect(showsGuidance).toBe(true)
+  })
+
+  // ── No crash ────────────────────────────────────────────────────────────────
+
+  test('page does not crash when Freighter is absent', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/offramp')
+    await page.waitForTimeout(3_000)
+
+    expect(errors, `Unexpected JS errors: ${errors.join('; ')}`).toHaveLength(0)
+  })
+
+  // ── Page remains functional ─────────────────────────────────────────────────
+
+  test('offramp page renders corridor selector and amount input without Freighter', async ({
+    page,
+  }) => {
+    await page.goto('/offramp')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('heading', { name: /off-ramp comparator/i })).toBeVisible()
+    await expect(page.locator('select').first()).toBeVisible()
+    await expect(page.getByLabel('Amount (USDC)')).toBeVisible()
+  })
+
+  test('wallet guidance element is keyboard-reachable when Freighter is absent', async ({
+    page,
+  }) => {
+    await page.goto('/offramp')
+    await page.waitForLoadState('networkidle')
+
+    const installLink = page.getByRole('link', { name: /install freighter/i })
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i })
+
+    const showsInstall = await installLink.isVisible().catch(() => false)
+    const target = showsInstall ? installLink : connectBtn
+
+    await target.focus()
+    await expect(target).toBeFocused()
+  })
+})

--- a/tests/e2e/slow-network.spec.ts
+++ b/tests/e2e/slow-network.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * #196 [#105] slow-3G network profile
+ *
+ * Runs the /offramp happy path under simulated Slow 3G conditions via a
+ * Playwright CDP session. Verifies that skeleton placeholders render during
+ * the wait and that the page eventually reaches a stable state.
+ *
+ * Slow 3G parameters (matching Chrome DevTools preset):
+ *   Download : 400 Kbps  → 50 KB/s
+ *   Upload   : 400 Kbps  → 50 KB/s
+ *   Latency  : 400 ms additional RTT
+ */
+import { test, expect, type CDPSession } from '@playwright/test'
+
+const SLOW_3G = {
+  offline: false,
+  downloadThroughput: Math.round((400 * 1024) / 8), // bytes/s
+  uploadThroughput: Math.round((400 * 1024) / 8),
+  latency: 400,
+} as const
+
+const RESTORE_NETWORK = {
+  offline: false,
+  downloadThroughput: -1,
+  uploadThroughput: -1,
+  latency: 0,
+} as const
+
+test.describe('[#105] slow-3G network profile', () => {
+  let cdp: CDPSession
+
+  test.beforeEach(async ({ page, context }) => {
+    cdp = await context.newCDPSession(page)
+    await cdp.send('Network.enable')
+    await cdp.send('Network.emulateNetworkConditions', SLOW_3G)
+  })
+
+  test.afterEach(async () => {
+    await cdp.send('Network.emulateNetworkConditions', RESTORE_NETWORK).catch(() => null)
+  })
+
+  // ── Skeleton renders during load ────────────────────────────────────────────
+
+  test('skeleton placeholders appear while rates are loading on slow 3G', async ({ page }) => {
+    // Navigate without waiting for networkidle so we observe the loading state
+    const navPromise = page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+
+    // The RateTable renders <Skeleton rows={5} /> with animate-pulse while loading.
+    // On a throttled connection, this must be visible before data arrives.
+    await expect(page.locator('.animate-pulse').first()).toBeVisible({ timeout: 30_000 })
+
+    await navPromise
+  })
+
+  // ── Happy path completes ────────────────────────────────────────────────────
+
+  test('rate table or empty state renders after skeleton on slow 3G', async ({ page }) => {
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+
+    // Skeleton may be visible during the throttled load
+    await expect(page.locator('.animate-pulse').first())
+      .toBeVisible({ timeout: 20_000 })
+      .catch(() => null) // acceptable if content loads before assertion
+
+    // Eventually the table, an empty state, or an error retry button must appear
+    const settled = page
+      .getByRole('table')
+      .or(page.getByText('No rates available for this corridor.'))
+      .or(page.getByRole('button', { name: /retry/i }))
+
+    await expect(settled.first()).toBeVisible({ timeout: 90_000 })
+  })
+
+  test('page header and inputs render correctly under throttling', async ({ page }) => {
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+
+    // Static content should paint quickly even on a slow connection
+    await expect(page.getByRole('heading', { name: /off-ramp comparator/i })).toBeVisible({
+      timeout: 30_000,
+    })
+
+    await expect(page.getByLabel('Amount (USDC)')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('select').first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  // ── No crash ────────────────────────────────────────────────────────────────
+
+  test('no unhandled JS errors occur on slow 3G', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+
+    // Allow a few seconds for async operations to settle
+    await page.waitForTimeout(4_000)
+
+    expect(errors, `Unexpected JS errors on slow 3G: ${errors.join('; ')}`).toHaveLength(0)
+  })
+
+  // ── Inputs remain interactive under throttling ───────────────────────────────
+
+  test('amount input accepts keyboard input while network is throttled', async ({ page }) => {
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+
+    const input = page.getByLabel('Amount (USDC)')
+    await input.waitFor({ state: 'visible', timeout: 30_000 })
+
+    await input.focus()
+    await input.selectText()
+    await page.keyboard.type('200')
+
+    await expect(input).toHaveValue('200')
+  })
+})

--- a/tests/e2e/slow-network.spec.ts
+++ b/tests/e2e/slow-network.spec.ts
@@ -10,105 +10,105 @@
  *   Upload   : 400 Kbps  → 50 KB/s
  *   Latency  : 400 ms additional RTT
  */
-import { test, expect, type CDPSession } from '@playwright/test'
+import { test, expect, type CDPSession } from '@playwright/test';
 
 const SLOW_3G = {
   offline: false,
   downloadThroughput: Math.round((400 * 1024) / 8), // bytes/s
   uploadThroughput: Math.round((400 * 1024) / 8),
   latency: 400,
-} as const
+} as const;
 
 const RESTORE_NETWORK = {
   offline: false,
   downloadThroughput: -1,
   uploadThroughput: -1,
   latency: 0,
-} as const
+} as const;
 
 test.describe('[#105] slow-3G network profile', () => {
-  let cdp: CDPSession
+  let cdp: CDPSession;
 
   test.beforeEach(async ({ page, context }) => {
-    cdp = await context.newCDPSession(page)
-    await cdp.send('Network.enable')
-    await cdp.send('Network.emulateNetworkConditions', SLOW_3G)
-  })
+    cdp = await context.newCDPSession(page);
+    await cdp.send('Network.enable');
+    await cdp.send('Network.emulateNetworkConditions', SLOW_3G);
+  });
 
   test.afterEach(async () => {
-    await cdp.send('Network.emulateNetworkConditions', RESTORE_NETWORK).catch(() => null)
-  })
+    await cdp.send('Network.emulateNetworkConditions', RESTORE_NETWORK).catch(() => null);
+  });
 
   // ── Skeleton renders during load ────────────────────────────────────────────
 
   test('skeleton placeholders appear while rates are loading on slow 3G', async ({ page }) => {
     // Navigate without waiting for networkidle so we observe the loading state
-    const navPromise = page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+    const navPromise = page.goto('/offramp', { waitUntil: 'domcontentloaded' });
 
     // The RateTable renders <Skeleton rows={5} /> with animate-pulse while loading.
     // On a throttled connection, this must be visible before data arrives.
-    await expect(page.locator('.animate-pulse').first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('.animate-pulse').first()).toBeVisible({ timeout: 30_000 });
 
-    await navPromise
-  })
+    await navPromise;
+  });
 
   // ── Happy path completes ────────────────────────────────────────────────────
 
   test('rate table or empty state renders after skeleton on slow 3G', async ({ page }) => {
-    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' });
 
     // Skeleton may be visible during the throttled load
     await expect(page.locator('.animate-pulse').first())
       .toBeVisible({ timeout: 20_000 })
-      .catch(() => null) // acceptable if content loads before assertion
+      .catch(() => null); // acceptable if content loads before assertion
 
     // Eventually the table, an empty state, or an error retry button must appear
     const settled = page
       .getByRole('table')
       .or(page.getByText('No rates available for this corridor.'))
-      .or(page.getByRole('button', { name: /retry/i }))
+      .or(page.getByRole('button', { name: /retry/i }));
 
-    await expect(settled.first()).toBeVisible({ timeout: 90_000 })
-  })
+    await expect(settled.first()).toBeVisible({ timeout: 90_000 });
+  });
 
   test('page header and inputs render correctly under throttling', async ({ page }) => {
-    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' });
 
     // Static content should paint quickly even on a slow connection
     await expect(page.getByRole('heading', { name: /off-ramp comparator/i })).toBeVisible({
       timeout: 30_000,
-    })
+    });
 
-    await expect(page.getByLabel('Amount (USDC)')).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator('select').first()).toBeVisible({ timeout: 10_000 })
-  })
+    await expect(page.getByLabel('Amount (USDC)')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('select').first()).toBeVisible({ timeout: 10_000 });
+  });
 
   // ── No crash ────────────────────────────────────────────────────────────────
 
   test('no unhandled JS errors occur on slow 3G', async ({ page }) => {
-    const errors: string[] = []
-    page.on('pageerror', (err) => errors.push(err.message))
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
 
-    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' });
 
     // Allow a few seconds for async operations to settle
-    await page.waitForTimeout(4_000)
+    await page.waitForTimeout(4_000);
 
-    expect(errors, `Unexpected JS errors on slow 3G: ${errors.join('; ')}`).toHaveLength(0)
-  })
+    expect(errors, `Unexpected JS errors on slow 3G: ${errors.join('; ')}`).toHaveLength(0);
+  });
 
   // ── Inputs remain interactive under throttling ───────────────────────────────
 
   test('amount input accepts keyboard input while network is throttled', async ({ page }) => {
-    await page.goto('/offramp', { waitUntil: 'domcontentloaded' })
+    await page.goto('/offramp', { waitUntil: 'domcontentloaded' });
 
-    const input = page.getByLabel('Amount (USDC)')
-    await input.waitFor({ state: 'visible', timeout: 30_000 })
+    const input = page.getByLabel('Amount (USDC)');
+    await input.waitFor({ state: 'visible', timeout: 30_000 });
 
-    await input.focus()
-    await input.selectText()
-    await page.keyboard.type('200')
+    await input.focus();
+    await input.selectText();
+    await page.keyboard.type('200');
 
-    await expect(input).toHaveValue('200')
-  })
-})
+    await expect(input).toHaveValue('200');
+  });
+});

--- a/tests/hooks/useAnchorRates.test.ts
+++ b/tests/hooks/useAnchorRates.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
-import { createElement } from 'react'
-import { SWRConfig } from 'swr'
-import { useAnchorRates } from '@/hooks/useAnchorRates'
-import type { RateComparison } from '@/types'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { useAnchorRates } from '@/hooks/useAnchorRates';
+import type { RateComparison } from '@/types';
 
 // Fresh SWR cache per test — prevents cross-test cache pollution
 const wrapper = ({ children }: { children: React.ReactNode }) =>
-  createElement(SWRConfig, { value: { provider: () => new Map() } }, children)
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
 
 const mockRates: RateComparison = {
   corridorId: 'usdc-ngn',
@@ -25,43 +25,52 @@ const mockRates: RateComparison = {
       updatedAt: new Date(),
     },
   ],
-}
+};
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 describe('useAnchorRates', () => {
   it('is loading on initial render', () => {
-    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
-    expect(result.current.isLoading).toBe(true)
-  })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    );
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
+    expect(result.current.isLoading).toBe(true);
+  });
 
   it('returns rates with bestRateId once data loads', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ rates: mockRates, fetchedAt: new Date().toISOString() }),
+      }))
+    );
 
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.rates?.bestRateId).toBe('cowrie')
-    expect(result.current.error).toBeUndefined()
-  })
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.rates?.bestRateId).toBe('cowrie');
+    expect(result.current.error).toBeUndefined();
+  });
 
   it('exposes an error string when the fetch fails', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 500,
-      json: async () => ({ message: 'All anchors failed' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'All anchors failed' }),
+      }))
+    );
 
-    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper })
+    const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBe('All anchors failed')
-    expect(result.current.rates).toBeUndefined()
-  })
-})
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('All anchors failed');
+    expect(result.current.rates).toBeUndefined();
+  });
+});

--- a/tests/hooks/useFreighter.test.tsx
+++ b/tests/hooks/useFreighter.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
-import { useFreighter } from '@/hooks/useFreighter'
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useFreighter } from '@/hooks/useFreighter';
 
 vi.mock('@stellar/freighter-api', () => ({
   isConnected: vi.fn(),
@@ -9,87 +9,93 @@ vi.mock('@stellar/freighter-api', () => ({
   getNetwork: vi.fn(),
   requestAccess: vi.fn(),
   WatchWalletChanges: class {
-    watch = vi.fn()
-    stop = vi.fn()
-  }
-}))
+    watch = vi.fn();
+    stop = vi.fn();
+  },
+}));
 
-import { WalletProvider } from '@/contexts/WalletContext'
+import { WalletProvider } from '@/contexts/WalletContext';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <WalletProvider>{children}</WalletProvider>
-)
+);
 
 async function getApi() {
-  return await import('@stellar/freighter-api')
+  return await import('@stellar/freighter-api');
 }
 
 beforeEach(async () => {
-  vi.clearAllMocks()
-  const api = await getApi()
-  vi.mocked(api.isConnected).mockResolvedValue({ isConnected: false })
-  vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' })
-  vi.mocked(api.getNetwork).mockResolvedValue({ network: 'PUBLIC', networkPassphrase: 'Public Global Stellar Network ; September 2015' })
-  vi.mocked(api.requestAccess).mockResolvedValue({ address: 'GPUBLICKEY' })
-})
+  vi.clearAllMocks();
+  const api = await getApi();
+  vi.mocked(api.isConnected).mockResolvedValue({ isConnected: false });
+  vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' });
+  vi.mocked(api.getNetwork).mockResolvedValue({
+    network: 'PUBLIC',
+    networkPassphrase: 'Public Global Stellar Network ; September 2015',
+  });
+  vi.mocked(api.requestAccess).mockResolvedValue({ address: 'GPUBLICKEY' });
+});
 
 describe('useFreighter', () => {
   it('isInstalled is false when isConnected() throws', async () => {
-    const api = await getApi()
-    vi.mocked(api.isConnected).mockRejectedValue(new Error('Extension not found'))
+    const api = await getApi();
+    vi.mocked(api.isConnected).mockRejectedValue(new Error('Extension not found'));
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
-    await waitFor(() => expect(result.current.isInstalled).toBe(false))
-  })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
+    await waitFor(() => expect(result.current.isInstalled).toBe(false));
+  });
 
   it('isInstalled is true and isConnected is false when extension is present but locked', async () => {
-    const { result } = renderHook(() => useFreighter(), { wrapper })
-    await waitFor(() => expect(result.current.isInstalled).toBe(true))
-    expect(result.current.isConnected).toBe(false)
-  })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
+    await waitFor(() => expect(result.current.isInstalled).toBe(true));
+    expect(result.current.isConnected).toBe(false);
+  });
 
   it('connect() calls requestAccess and then sets publicKey in state', async () => {
-    const api = await getApi()
-    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY123' })
+    const api = await getApi();
+    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY123' });
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
-    await waitFor(() => expect(result.current.isInstalled).toBe(true))
+    const { result } = renderHook(() => useFreighter(), { wrapper });
+    await waitFor(() => expect(result.current.isInstalled).toBe(true));
 
     await act(async () => {
-      await result.current.connect()
-    })
+      await result.current.connect();
+    });
 
-    expect(api.requestAccess).toHaveBeenCalled()
-    expect(result.current.publicKey).toBe('GPUBLICKEY123')
-    expect(result.current.isConnected).toBe(true)
-  })
+    expect(api.requestAccess).toHaveBeenCalled();
+    expect(result.current.publicKey).toBe('GPUBLICKEY123');
+    expect(result.current.isConnected).toBe(true);
+  });
 
   it('sets error when network is not PUBLIC', async () => {
-    const api = await getApi()
-    vi.mocked(api.isConnected).mockResolvedValue({ isConnected: true })
-    vi.mocked(api.getNetwork).mockResolvedValue({ network: 'TESTNET', networkPassphrase: 'Test SDF Network ; September 2015' })
-    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' })
+    const api = await getApi();
+    vi.mocked(api.isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(api.getNetwork).mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' });
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
-    await waitFor(() => expect(result.current.isConnected).toBe(true))
-    expect(result.current.error).toBe('Please switch Freighter to Mainnet')
-  })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+    expect(result.current.error).toBe('Please switch Freighter to Mainnet');
+  });
 
   it('disconnect() resets state to the disconnected baseline', async () => {
-    const api = await getApi()
-    vi.mocked(api.isConnected).mockResolvedValue({ isConnected: true })
-    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' })
+    const api = await getApi();
+    vi.mocked(api.isConnected).mockResolvedValue({ isConnected: true });
+    vi.mocked(api.getAddress).mockResolvedValue({ address: 'GPUBLICKEY' });
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
-    await waitFor(() => expect(result.current.isConnected).toBe(true))
+    const { result } = renderHook(() => useFreighter(), { wrapper });
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
 
     act(() => {
-      result.current.disconnect()
-    })
+      result.current.disconnect();
+    });
 
-    expect(result.current.isConnected).toBe(false)
-    expect(result.current.publicKey).toBeNull()
-    expect(result.current.network).toBeNull()
-    expect(result.current.error).toBeNull()
-  })
-})
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.network).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/tests/hooks/useWithdrawStatus.test.ts
+++ b/tests/hooks/useWithdrawStatus.test.ts
@@ -1,77 +1,76 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
-import { createElement } from 'react'
-import { SWRConfig } from 'swr'
-import { useWithdrawStatus } from '@/hooks/useWithdrawStatus'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { useWithdrawStatus } from '@/hooks/useWithdrawStatus';
 
 const wrapper = ({ children }: { children: React.ReactNode }) =>
-  createElement(SWRConfig, { value: { provider: () => new Map() } }, children)
+  createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
-const TXN_ID = 'txn-abc123'
-const JWT = 'test-jwt'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
+const TXN_ID = 'txn-abc123';
+const JWT = 'test-jwt';
 
 function mockFetch(status: string) {
-  vi.stubGlobal('fetch', vi.fn(async () => ({
-    ok: true,
-    json: async () => ({
-      transaction: {
-        id: TXN_ID,
-        status,
-        amount_in: '100',
-        amount_out: '97.5',
-        amount_fee: '2.5',
-      },
-    }),
-  })))
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        transaction: {
+          id: TXN_ID,
+          status,
+          amount_in: '100',
+          amount_out: '97.5',
+          amount_fee: '2.5',
+        },
+      }),
+    }))
+  );
 }
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 describe('useWithdrawStatus', () => {
   it('polling is enabled (SWR key is non-null) when all three parameters are provided', async () => {
-    mockFetch('pending_external')
-    const { result } = renderHook(
-      () => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT),
-      { wrapper }
-    )
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.status).toBe('pending_external')
-  })
+    mockFetch('pending_external');
+    const { result } = renderHook(() => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.status).toBe('pending_external');
+  });
 
   it('polling is disabled (SWR key is null) when transactionId is null', () => {
-    vi.stubGlobal('fetch', vi.fn())
-    renderHook(() => useWithdrawStatus(TRANSFER_SERVER, null, JWT), { wrapper })
+    vi.stubGlobal('fetch', vi.fn());
+    renderHook(() => useWithdrawStatus(TRANSFER_SERVER, null, JWT), { wrapper });
     // fetch should never be called
-    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
-  })
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
 
   it('raw status string "pending_external" is correctly mapped and returned', async () => {
-    mockFetch('pending_external')
-    const { result } = renderHook(
-      () => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT),
-      { wrapper }
-    )
-    await waitFor(() => expect(result.current.status).toBe('pending_external'))
-  })
+    mockFetch('pending_external');
+    const { result } = renderHook(() => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.status).toBe('pending_external'));
+  });
 
   it('returns completed status correctly', async () => {
-    mockFetch('completed')
-    const { result } = renderHook(
-      () => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT),
-      { wrapper }
-    )
-    await waitFor(() => expect(result.current.status).toBe('completed'))
-  })
+    mockFetch('completed');
+    const { result } = renderHook(() => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.status).toBe('completed'));
+  });
 
   it('returns error status correctly', async () => {
-    mockFetch('error')
-    const { result } = renderHook(
-      () => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT),
-      { wrapper }
-    )
-    await waitFor(() => expect(result.current.status).toBe('error'))
-  })
-})
+    mockFetch('error');
+    const { result } = renderHook(() => useWithdrawStatus(TRANSFER_SERVER, TXN_ID, JWT), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.status).toBe('error'));
+  });
+});

--- a/tests/lib/anchors.test.ts
+++ b/tests/lib/anchors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 import {
   ANCHORS,
   CORRIDORS,
@@ -7,46 +7,45 @@ import {
   getAnchorsByCorridorId,
   getCorridorById,
   isValidCorridorId,
-} from '@/lib/stellar/anchors'
+} from '@/lib/stellar/anchors';
 
 describe('ANCHORS', () => {
   it('contains MoneyGram, Cowrie, and Anclap', () => {
-    const ids = ANCHORS.map((a) => a.id)
-    expect(ids).toContain('moneygram')
-    expect(ids).toContain('cowrie')
-    expect(ids).toContain('anclap')
-    expect(ids).toHaveLength(3)
-  })
+    const ids = ANCHORS.map((a) => a.id);
+    expect(ids).toContain('moneygram');
+    expect(ids).toContain('cowrie');
+    expect(ids).toContain('anclap');
+    expect(ids).toHaveLength(3);
+  });
 
   it('MoneyGram covers all five primary corridors', () => {
-    const mg = ANCHORS.find((a) => a.id === 'moneygram')!
-    expect(mg.corridors).toContain('usdc-ngn')
-    expect(mg.corridors).toContain('usdc-kes')
-    expect(mg.corridors).toContain('usdc-ghs')
-    expect(mg.corridors).toContain('usdc-mxn')
-    expect(mg.corridors).toContain('usdc-brl')
-  })
+    const mg = ANCHORS.find((a) => a.id === 'moneygram')!;
+    expect(mg.corridors).toContain('usdc-ngn');
+    expect(mg.corridors).toContain('usdc-kes');
+    expect(mg.corridors).toContain('usdc-ghs');
+    expect(mg.corridors).toContain('usdc-mxn');
+    expect(mg.corridors).toContain('usdc-brl');
+  });
 
   it('Cowrie is only in usdc-ngn', () => {
-    const cowrie = ANCHORS.find((a) => a.id === 'cowrie')!
-    expect(cowrie.corridors).toEqual(['usdc-ngn'])
-  })
-
+    const cowrie = ANCHORS.find((a) => a.id === 'cowrie')!;
+    expect(cowrie.corridors).toEqual(['usdc-ngn']);
+  });
 
   it('Anclap covers usdc-ars and usdc-pen', () => {
-    const anclap = ANCHORS.find((a) => a.id === 'anclap')!
-    expect(anclap.corridors).toContain('usdc-ars')
-    expect(anclap.corridors).toContain('usdc-pen')
-  })
-})
+    const anclap = ANCHORS.find((a) => a.id === 'anclap')!;
+    expect(anclap.corridors).toContain('usdc-ars');
+    expect(anclap.corridors).toContain('usdc-pen');
+  });
+});
 
 describe('CORRIDORS', () => {
   it('contains 7 corridors', () => {
-    expect(CORRIDORS).toHaveLength(7)
-  })
+    expect(CORRIDORS).toHaveLength(7);
+  });
 
   it('contains the expected corridor IDs', () => {
-    const ids = CORRIDORS.map((c) => c.id)
+    const ids = CORRIDORS.map((c) => c.id);
     expect(ids).toEqual(
       expect.arrayContaining([
         'usdc-ngn',
@@ -57,107 +56,106 @@ describe('CORRIDORS', () => {
         'usdc-ars',
         'usdc-pen',
       ])
-    )
-  })
-})
+    );
+  });
+});
 
 describe('ANCHOR_HOME_DOMAINS', () => {
   it('maps moneygram to stellar.moneygram.com', () => {
-    expect(ANCHOR_HOME_DOMAINS['moneygram']).toBe('stellar.moneygram.com')
-  })
+    expect(ANCHOR_HOME_DOMAINS['moneygram']).toBe('stellar.moneygram.com');
+  });
 
   it('maps cowrie to cowrie.exchange', () => {
-    expect(ANCHOR_HOME_DOMAINS['cowrie']).toBe('cowrie.exchange')
-  })
-
+    expect(ANCHOR_HOME_DOMAINS['cowrie']).toBe('cowrie.exchange');
+  });
 
   it('maps anclap to anclap.com', () => {
-    expect(ANCHOR_HOME_DOMAINS['anclap']).toBe('anclap.com')
-  })
-})
+    expect(ANCHOR_HOME_DOMAINS['anclap']).toBe('anclap.com');
+  });
+});
 
 describe('getAnchorById', () => {
   it('returns the MoneyGram anchor', () => {
-    const anchor = getAnchorById('moneygram')
-    expect(anchor.id).toBe('moneygram')
-    expect(anchor.homeDomain).toBe('stellar.moneygram.com')
-  })
+    const anchor = getAnchorById('moneygram');
+    expect(anchor.id).toBe('moneygram');
+    expect(anchor.homeDomain).toBe('stellar.moneygram.com');
+  });
 
   it('returns the Cowrie anchor', () => {
-    const anchor = getAnchorById('cowrie')
-    expect(anchor.id).toBe('cowrie')
-    expect(anchor.homeDomain).toBe('cowrie.exchange')
-  })
+    const anchor = getAnchorById('cowrie');
+    expect(anchor.id).toBe('cowrie');
+    expect(anchor.homeDomain).toBe('cowrie.exchange');
+  });
 
   it('throws a descriptive error for an unknown id', () => {
-    expect(() => getAnchorById('unknown')).toThrow(/Unknown anchor.*"unknown"/)
-  })
-})
+    expect(() => getAnchorById('unknown')).toThrow(/Unknown anchor.*"unknown"/);
+  });
+});
 
 describe('getAnchorsByCorridorId', () => {
   it('returns MoneyGram and Cowrie for usdc-ngn', () => {
-    const anchors = getAnchorsByCorridorId('usdc-ngn')
-    const ids = anchors.map((a) => a.id)
-    expect(ids).toContain('moneygram')
-    expect(ids).toContain('cowrie')
-    expect(ids).toHaveLength(2)
-  })
+    const anchors = getAnchorsByCorridorId('usdc-ngn');
+    const ids = anchors.map((a) => a.id);
+    expect(ids).toContain('moneygram');
+    expect(ids).toContain('cowrie');
+    expect(ids).toHaveLength(2);
+  });
 
   it('returns MoneyGram for usdc-kes', () => {
-    const anchors = getAnchorsByCorridorId('usdc-kes')
-    const ids = anchors.map((a) => a.id)
-    expect(ids).toEqual(['moneygram'])
-  })
+    const anchors = getAnchorsByCorridorId('usdc-kes');
+    const ids = anchors.map((a) => a.id);
+    expect(ids).toEqual(['moneygram']);
+  });
 
   it('returns only MoneyGram for usdc-mxn', () => {
-    const anchors = getAnchorsByCorridorId('usdc-mxn')
-    expect(anchors).toHaveLength(1)
-    expect(anchors[0]?.id).toBe('moneygram')
-  })
+    const anchors = getAnchorsByCorridorId('usdc-mxn');
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.id).toBe('moneygram');
+  });
 
   it('returns only Anclap for usdc-ars', () => {
-    const anchors = getAnchorsByCorridorId('usdc-ars')
-    expect(anchors).toHaveLength(1)
-    expect(anchors[0]?.id).toBe('anclap')
-  })
+    const anchors = getAnchorsByCorridorId('usdc-ars');
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.id).toBe('anclap');
+  });
 
   it('returns an empty array for an unknown corridor', () => {
-    expect(getAnchorsByCorridorId('usdc-xyz')).toEqual([])
-  })
-})
+    expect(getAnchorsByCorridorId('usdc-xyz')).toEqual([]);
+  });
+});
 
 describe('getCorridorById', () => {
   it('returns the Nigeria corridor', () => {
-    const corridor = getCorridorById('usdc-ngn')
-    expect(corridor.to).toBe('NGN')
-    expect(corridor.countryCode).toBe('NG')
-  })
+    const corridor = getCorridorById('usdc-ngn');
+    expect(corridor.to).toBe('NGN');
+    expect(corridor.countryCode).toBe('NG');
+  });
 
   it('returns the Argentina corridor', () => {
-    const corridor = getCorridorById('usdc-ars')
-    expect(corridor.to).toBe('ARS')
-    expect(corridor.countryCode).toBe('AR')
-  })
+    const corridor = getCorridorById('usdc-ars');
+    expect(corridor.to).toBe('ARS');
+    expect(corridor.countryCode).toBe('AR');
+  });
 
   it('throws a descriptive error for an unknown id', () => {
-    expect(() => getCorridorById('unknown')).toThrow(/Unknown corridor.*"unknown"/)
-  })
-})
+    expect(() => getCorridorById('unknown')).toThrow(/Unknown corridor.*"unknown"/);
+  });
+});
 
 describe('isValidCorridorId', () => {
   it('returns true for usdc-ngn', () => {
-    expect(isValidCorridorId('usdc-ngn')).toBe(true)
-  })
+    expect(isValidCorridorId('usdc-ngn')).toBe(true);
+  });
 
   it('returns true for usdc-ars', () => {
-    expect(isValidCorridorId('usdc-ars')).toBe(true)
-  })
+    expect(isValidCorridorId('usdc-ars')).toBe(true);
+  });
 
   it('returns false for an invalid id', () => {
-    expect(isValidCorridorId('invalid')).toBe(false)
-  })
+    expect(isValidCorridorId('invalid')).toBe(false);
+  });
 
   it('returns false for an empty string', () => {
-    expect(isValidCorridorId('')).toBe(false)
-  })
-})
+    expect(isValidCorridorId('')).toBe(false);
+  });
+});

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -1,59 +1,59 @@
-import { describe, it, expect } from 'vitest'
-import { SepError, parseSepErrorBody } from '@/lib/stellar/errors'
+import { describe, it, expect } from 'vitest';
+import { SepError, parseSepErrorBody } from '@/lib/stellar/errors';
 
 describe('parseSepErrorBody', () => {
   it('normalizes a JSON API error body { error: string, code: string }', () => {
-    const body = { error: 'Invalid asset code', code: 'INVALID_ASSET' }
-    const err = parseSepErrorBody(body, 400)
+    const body = { error: 'Invalid asset code', code: 'INVALID_ASSET' };
+    const err = parseSepErrorBody(body, 400);
 
-    expect(err).toBeInstanceOf(SepError)
-    expect(err.message).toBe('Invalid asset code')
-    expect(err.code).toBe('INVALID_ASSET')
-    expect(err.httpStatus).toBe(400)
-    expect(err.raw).toBe(body)
-  })
+    expect(err).toBeInstanceOf(SepError);
+    expect(err.message).toBe('Invalid asset code');
+    expect(err.code).toBe('INVALID_ASSET');
+    expect(err.httpStatus).toBe(400);
+    expect(err.raw).toBe(body);
+  });
 
   it('normalizes a plain string error body', () => {
-    const body = 'Unauthorized'
-    const err = parseSepErrorBody(body, 401)
+    const body = 'Unauthorized';
+    const err = parseSepErrorBody(body, 401);
 
-    expect(err).toBeInstanceOf(SepError)
-    expect(err.message).toBe('Unauthorized')
-    expect(err.httpStatus).toBe(401)
-    expect(err.raw).toBe(body)
-  })
+    expect(err).toBeInstanceOf(SepError);
+    expect(err.message).toBe('Unauthorized');
+    expect(err.httpStatus).toBe(401);
+    expect(err.raw).toBe(body);
+  });
 
   it('normalizes a nested error body { error: { message, code } }', () => {
-    const body = { error: { message: 'Rate limit exceeded', code: 'RATE_LIMIT' } }
-    const err = parseSepErrorBody(body, 429)
+    const body = { error: { message: 'Rate limit exceeded', code: 'RATE_LIMIT' } };
+    const err = parseSepErrorBody(body, 429);
 
-    expect(err).toBeInstanceOf(SepError)
-    expect(err.message).toBe('Rate limit exceeded')
-    expect(err.code).toBe('RATE_LIMIT')
-    expect(err.httpStatus).toBe(429)
-    expect(err.raw).toBe(body)
-  })
+    expect(err).toBeInstanceOf(SepError);
+    expect(err.message).toBe('Rate limit exceeded');
+    expect(err.code).toBe('RATE_LIMIT');
+    expect(err.httpStatus).toBe(429);
+    expect(err.raw).toBe(body);
+  });
 
   it('falls back gracefully when fields are missing (empty object)', () => {
-    const body = {}
-    const err = parseSepErrorBody(body, 500)
+    const body = {};
+    const err = parseSepErrorBody(body, 500);
 
-    expect(err).toBeInstanceOf(SepError)
-    expect(typeof err.message).toBe('string')
-    expect(err.message.length).toBeGreaterThan(0)
-    expect(err.httpStatus).toBe(500)
-    expect(err.raw).toBe(body)
-  })
+    expect(err).toBeInstanceOf(SepError);
+    expect(typeof err.message).toBe('string');
+    expect(err.message.length).toBeGreaterThan(0);
+    expect(err.httpStatus).toBe(500);
+    expect(err.raw).toBe(body);
+  });
 
   it('falls back gracefully for malformed bodies (null, number, undefined)', () => {
     for (const body of [null, 42, undefined]) {
-      const err = parseSepErrorBody(body, 503)
+      const err = parseSepErrorBody(body, 503);
 
-      expect(err).toBeInstanceOf(SepError)
-      expect(typeof err.message).toBe('string')
-      expect(err.message.length).toBeGreaterThan(0)
-      expect(err.httpStatus).toBe(503)
-      expect(err.raw).toBe(body)
+      expect(err).toBeInstanceOf(SepError);
+      expect(typeof err.message).toBe('string');
+      expect(err.message.length).toBeGreaterThan(0);
+      expect(err.httpStatus).toBe(503);
+      expect(err.raw).toBe(body);
     }
-  })
-})
+  });
+});

--- a/tests/lib/format.test.ts
+++ b/tests/lib/format.test.ts
@@ -1,42 +1,42 @@
-import { describe, it, expect } from 'vitest'
-import { formatDeliveredAmount } from '@/lib/format'
+import { describe, it, expect } from 'vitest';
+import { formatDeliveredAmount } from '@/lib/format';
 
 describe('formatDeliveredAmount', () => {
   it('formats NGN with currency style', () => {
-    const result = formatDeliveredAmount('158000', 'NGN')
-    expect(result).toContain('158')
-    expect(result).toMatch(/NGN|₦/)
-  })
+    const result = formatDeliveredAmount('158000', 'NGN');
+    expect(result).toContain('158');
+    expect(result).toMatch(/NGN|₦/);
+  });
 
   it('formats KES with currency style', () => {
-    const result = formatDeliveredAmount('13500.50', 'KES')
-    expect(result).toContain('13')
-    expect(result).toMatch(/KES|KSh/)
-  })
+    const result = formatDeliveredAmount('13500.50', 'KES');
+    expect(result).toContain('13');
+    expect(result).toMatch(/KES|KSh/);
+  });
 
   it('formats BRL with currency style', () => {
-    const result = formatDeliveredAmount('520.75', 'BRL')
-    expect(result).toContain('520')
-    expect(result).toMatch(/BRL|R\$/)
-  })
+    const result = formatDeliveredAmount('520.75', 'BRL');
+    expect(result).toContain('520');
+    expect(result).toMatch(/BRL|R\$/);
+  });
 
   it('falls back gracefully for a non-numeric string', () => {
-    const result = formatDeliveredAmount('N/A', 'NGN')
-    expect(result).toBe('N/A NGN')
-  })
+    const result = formatDeliveredAmount('N/A', 'NGN');
+    expect(result).toBe('N/A NGN');
+  });
 
   it('falls back gracefully for an empty string', () => {
-    const result = formatDeliveredAmount('', 'KES')
-    expect(result).toBe(' KES')
-  })
+    const result = formatDeliveredAmount('', 'KES');
+    expect(result).toBe(' KES');
+  });
 
   it('handles zero correctly', () => {
-    const result = formatDeliveredAmount('0', 'MXN')
-    expect(result).toContain('0')
-    expect(result).toMatch(/MXN|\$/)
-  })
+    const result = formatDeliveredAmount('0', 'MXN');
+    expect(result).toContain('0');
+    expect(result).toMatch(/MXN|\$/);
+  });
 
   it('handles large numbers without throwing', () => {
-    expect(() => formatDeliveredAmount('9999999.99', 'NGN')).not.toThrow()
-  })
-})
+    expect(() => formatDeliveredAmount('9999999.99', 'NGN')).not.toThrow();
+  });
+});

--- a/tests/lib/horizon.test.ts
+++ b/tests/lib/horizon.test.ts
@@ -1,41 +1,43 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Account } from '@stellar/stellar-sdk'
-import { fetchAccount, buildWithdrawPayment } from '@/lib/stellar/horizon'
-import { horizonServer } from '@/lib/stellar/horizon'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Account } from '@stellar/stellar-sdk';
+import { fetchAccount, buildWithdrawPayment } from '@/lib/stellar/horizon';
+import { horizonServer } from '@/lib/stellar/horizon';
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
-}))
+}));
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 // Valid Stellar public keys generated via Keypair.random()
-const SOURCE_KEY = 'GAI2X6XPCRM47DBZTMNQQHTFDR6E4LNY7XQDJ7T6GJL3DPEEQB3HSNVB'
-const ANCHOR_ACCOUNT = 'GBGNTATIEI4PBPLLX4QPIWDQZSOF6XUVJAVWEWRP7MGPOOTD53SMAWT2'
-const USDC_ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+const SOURCE_KEY = 'GAI2X6XPCRM47DBZTMNQQHTFDR6E4LNY7XQDJ7T6GJL3DPEEQB3HSNVB';
+const ANCHOR_ACCOUNT = 'GBGNTATIEI4PBPLLX4QPIWDQZSOF6XUVJAVWEWRP7MGPOOTD53SMAWT2';
+const USDC_ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
 
 // Use a real Account instance so TransactionBuilder.build() works correctly
-const mockAccount = new Account(SOURCE_KEY, '1000') as unknown as Awaited<ReturnType<typeof horizonServer.loadAccount>>
+const mockAccount = new Account(SOURCE_KEY, '1000') as unknown as Awaited<
+  ReturnType<typeof horizonServer.loadAccount>
+>;
 
 describe('fetchAccount', () => {
   it('throws a clear error when Horizon returns 404', async () => {
     vi.spyOn(horizonServer, 'loadAccount').mockRejectedValue({
       response: { status: 404 },
-    })
+    });
 
     await expect(fetchAccount(SOURCE_KEY)).rejects.toThrow(
       'Account does not exist on the Stellar network'
-    )
-  })
-})
+    );
+  });
+});
 
 describe('buildWithdrawPayment', () => {
   beforeEach(() => {
-    vi.spyOn(horizonServer, 'loadAccount').mockResolvedValue(mockAccount)
-    vi.spyOn(horizonServer, 'fetchBaseFee').mockResolvedValue(100)
-  })
+    vi.spyOn(horizonServer, 'loadAccount').mockResolvedValue(mockAccount);
+    vi.spyOn(horizonServer, 'fetchBaseFee').mockResolvedValue(100);
+  });
 
   it('builds a transaction with exactly one payment operation', async () => {
     const tx = await buildWithdrawPayment({
@@ -46,11 +48,11 @@ describe('buildWithdrawPayment', () => {
       memoType: 'text',
       assetCode: 'USDC',
       assetIssuer: USDC_ISSUER,
-    })
+    });
 
-    expect(tx.operations).toHaveLength(1)
-    expect(tx.operations[0].type).toBe('payment')
-  })
+    expect(tx.operations).toHaveLength(1);
+    expect(tx.operations[0].type).toBe('payment');
+  });
 
   it('applies the memo field to the built transaction', async () => {
     const tx = await buildWithdrawPayment({
@@ -61,10 +63,10 @@ describe('buildWithdrawPayment', () => {
       memoType: 'text',
       assetCode: 'USDC',
       assetIssuer: USDC_ISSUER,
-    })
+    });
 
-    expect(tx.memo.value).toBe('abc123')
-  })
+    expect(tx.memo.value).toBe('abc123');
+  });
 
   it('uses the correct USDC asset code and issuer', async () => {
     const tx = await buildWithdrawPayment({
@@ -75,16 +77,16 @@ describe('buildWithdrawPayment', () => {
       memoType: 'text',
       assetCode: 'USDC',
       assetIssuer: USDC_ISSUER,
-    })
+    });
 
-    const op = tx.operations[0] as { asset: { code: string; issuer: string } }
-    expect(op.asset.code).toBe('USDC')
-    expect(op.asset.issuer).toBe(USDC_ISSUER)
-  })
+    const op = tx.operations[0] as { asset: { code: string; issuer: string } };
+    expect(op.asset.code).toBe('USDC');
+    expect(op.asset.issuer).toBe(USDC_ISSUER);
+  });
 
   it('extracts result_codes into a readable message on Horizon submit error', async () => {
-    const { signAndSubmitPayment } = await import('@/lib/stellar/horizon')
-    const freighter = await import('@stellar/freighter-api')
+    const { signAndSubmitPayment } = await import('@/lib/stellar/horizon');
+    const freighter = await import('@stellar/freighter-api');
 
     // Build a real transaction so we have valid XDR to sign
     const tx = await buildWithdrawPayment({
@@ -95,13 +97,13 @@ describe('buildWithdrawPayment', () => {
       memoType: 'text',
       assetCode: 'USDC',
       assetIssuer: USDC_ISSUER,
-    })
+    });
 
     // Return the same XDR as the "signed" result so fromXDR can parse it
     vi.mocked(freighter.signTransaction).mockResolvedValue({
       signedTxXdr: tx.toXDR(),
       signerAddress: SOURCE_KEY,
-    })
+    });
 
     vi.spyOn(horizonServer, 'submitTransaction').mockRejectedValue({
       response: {
@@ -111,8 +113,8 @@ describe('buildWithdrawPayment', () => {
           },
         },
       },
-    })
+    });
 
-    await expect(signAndSubmitPayment(tx)).rejects.toThrow(/tx_failed|op_underfunded/)
-  })
-})
+    await expect(signAndSubmitPayment(tx)).rejects.toThrow(/tx_failed|op_underfunded/);
+  });
+});

--- a/tests/lib/sep1.test.ts
+++ b/tests/lib/sep1.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { Networks, StellarToml } from '@stellar/stellar-sdk'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Networks, StellarToml } from '@stellar/stellar-sdk';
 import {
   resolveAnchor,
   resolveToml,
@@ -7,7 +7,7 @@ import {
   getWebAuthEndpoint,
   resolveAllAnchors,
   _clearTomlCache,
-} from '@/lib/stellar/sep1'
+} from '@/lib/stellar/sep1';
 
 const VALID_TOML = {
   TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
@@ -18,25 +18,25 @@ const VALID_TOML = {
   CURRENCIES: [
     { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
   ],
-}
+};
 
 beforeEach(() => {
-  _clearTomlCache()
-  vi.restoreAllMocks()
-  vi.useRealTimers()
-})
+  _clearTomlCache();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 afterEach(() => {
-  vi.useRealTimers()
-})
+  vi.useRealTimers();
+});
 
 describe('resolveAnchor', () => {
   it('calls StellarToml.Resolver.resolve and extracts SEP-1 fields', async () => {
-    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    const result = await resolveAnchor('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange');
 
-    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange');
     expect(result).toEqual({
       domain: 'cowrie.exchange',
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
@@ -53,81 +53,81 @@ describe('resolveAnchor', () => {
         sep38: true,
         sep12: true,
       },
-    })
-  })
+    });
+  });
 
   it('normalizes domain casing for cache keys', async () => {
-    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    await resolveAnchor(' Cowrie.Exchange ')
-    await resolveAnchor('cowrie.exchange')
+    await resolveAnchor(' Cowrie.Exchange ');
+    await resolveAnchor('cowrie.exchange');
 
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith('cowrie.exchange')
-  })
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('cowrie.exchange');
+  });
 
   it('returns nullable fields when optional TOML values are absent', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({} as never)
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({} as never);
 
-    const result = await resolveAnchor('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange');
 
-    expect(result.TRANSFER_SERVER_SEP0024).toBeNull()
-    expect(result.ANCHOR_QUOTE_SERVER).toBeNull()
-    expect(result.WEB_AUTH_ENDPOINT).toBeNull()
-    expect(result.SIGNING_KEY).toBeNull()
-    expect(result.NETWORK_PASSPHRASE).toBeNull()
-    expect(result.CURRENCIES).toEqual([])
-  })
+    expect(result.TRANSFER_SERVER_SEP0024).toBeNull();
+    expect(result.ANCHOR_QUOTE_SERVER).toBeNull();
+    expect(result.WEB_AUTH_ENDPOINT).toBeNull();
+    expect(result.SIGNING_KEY).toBeNull();
+    expect(result.NETWORK_PASSPHRASE).toBeNull();
+    expect(result.CURRENCIES).toEqual([]);
+  });
 
   it('sets sep24 false and sep10 true when TRANSFER_SERVER_SEP0024 is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
-    } as never)
+    } as never);
 
-    const result = await resolveAnchor('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange');
 
-    expect(result.capabilities.sep24).toBe(false)
-    expect(result.capabilities.sep10).toBe(true)
-    expect(result.TRANSFER_SERVER_SEP0024).toBeNull()
-  })
+    expect(result.capabilities.sep24).toBe(false);
+    expect(result.capabilities.sep10).toBe(true);
+    expect(result.TRANSFER_SERVER_SEP0024).toBeNull();
+  });
 
   it('sets sep10 false and sep24 true when WEB_AUTH_ENDPOINT is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
-    } as never)
+    } as never);
 
-    const result = await resolveAnchor('cowrie.exchange')
+    const result = await resolveAnchor('cowrie.exchange');
 
-    expect(result.capabilities.sep10).toBe(false)
-    expect(result.capabilities.sep24).toBe(true)
-    expect(result.WEB_AUTH_ENDPOINT).toBeNull()
-  })
+    expect(result.capabilities.sep10).toBe(false);
+    expect(result.capabilities.sep24).toBe(true);
+    expect(result.WEB_AUTH_ENDPOINT).toBeNull();
+  });
 
   it('throws a descriptive error when the network call fails', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'));
 
     await expect(resolveAnchor('cowrie.exchange')).rejects.toThrow(
       /Failed to resolve stellar\.toml for "cowrie\.exchange"/
-    )
-  })
+    );
+  });
 
   it('returns a cache hit in under 1ms', async () => {
-    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    await resolveAnchor('cowrie.exchange')
+    await resolveAnchor('cowrie.exchange');
 
-    const startedAt = performance.now()
-    const cached = await resolveAnchor('cowrie.exchange')
-    const elapsedMs = performance.now() - startedAt
+    const startedAt = performance.now();
+    const cached = await resolveAnchor('cowrie.exchange');
+    const elapsedMs = performance.now() - startedAt;
 
-    expect(cached.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
-    expect(elapsedMs).toBeLessThan(1)
-    expect(spy).toHaveBeenCalledTimes(1)
-  })
+    expect(cached.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth');
+    expect(elapsedMs).toBeLessThan(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 
   it('refreshes the cached TOML after the 15-minute TTL expires', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
 
     const spy = vi
       .spyOn(StellarToml.Resolver, 'resolve')
@@ -135,103 +135,103 @@ describe('resolveAnchor', () => {
       .mockResolvedValueOnce({
         ...VALID_TOML,
         WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/new-auth',
-      } as never)
+      } as never);
 
-    await resolveAnchor('cowrie.exchange')
-    vi.setSystemTime(new Date('2026-01-01T00:15:00.001Z'))
+    await resolveAnchor('cowrie.exchange');
+    vi.setSystemTime(new Date('2026-01-01T00:15:00.001Z'));
 
-    const refreshed = await resolveAnchor('cowrie.exchange')
+    const refreshed = await resolveAnchor('cowrie.exchange');
 
-    expect(refreshed.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/new-auth')
-    expect(spy).toHaveBeenCalledTimes(2)
-  })
-})
+    expect(refreshed.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/new-auth');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('resolveToml', () => {
   it('returns ok:true with data on success', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    const result = await resolveToml('cowrie.exchange')
+    const result = await resolveToml('cowrie.exchange');
 
-    expect(result.ok).toBe(true)
+    expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data.ANCHOR_QUOTE_SERVER).toBe('https://cowrie.exchange/quotes')
-      expect(result.data.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
-      expect(result.data.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth')
+      expect(result.data.ANCHOR_QUOTE_SERVER).toBe('https://cowrie.exchange/quotes');
+      expect(result.data.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24');
+      expect(result.data.WEB_AUTH_ENDPOINT).toBe('https://cowrie.exchange/auth');
     }
-  })
+  });
 
   it('returns ok:false with error message on failure', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'))
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockRejectedValue(new Error('Network timeout'));
 
-    const result = await resolveToml('cowrie.exchange')
+    const result = await resolveToml('cowrie.exchange');
 
-    expect(result.ok).toBe(false)
+    expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toMatch(/Failed to resolve stellar\.toml for "cowrie\.exchange"/)
+      expect(result.error).toMatch(/Failed to resolve stellar\.toml for "cowrie\.exchange"/);
     }
-  })
-})
+  });
+});
 
 describe('getTransferServer', () => {
   it('returns the transfer server URL', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    const url = await getTransferServer('cowrie.exchange')
-    expect(url).toBe('https://cowrie.exchange/sep24')
-  })
+    const url = await getTransferServer('cowrie.exchange');
+    expect(url).toBe('https://cowrie.exchange/sep24');
+  });
 
   it('throws when TRANSFER_SERVER_SEP0024 is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
-    } as never)
+    } as never);
 
     await expect(getTransferServer('cowrie.exchange')).rejects.toThrow(
       /Missing TRANSFER_SERVER_SEP0024.*"cowrie\.exchange"/
-    )
-  })
-})
+    );
+  });
+});
 
 describe('getWebAuthEndpoint', () => {
   it('returns the web auth endpoint URL', async () => {
-    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    const url = await getWebAuthEndpoint('cowrie.exchange')
-    expect(url).toBe('https://cowrie.exchange/auth')
-  })
+    const url = await getWebAuthEndpoint('cowrie.exchange');
+    expect(url).toBe('https://cowrie.exchange/auth');
+  });
 
   it('throws when WEB_AUTH_ENDPOINT is absent', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue({
       TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
-    } as never)
+    } as never);
 
     await expect(getWebAuthEndpoint('cowrie.exchange')).rejects.toThrow(
       /Missing WEB_AUTH_ENDPOINT.*"cowrie\.exchange"/
-    )
-  })
-})
+    );
+  });
+});
 
 describe('resolveAllAnchors', () => {
   it('calls resolve for each anchor in ANCHORS', async () => {
-    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never)
+    const spy = vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(VALID_TOML as never);
 
-    await resolveAllAnchors()
+    await resolveAllAnchors();
 
     // ANCHORS has 3 entries: moneygram, cowrie, anclap
-    expect(spy).toHaveBeenCalledTimes(3)
-  })
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
 
   it('returns partial results when one anchor fails', async () => {
     vi.spyOn(StellarToml.Resolver, 'resolve').mockImplementation((domain) => {
-      if (domain === 'anclap.com') return Promise.reject(new Error('timeout'))
-      return Promise.resolve(VALID_TOML as never)
-    })
+      if (domain === 'anclap.com') return Promise.reject(new Error('timeout'));
+      return Promise.resolve(VALID_TOML as never);
+    });
 
-    const result = await resolveAllAnchors()
-    expect(result['moneygram']).toBeDefined()
-    expect(result['moneygram']?.homeDomain).toBe('stellar.moneygram.com')
-    expect(result['moneygram']?.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24')
-    expect(result['cowrie']).toBeDefined()
-    expect(result['anclap']).toBeUndefined()
-  })
-})
+    const result = await resolveAllAnchors();
+    expect(result['moneygram']).toBeDefined();
+    expect(result['moneygram']?.homeDomain).toBe('stellar.moneygram.com');
+    expect(result['moneygram']?.TRANSFER_SERVER_SEP0024).toBe('https://cowrie.exchange/sep24');
+    expect(result['cowrie']).toBeDefined();
+    expect(result['anclap']).toBeUndefined();
+  });
+});

--- a/tests/lib/sep10.test.ts
+++ b/tests/lib/sep10.test.ts
@@ -27,6 +27,12 @@ const MOCK_RESOLVED_ANCHOR = {
   TRANSFER_SERVER_SEP0024: 'https://cowrie.exchange/sep24',
   WEB_AUTH_ENDPOINT: WEB_AUTH_ENDPOINT,
   SIGNING_KEY: 'G...',
+  domain: 'cowrie.exchange',
+  ANCHOR_QUOTE_SERVER: null,
+  NETWORK_PASSPHRASE: null,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 };
 

--- a/tests/lib/sep10.test.ts
+++ b/tests/lib/sep10.test.ts
@@ -1,22 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Networks } from '@stellar/stellar-sdk'
-import { fetchChallenge, signChallenge, submitChallenge, authenticate } from '@/lib/stellar/sep10'
-import * as sep1 from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Networks } from '@stellar/stellar-sdk';
+import { fetchChallenge, signChallenge, submitChallenge, authenticate } from '@/lib/stellar/sep10';
 
-const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth'
-const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
-const CHALLENGE_XDR = 'AAAAAQAAAAC...'
-const SIGNED_XDR = 'AAAAAQAAAAD...'
+const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth';
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789';
+const CHALLENGE_XDR = 'AAAAAQAAAAC...';
+const SIGNED_XDR = 'AAAAAQAAAAD...';
 function makeJwt(expSeconds: number): string {
-  const b64 = (s: string) => btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
-  const header = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
-  const payload = b64(JSON.stringify({ exp: expSeconds }))
-  return `${header}.${payload}.signature`
+  const b64 = (s: string) => btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const header = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64(JSON.stringify({ exp: expSeconds }));
+  return `${header}.${payload}.signature`;
 }
 
-const EXP_TIMESTAMP = Math.floor(Date.now() / 1000) + 3600
-const JWT = makeJwt(EXP_TIMESTAMP)
-const EXP_DATE = new Date(EXP_TIMESTAMP * 1000)
+const EXP_TIMESTAMP = Math.floor(Date.now() / 1000) + 3600;
+const JWT = makeJwt(EXP_TIMESTAMP);
+const EXP_DATE = new Date(EXP_TIMESTAMP * 1000);
 
 const MOCK_RESOLVED_ANCHOR = {
   id: 'cowrie',
@@ -29,155 +28,172 @@ const MOCK_RESOLVED_ANCHOR = {
   WEB_AUTH_ENDPOINT: WEB_AUTH_ENDPOINT,
   SIGNING_KEY: 'G...',
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
-}
+};
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
-}))
+}));
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 async function getFreighter() {
-  return await import('@stellar/freighter-api')
+  return await import('@stellar/freighter-api');
 }
 
 // ─── fetchChallenge ───────────────────────────────────────────────────────────
 
 describe('fetchChallenge', () => {
   it('constructs the correct challenge URL with the public key', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      capturedUrl = url
-      return {
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC,
+          }),
+        };
+      })
+    );
+
+    await fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY);
+    expect(capturedUrl).toContain(`account=${PUBLIC_KEY}`);
+  });
+
+  it('throws when network_passphrase does not match mainnet', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
         ok: true,
         json: async () => ({
           transaction: CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC,
+          network_passphrase: 'Test SDF Network ; September 2015',
         }),
-      }
-    }))
+      }))
+    );
 
-    await fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)
-    expect(capturedUrl).toContain(`account=${PUBLIC_KEY}`)
-  })
-
-  it('throws when network_passphrase does not match mainnet', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        transaction: CHALLENGE_XDR,
-        network_passphrase: 'Test SDF Network ; September 2015',
-      }),
-    })))
-
-    await expect(fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)).rejects.toThrow(
-      /wrong network/
-    )
-  })
+    await expect(fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)).rejects.toThrow(/wrong network/);
+  });
 
   it('throws when transaction is absent', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ network_passphrase: Networks.PUBLIC }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ network_passphrase: Networks.PUBLIC }),
+      }))
+    );
 
-    await expect(fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)).rejects.toThrow(
-      /"transaction"/
-    )
-  })
+    await expect(fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)).rejects.toThrow(/"transaction"/);
+  });
 
   it('throws when network_passphrase is absent', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: CHALLENGE_XDR }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ transaction: CHALLENGE_XDR }),
+      }))
+    );
 
     await expect(fetchChallenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY)).rejects.toThrow(
       /"network_passphrase"/
-    )
-  })
-})
+    );
+  });
+});
 
 // ─── submitChallenge ──────────────────────────────────────────────────────────
 
 describe('submitChallenge', () => {
   it('extracts the JWT from the anchor response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ token: JWT }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ token: JWT }),
+      }))
+    );
 
-    const result = await submitChallenge(WEB_AUTH_ENDPOINT, SIGNED_XDR)
-    expect(result.token).toBe(JWT)
-    expect(result.expiresAt).toEqual(EXP_DATE)
-  })
+    const result = await submitChallenge(WEB_AUTH_ENDPOINT, SIGNED_XDR);
+    expect(result.token).toBe(JWT);
+    expect(result.expiresAt).toEqual(EXP_DATE);
+  });
 
   it('throws when token is absent from the response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ other: 'data' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ other: 'data' }),
+      }))
+    );
 
-    await expect(submitChallenge(WEB_AUTH_ENDPOINT, SIGNED_XDR)).rejects.toThrow(/"token"/)
-  })
-})
+    await expect(submitChallenge(WEB_AUTH_ENDPOINT, SIGNED_XDR)).rejects.toThrow(/"token"/);
+  });
+});
 
 // ─── signChallenge ────────────────────────────────────────────────────────────
 
 describe('signChallenge', () => {
   it('returns the signed XDR from Freighter', async () => {
-    const freighter = await getFreighter()
+    const freighter = await getFreighter();
     vi.mocked(freighter.signTransaction).mockResolvedValue({
       signedTxXdr: SIGNED_XDR,
       signerAddress: PUBLIC_KEY,
-    })
+    });
 
-    const result = await signChallenge(CHALLENGE_XDR, Networks.PUBLIC)
-    expect(result).toBe(SIGNED_XDR)
-  })
+    const result = await signChallenge(CHALLENGE_XDR, Networks.PUBLIC);
+    expect(result).toBe(SIGNED_XDR);
+  });
 
   it('throws "User rejected signing" when Freighter returns an error', async () => {
-    const freighter = await getFreighter()
+    const freighter = await getFreighter();
     vi.mocked(freighter.signTransaction).mockResolvedValue({
       signedTxXdr: '',
       signerAddress: '',
       error: { message: 'User declined', code: -1 },
-    })
+    });
 
     await expect(signChallenge(CHALLENGE_XDR, Networks.PUBLIC)).rejects.toThrow(
       'User rejected the request'
-    )
-  })
-})
+    );
+  });
+});
 
 // ─── authenticate ─────────────────────────────────────────────────────────────
 
 describe('authenticate', () => {
   it('calls fetchChallenge, signChallenge, and submitChallenge in sequence', async () => {
-    const freighter = await getFreighter()
+    const freighter = await getFreighter();
     vi.mocked(freighter.signTransaction).mockResolvedValue({
       signedTxXdr: SIGNED_XDR,
       signerAddress: PUBLIC_KEY,
-    })
+    });
 
-    vi.stubGlobal('fetch', vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ transaction: CHALLENGE_XDR, network_passphrase: Networks.PUBLIC }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: JWT }),
-      })
-    )
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ transaction: CHALLENGE_XDR, network_passphrase: Networks.PUBLIC }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ token: JWT }),
+        })
+    );
 
-    const result = await authenticate(MOCK_RESOLVED_ANCHOR, PUBLIC_KEY)
+    const result = await authenticate(MOCK_RESOLVED_ANCHOR, PUBLIC_KEY);
 
-    expect(result.jwt).toBe(JWT)
-    expect(result.anchorDomain).toBe('cowrie.exchange')
-    expect(result.publicKey).toBe(PUBLIC_KEY)
-    expect(result.expiresAt).toBeInstanceOf(Date)
-  })
-})
+    expect(result.jwt).toBe(JWT);
+    expect(result.anchorDomain).toBe('cowrie.exchange');
+    expect(result.publicKey).toBe(PUBLIC_KEY);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+  });
+});

--- a/tests/lib/sep24.test.ts
+++ b/tests/lib/sep24.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchAnchorFee, fetchAllAnchorFees, computeRateComparison, initiateWithdraw, getWithdrawTransactionRecord } from '@/lib/stellar/sep24'
-import * as sep1 from '@/lib/stellar/sep1'
-import type { AnchorRate } from '@/types'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchAnchorFee,
+  fetchAllAnchorFees,
+  computeRateComparison,
+  initiateWithdraw,
+  getWithdrawTransactionRecord,
+} from '@/lib/stellar/sep24';
+import * as sep1 from '@/lib/stellar/sep1';
+import type { AnchorRate } from '@/types';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
 
 const MOCK_ANCHOR = {
   id: 'cowrie',
@@ -12,7 +18,7 @@ const MOCK_ANCHOR = {
   corridors: ['usdc-ngn'],
   assetCode: 'USDC',
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-}
+};
 
 const RESOLVED_ANCHOR = {
   ...MOCK_ANCHOR,
@@ -20,12 +26,12 @@ const RESOLVED_ANCHOR = {
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'G...',
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
-}
+};
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-  vi.spyOn(sep1, 'getTransferServer').mockResolvedValue(TRANSFER_SERVER)
-})
+  vi.restoreAllMocks();
+  vi.spyOn(sep1, 'getTransferServer').mockResolvedValue(TRANSFER_SERVER);
+});
 
 // ─── fetchAnchorFee ───────────────────────────────────────────────────────────
 
@@ -37,79 +43,92 @@ describe('fetchAnchorFee', () => {
     assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
     amount: '100',
     type: 'bank_account' as const,
-  }
+  };
 
   it('constructs the correct fee URL with all query parameters', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      capturedUrl = url
-      return { ok: true, json: async () => ({ fee: '2.00' }) }
-    }))
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return { ok: true, json: async () => ({ fee: '2.00' }) };
+      })
+    );
 
-    await fetchAnchorFee(params)
+    await fetchAnchorFee(params);
 
-    expect(capturedUrl).toContain('operation=withdraw')
-    expect(capturedUrl).toContain('asset_code=USDC')
-    expect(capturedUrl).toContain('amount=100')
-    expect(capturedUrl).toContain('type=bank_account')
-  })
+    expect(capturedUrl).toContain('operation=withdraw');
+    expect(capturedUrl).toContain('asset_code=USDC');
+    expect(capturedUrl).toContain('amount=100');
+    expect(capturedUrl).toContain('type=bank_account');
+  });
 
   it('correctly parses a { fee: "2.00" } response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ fee: '2.00' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ fee: '2.00' }),
+      }))
+    );
 
-    const result = await fetchAnchorFee(params)
-    expect(result.fee).toBe('2.00')
-  })
+    const result = await fetchAnchorFee(params);
+    expect(result.fee).toBe('2.00');
+  });
 
   it('throws a descriptive error on HTTP 400', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 400 })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 400 }))
+    );
 
-    await expect(fetchAnchorFee(params)).rejects.toThrow(/HTTP 400.*cowrie\.exchange/)
-  })
+    await expect(fetchAnchorFee(params)).rejects.toThrow(/HTTP 400.*cowrie\.exchange/);
+  });
 
   it('throws a timeout error when the request exceeds 10 seconds', async () => {
-    vi.useFakeTimers()
-    vi.stubGlobal('fetch', vi.fn((_url: string, opts: { signal: AbortSignal }) => {
-      return new Promise((_resolve, reject) => {
-        opts.signal.addEventListener('abort', () => {
-          const err = new Error('The operation was aborted')
-          ;(err as NodeJS.ErrnoException).name = 'AbortError'
-          reject(err)
-        })
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, opts: { signal: AbortSignal }) => {
+        return new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            (err as NodeJS.ErrnoException).name = 'AbortError';
+            reject(err);
+          });
+        });
       })
-    }))
+    );
 
-    const [, result] = await Promise.allSettled([
-      vi.runAllTimersAsync(),
-      fetchAnchorFee(params),
-    ])
-    expect(result.status).toBe('rejected')
-    expect((result as PromiseRejectedResult).reason.message).toMatch(/timed out/)
-    vi.useRealTimers()
-  })
-})
+    const [, result] = await Promise.allSettled([vi.runAllTimersAsync(), fetchAnchorFee(params)]);
+    expect(result.status).toBe('rejected');
+    expect((result as PromiseRejectedResult).reason.message).toMatch(/timed out/);
+    vi.useRealTimers();
+  });
+});
 
 // ─── fetchAllAnchorFees ───────────────────────────────────────────────────────
 
 describe('fetchAllAnchorFees', () => {
   it('returns partial results when one anchor fails', async () => {
-    let callCount = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      callCount++
-      if (callCount === 1) return { ok: true, json: async () => ({ fee: '2.00', exchange_rate: '1580' }) }
-      throw new Error('network error')
-    }))
+    let callCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        callCount++;
+        if (callCount === 1)
+          return { ok: true, json: async () => ({ fee: '2.00', exchange_rate: '1580' }) };
+        throw new Error('network error');
+      })
+    );
 
-    const results = await fetchAllAnchorFees('100', 'usdc-ngn')
-    const fulfilled = results.filter((r) => r.status === 'fulfilled')
-    const rejected = results.filter((r) => r.status === 'rejected')
-    expect(fulfilled.length).toBeGreaterThan(0)
-    expect(rejected.length).toBeGreaterThan(0)
-  })
-})
+    const results = await fetchAllAnchorFees('100', 'usdc-ngn');
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled.length).toBeGreaterThan(0);
+    expect(rejected.length).toBeGreaterThan(0);
+  });
+});
 
 // ─── computeRateComparison ────────────────────────────────────────────────────
 
@@ -118,28 +137,48 @@ describe('computeRateComparison', () => {
     const results: PromiseSettledResult<AnchorRate>[] = [
       {
         status: 'fulfilled',
-        value: { anchorId: 'cowrie', anchorName: 'Cowrie', corridorId: 'usdc-ngn', fee: 3, feeType: 'flat', exchangeRate: 1580, totalReceived: 97 * 1580, source: 'sep24-fee' as const, updatedAt: new Date() },
+        value: {
+          anchorId: 'cowrie',
+          anchorName: 'Cowrie',
+          corridorId: 'usdc-ngn',
+          fee: 3,
+          feeType: 'flat',
+          exchangeRate: 1580,
+          totalReceived: 97 * 1580,
+          source: 'sep24-fee' as const,
+          updatedAt: new Date(),
+        },
       },
       {
         status: 'fulfilled',
-        value: { anchorId: 'flutterwave', anchorName: 'Flutterwave', corridorId: 'usdc-ngn', fee: 1.5, feeType: 'flat', exchangeRate: 1580, totalReceived: 98.5 * 1580, source: 'sep24-fee' as const, updatedAt: new Date() },
+        value: {
+          anchorId: 'flutterwave',
+          anchorName: 'Flutterwave',
+          corridorId: 'usdc-ngn',
+          fee: 1.5,
+          feeType: 'flat',
+          exchangeRate: 1580,
+          totalReceived: 98.5 * 1580,
+          source: 'sep24-fee' as const,
+          updatedAt: new Date(),
+        },
       },
-    ]
+    ];
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.bestRateId).toBe('flutterwave')
-    expect(comparison.rates).toHaveLength(2)
-  })
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.bestRateId).toBe('flutterwave');
+    expect(comparison.rates).toHaveLength(2);
+  });
 
   it('returns an empty comparison when all results are rejected', () => {
     const results: PromiseSettledResult<AnchorRate>[] = [
       { status: 'rejected', reason: new Error('timeout') },
-    ]
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.rates).toHaveLength(0)
-    expect(comparison.bestRateId).toBe('')
-  })
-})
+    ];
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.rates).toHaveLength(0);
+    expect(comparison.bestRateId).toBe('');
+  });
+});
 
 // ─── initiateWithdraw ─────────────────────────────────────────────────────────
 
@@ -150,73 +189,94 @@ describe('initiateWithdraw', () => {
     assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
     amount: '100',
     account: 'GABCDEF',
-  }
+  };
 
   it('constructs the correct POST body with all required fields', async () => {
-    let capturedBody = ''
-    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => {
-      capturedBody = opts.body as string
-      return {
-        ok: true,
-        json: async () => ({ type: 'interactive_customer_info_needed', url: 'https://anchor.io/kyc', id: 'txn-1' }),
-      }
-    }))
+    let capturedBody = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts: RequestInit) => {
+        capturedBody = opts.body as string;
+        return {
+          ok: true,
+          json: async () => ({
+            type: 'interactive_customer_info_needed',
+            url: 'https://anchor.io/kyc',
+            id: 'txn-1',
+          }),
+        };
+      })
+    );
 
-    await initiateWithdraw(RESOLVED_ANCHOR, params)
-    const body = JSON.parse(capturedBody)
-    expect(body.asset_code).toBe('USDC')
-    expect(body.amount).toBe('100')
-    expect(body.account).toBe('GABCDEF')
-  })
+    await initiateWithdraw(RESOLVED_ANCHOR, params);
+    const body = JSON.parse(capturedBody);
+    expect(body.asset_code).toBe('USDC');
+    expect(body.amount).toBe('100');
+    expect(body.account).toBe('GABCDEF');
+  });
 
   it('throws when response type is not interactive_customer_info_needed', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ type: 'error', error: 'not supported' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ type: 'error', error: 'not supported' }),
+      }))
+    );
 
-    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(/Unexpected response type/)
-  })
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(
+      /Unexpected response type/
+    );
+  });
 
   it('throws when url is absent from the response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
+      }))
+    );
 
-    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(/"url"/)
-  })
-})
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, params)).rejects.toThrow(/"url"/);
+  });
+});
 
 // ─── getWithdrawTransactionRecord ─────────────────────────────────────────────
 
 describe('getWithdrawTransactionRecord', () => {
   it('extracts memo and anchor account correctly', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        transaction: {
-          withdraw_anchor_account: 'GANCHOR',
-          memo: 'abc123',
-          memo_type: 'text',
-        },
-      }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          transaction: {
+            withdraw_anchor_account: 'GANCHOR',
+            memo: 'abc123',
+            memo_type: 'text',
+          },
+        }),
+      }))
+    );
 
-    const result = await getWithdrawTransactionRecord(TRANSFER_SERVER, 'txn-1', 'jwt')
-    expect(result.withdrawAnchorAccount).toBe('GANCHOR')
-    expect(result.memo).toBe('abc123')
-    expect(result.memoType).toBe('text')
-  })
+    const result = await getWithdrawTransactionRecord(TRANSFER_SERVER, 'txn-1', 'jwt');
+    expect(result.withdrawAnchorAccount).toBe('GANCHOR');
+    expect(result.memo).toBe('abc123');
+    expect(result.memoType).toBe('text');
+  });
 
   it('throws when withdraw_anchor_account is absent', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: { memo: 'abc123' } }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ transaction: { memo: 'abc123' } }),
+      }))
+    );
 
-    await expect(
-      getWithdrawTransactionRecord(TRANSFER_SERVER, 'txn-1', 'jwt')
-    ).rejects.toThrow(/withdraw_anchor_account/)
-  })
-})
+    await expect(getWithdrawTransactionRecord(TRANSFER_SERVER, 'txn-1', 'jwt')).rejects.toThrow(
+      /withdraw_anchor_account/
+    );
+  });
+});

--- a/tests/lib/sep24.test.ts
+++ b/tests/lib/sep24.test.ts
@@ -25,6 +25,12 @@ const RESOLVED_ANCHOR = {
   TRANSFER_SERVER_SEP0024: TRANSFER_SERVER,
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'G...',
+  domain: 'cowrie.exchange',
+  ANCHOR_QUOTE_SERVER: null,
+  NETWORK_PASSPHRASE: null,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 };
 

--- a/tests/lib/types.test.ts
+++ b/tests/lib/types.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import type { Sep24Transaction, AnchorRate } from '@/types'
+import { describe, it, expect } from 'vitest';
+import type { Sep24Transaction, AnchorRate } from '@/types';
 
 describe('Sep24Transaction', () => {
   it('accepts a valid Sep24Transaction object', () => {
@@ -10,10 +10,10 @@ describe('Sep24Transaction', () => {
       amountOut: '97.50',
       amountFee: '2.50',
       updatedAt: new Date(),
-    }
-    expect(status.id).toBe('txn-123')
-    expect(status.status).toBe('pending_external')
-  })
+    };
+    expect(status.id).toBe('txn-123');
+    expect(status.status).toBe('pending_external');
+  });
 
   it('accepts a completed status with a stellar transaction id', () => {
     const status: Sep24Transaction = {
@@ -21,10 +21,10 @@ describe('Sep24Transaction', () => {
       status: 'completed',
       updatedAt: new Date(),
       stellarTransactionId: 'abc123',
-    }
-    expect(status.stellarTransactionId).toBe('abc123')
-  })
-})
+    };
+    expect(status.stellarTransactionId).toBe('abc123');
+  });
+});
 
 describe('AnchorRate', () => {
   it('accepts a valid AnchorRate without isMock', () => {
@@ -38,9 +38,9 @@ describe('AnchorRate', () => {
       totalReceived: 153660,
       source: 'sep24-fee' as const,
       updatedAt: new Date(),
-    }
-    expect(rate.anchorId).toBe('cowrie')
+    };
+    expect(rate.anchorId).toBe('cowrie');
     // isMock must not exist on the type
-    expect('isMock' in rate).toBe(false)
-  })
-})
+    expect('isMock' in rate).toBe(false);
+  });
+});

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 import {
   computeTotalReceived,
   formatCurrency,
@@ -6,96 +6,96 @@ import {
   truncatePublicKey,
   isExpired,
   timeAgo,
-} from '@/lib/utils'
+} from '@/lib/utils';
 
 describe('computeTotalReceived', () => {
   it('applies flat fee then exchange rate', () => {
     // 100 - 2 = 98 USDC remaining; 98 * 1580 = 154840
-    expect(computeTotalReceived(100, 2, 0, 1580)).toBe(98 * 1580)
-  })
+    expect(computeTotalReceived(100, 2, 0, 1580)).toBe(98 * 1580);
+  });
 
   it('applies percent fee (in percentage points) then exchange rate', () => {
     // 1% fee: 100 * (1 - 1/100) * 1580 = 99 * 1580
-    expect(computeTotalReceived(100, 0, 1, 1580)).toBe(99 * 1580)
-  })
+    expect(computeTotalReceived(100, 0, 1, 1580)).toBe(99 * 1580);
+  });
 
   it('returns 0 when amount is 0', () => {
-    expect(computeTotalReceived(0, 2, 0, 1580)).toBe(0)
-  })
+    expect(computeTotalReceived(0, 2, 0, 1580)).toBe(0);
+  });
 
   it('applies both flat and percent fee', () => {
     // (100 - 2) * (1 - 1/100) * 1580 = 98 * 0.99 * 1580
-    expect(computeTotalReceived(100, 2, 1, 1580)).toBeCloseTo(98 * 0.99 * 1580)
-  })
-})
+    expect(computeTotalReceived(100, 2, 1, 1580)).toBeCloseTo(98 * 0.99 * 1580);
+  });
+});
 
 describe('formatCurrency', () => {
   it('returns a non-empty string for NGN', () => {
-    const result = formatCurrency(1580.25, 'NGN')
-    expect(result.length).toBeGreaterThan(0)
-    expect(result).toContain('1,580')
-  })
+    const result = formatCurrency(1580.25, 'NGN');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('1,580');
+  });
 
   it('returns a non-empty string for USD', () => {
-    const result = formatCurrency(100, 'USD')
-    expect(result).toContain('100')
-  })
+    const result = formatCurrency(100, 'USD');
+    expect(result).toContain('100');
+  });
 
   it('falls back gracefully for an unrecognised currency code', () => {
-    const result = formatCurrency(50, 'XYZ')
-    expect(result).toContain('50')
-  })
-})
+    const result = formatCurrency(50, 'XYZ');
+    expect(result).toContain('50');
+  });
+});
 
 describe('formatRate', () => {
   it('formats a rate string correctly', () => {
-    expect(formatRate(1580, 'USDC', 'NGN')).toBe('1 USDC = 1,580 NGN')
-  })
+    expect(formatRate(1580, 'USDC', 'NGN')).toBe('1 USDC = 1,580 NGN');
+  });
 
   it('includes decimal places for fractional rates', () => {
-    const result = formatRate(1.5025, 'USDC', 'EUR')
-    expect(result).toContain('USDC')
-    expect(result).toContain('EUR')
-  })
-})
+    const result = formatRate(1.5025, 'USDC', 'EUR');
+    expect(result).toContain('USDC');
+    expect(result).toContain('EUR');
+  });
+});
 
 describe('truncatePublicKey', () => {
   it('shows first 4 and last 4 chars of a 56-char key', () => {
-    const key = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRST'
-    const result = truncatePublicKey(key)
-    expect(result).toBe('GABC...QRST')
-    expect(result).toContain('...')
-  })
+    const key = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRST';
+    const result = truncatePublicKey(key);
+    expect(result).toBe('GABC...QRST');
+    expect(result).toContain('...');
+  });
 
   it('returns the key unchanged if it is 8 chars or fewer', () => {
-    expect(truncatePublicKey('GABCWXYZ')).toBe('GABCWXYZ')
-  })
-})
+    expect(truncatePublicKey('GABCWXYZ')).toBe('GABCWXYZ');
+  });
+});
 
 describe('isExpired', () => {
   it('returns true for a date in the past', () => {
-    const past = new Date(Date.now() - 1000)
-    expect(isExpired(past)).toBe(true)
-  })
+    const past = new Date(Date.now() - 1000);
+    expect(isExpired(past)).toBe(true);
+  });
 
   it('returns false for a date in the future', () => {
-    const future = new Date(Date.now() + 60_000)
-    expect(isExpired(future)).toBe(false)
-  })
-})
+    const future = new Date(Date.now() + 60_000);
+    expect(isExpired(future)).toBe(false);
+  });
+});
 
 describe('timeAgo', () => {
   it('returns "just now" for a very recent date', () => {
-    expect(timeAgo(new Date())).toBe('just now')
-  })
+    expect(timeAgo(new Date())).toBe('just now');
+  });
 
   it('returns minutes for a date a few minutes ago', () => {
-    const d = new Date(Date.now() - 3 * 60 * 1000)
-    expect(timeAgo(d)).toBe('3 minutes ago')
-  })
+    const d = new Date(Date.now() - 3 * 60 * 1000);
+    expect(timeAgo(d)).toBe('3 minutes ago');
+  });
 
   it('returns hours for a date hours ago', () => {
-    const d = new Date(Date.now() - 2 * 60 * 60 * 1000)
-    expect(timeAgo(d)).toBe('2 hours ago')
-  })
-})
+    const d = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    expect(timeAgo(d)).toBe('2 hours ago');
+  });
+});

--- a/tests/rate-ranking.spec.ts
+++ b/tests/rate-ranking.spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import fc from 'fast-check'
-import { computeRateComparison } from '@/lib/stellar/sep24'
-import type { AnchorRate } from '@/types'
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { computeRateComparison } from '@/lib/stellar/sep24';
+import type { AnchorRate } from '@/types';
 
 /**
  * Property tests for rate ranking invariants.
@@ -29,7 +29,7 @@ function createMockRate(
     source: 'sep24-fee',
     updatedAt: new Date(),
     ...overrides,
-  }
+  };
 }
 
 // ─── Sort stability ───────────────────────────────────────────────────────────
@@ -40,36 +40,40 @@ describe('computeRateComparison — sort stability', () => {
       createMockRate('anchor-a', 100),
       createMockRate('anchor-b', 150),
       createMockRate('anchor-c', 120),
-    ]
+    ];
 
-    const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-      status: 'fulfilled',
-      value: r,
-    }))
-
-    const comparison1 = computeRateComparison(results, 'usdc-ngn')
-    const comparison2 = computeRateComparison(results, 'usdc-ngn')
-
-    expect(comparison1.bestRateId).toBe(comparison2.bestRateId)
-    expect(comparison1.bestRateId).toBe('anchor-b')
-  })
-
-  it('deterministically selects the highest totalReceived across multiple calls', () => {
-    const rate1 = createMockRate('anchor-a', 100)
-    const rate2 = createMockRate('anchor-b', 200)
-    const rate3 = createMockRate('anchor-c', 150)
-
-    for (let i = 0; i < 5; i++) {
-      const results = [rate1, rate2, rate3].map((r): PromiseFulfilledResult<AnchorRate> => ({
+    const results = rates.map(
+      (r): PromiseFulfilledResult<AnchorRate> => ({
         status: 'fulfilled',
         value: r,
-      }))
+      })
+    );
 
-      const comparison = computeRateComparison(results, 'usdc-ngn')
-      expect(comparison.bestRateId).toBe('anchor-b')
+    const comparison1 = computeRateComparison(results, 'usdc-ngn');
+    const comparison2 = computeRateComparison(results, 'usdc-ngn');
+
+    expect(comparison1.bestRateId).toBe(comparison2.bestRateId);
+    expect(comparison1.bestRateId).toBe('anchor-b');
+  });
+
+  it('deterministically selects the highest totalReceived across multiple calls', () => {
+    const rate1 = createMockRate('anchor-a', 100);
+    const rate2 = createMockRate('anchor-b', 200);
+    const rate3 = createMockRate('anchor-c', 150);
+
+    for (let i = 0; i < 5; i++) {
+      const results = [rate1, rate2, rate3].map(
+        (r): PromiseFulfilledResult<AnchorRate> => ({
+          status: 'fulfilled',
+          value: r,
+        })
+      );
+
+      const comparison = computeRateComparison(results, 'usdc-ngn');
+      expect(comparison.bestRateId).toBe('anchor-b');
     }
-  })
-})
+  });
+});
 
 // ─── Monotonicity ─────────────────────────────────────────────────────────────
 
@@ -80,54 +84,56 @@ describe('computeRateComparison — monotonicity', () => {
       createMockRate('anchor-b', 1200),
       createMockRate('anchor-c', 800),
       createMockRate('anchor-d', 650),
-    ]
+    ];
 
-    const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-      status: 'fulfilled',
-      value: r,
-    }))
+    const results = rates.map(
+      (r): PromiseFulfilledResult<AnchorRate> => ({
+        status: 'fulfilled',
+        value: r,
+      })
+    );
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
+    const comparison = computeRateComparison(results, 'usdc-ngn');
 
-    const bestRate = comparison.rates.find((r) => r.anchorId === comparison.bestRateId)
-    expect(bestRate).toBeDefined()
-    expect(bestRate?.totalReceived).toBe(1200)
+    const bestRate = comparison.rates.find((r) => r.anchorId === comparison.bestRateId);
+    expect(bestRate).toBeDefined();
+    expect(bestRate?.totalReceived).toBe(1200);
 
     // Verify no other rate is higher
     comparison.rates.forEach((rate) => {
-      expect(rate.totalReceived).toBeLessThanOrEqual(bestRate!.totalReceived)
-    })
-  })
+      expect(rate.totalReceived).toBeLessThanOrEqual(bestRate!.totalReceived);
+    });
+  });
 
   it('handles a single rate correctly', () => {
-    const rate = createMockRate('anchor-a', 100)
-    const results: PromiseFulfilledResult<AnchorRate>[] = [
-      { status: 'fulfilled', value: rate },
-    ]
+    const rate = createMockRate('anchor-a', 100);
+    const results: PromiseFulfilledResult<AnchorRate>[] = [{ status: 'fulfilled', value: rate }];
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.bestRateId).toBe('anchor-a')
-  })
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.bestRateId).toBe('anchor-a');
+  });
 
   it('preserves all provided rates in the output', () => {
     const rates = [
       createMockRate('anchor-a', 100),
       createMockRate('anchor-b', 200),
       createMockRate('anchor-c', 150),
-    ]
+    ];
 
-    const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-      status: 'fulfilled',
-      value: r,
-    }))
+    const results = rates.map(
+      (r): PromiseFulfilledResult<AnchorRate> => ({
+        status: 'fulfilled',
+        value: r,
+      })
+    );
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.rates).toHaveLength(3)
-    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-a')
-    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-b')
-    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-c')
-  })
-})
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.rates).toHaveLength(3);
+    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-a');
+    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-b');
+    expect(comparison.rates.map((r) => r.anchorId)).toContain('anchor-c');
+  });
+});
 
 // ─── Empty / error handling ───────────────────────────────────────────────────
 
@@ -136,126 +142,153 @@ describe('computeRateComparison — edge cases', () => {
     const results: PromiseSettledResult<AnchorRate>[] = [
       { status: 'rejected', reason: new Error('Network error') },
       { status: 'rejected', reason: new Error('Timeout') },
-    ]
+    ];
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.rates).toHaveLength(0)
-    expect(comparison.bestRateId).toBe('')
-  })
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.rates).toHaveLength(0);
+    expect(comparison.bestRateId).toBe('');
+  });
 
   it('ignores rejected results and only considers fulfilled ones', () => {
-    const rate1 = createMockRate('anchor-a', 100)
-    const rate2 = createMockRate('anchor-b', 300)
+    const rate1 = createMockRate('anchor-a', 100);
+    const rate2 = createMockRate('anchor-b', 300);
 
     const results: PromiseSettledResult<AnchorRate>[] = [
       { status: 'fulfilled', value: rate1 },
       { status: 'rejected', reason: new Error('Network error') },
       { status: 'fulfilled', value: rate2 },
-    ]
+    ];
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.rates).toHaveLength(2)
-    expect(comparison.bestRateId).toBe('anchor-b')
-  })
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.rates).toHaveLength(2);
+    expect(comparison.bestRateId).toBe('anchor-b');
+  });
 
   it('correctly identifies best rate even when it appears last', () => {
     const rates = [
       createMockRate('anchor-a', 100),
       createMockRate('anchor-b', 50),
       createMockRate('anchor-c', 999),
-    ]
+    ];
 
-    const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-      status: 'fulfilled',
-      value: r,
-    }))
+    const results = rates.map(
+      (r): PromiseFulfilledResult<AnchorRate> => ({
+        status: 'fulfilled',
+        value: r,
+      })
+    );
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.bestRateId).toBe('anchor-c')
-  })
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.bestRateId).toBe('anchor-c');
+  });
 
   it('correctly identifies best rate even when it appears first', () => {
     const rates = [
       createMockRate('anchor-a', 999),
       createMockRate('anchor-b', 100),
       createMockRate('anchor-c', 50),
-    ]
+    ];
 
-    const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-      status: 'fulfilled',
-      value: r,
-    }))
+    const results = rates.map(
+      (r): PromiseFulfilledResult<AnchorRate> => ({
+        status: 'fulfilled',
+        value: r,
+      })
+    );
 
-    const comparison = computeRateComparison(results, 'usdc-ngn')
-    expect(comparison.bestRateId).toBe('anchor-a')
-  })
-})
+    const comparison = computeRateComparison(results, 'usdc-ngn');
+    expect(comparison.bestRateId).toBe('anchor-a');
+  });
+});
 
 // ─── Property-based tests with fast-check ─────────────────────────────────────
 
 describe('computeRateComparison — property tests', () => {
   it('bestRateId always has the maximum totalReceived (for non-empty arrays)', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
-        const rates = totalReceivedValues.map((total, idx) =>
-          createMockRate(`anchor-${idx}`, total)
-        )
+      fc.property(
+        fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), {
+          minLength: 1,
+        }),
+        (totalReceivedValues) => {
+          const rates = totalReceivedValues.map((total, idx) =>
+            createMockRate(`anchor-${idx}`, total)
+          );
 
-        const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-          status: 'fulfilled',
-          value: r,
-        }))
+          const results = rates.map(
+            (r): PromiseFulfilledResult<AnchorRate> => ({
+              status: 'fulfilled',
+              value: r,
+            })
+          );
 
-        const comparison = computeRateComparison(results, 'usdc-ngn')
-        const bestRate = comparison.rates.find((r) => r.anchorId === comparison.bestRateId)
+          const comparison = computeRateComparison(results, 'usdc-ngn');
+          const bestRate = comparison.rates.find((r) => r.anchorId === comparison.bestRateId);
 
-        // The best rate must exist and have the maximum totalReceived
-        expect(bestRate).toBeDefined()
-        expect(bestRate?.totalReceived).toBe(Math.max(...totalReceivedValues))
-      })
-    )
-  })
+          // The best rate must exist and have the maximum totalReceived
+          expect(bestRate).toBeDefined();
+          expect(bestRate?.totalReceived).toBe(Math.max(...totalReceivedValues));
+        }
+      )
+    );
+  });
 
   it('reordering inputs does not change bestRateId', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
-        const rates1 = totalReceivedValues.map((total, idx) =>
-          createMockRate(`anchor-${idx}`, total)
-        )
-        const rates2 = [...rates1].reverse()
+      fc.property(
+        fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), {
+          minLength: 1,
+        }),
+        (totalReceivedValues) => {
+          const rates1 = totalReceivedValues.map((total, idx) =>
+            createMockRate(`anchor-${idx}`, total)
+          );
+          const rates2 = [...rates1].reverse();
 
-        const results1 = rates1.map((r): PromiseFulfilledResult<AnchorRate> => ({
-          status: 'fulfilled',
-          value: r,
-        }))
-        const results2 = rates2.map((r): PromiseFulfilledResult<AnchorRate> => ({
-          status: 'fulfilled',
-          value: r,
-        }))
+          const results1 = rates1.map(
+            (r): PromiseFulfilledResult<AnchorRate> => ({
+              status: 'fulfilled',
+              value: r,
+            })
+          );
+          const results2 = rates2.map(
+            (r): PromiseFulfilledResult<AnchorRate> => ({
+              status: 'fulfilled',
+              value: r,
+            })
+          );
 
-        const comparison1 = computeRateComparison(results1, 'usdc-ngn')
-        const comparison2 = computeRateComparison(results2, 'usdc-ngn')
+          const comparison1 = computeRateComparison(results1, 'usdc-ngn');
+          const comparison2 = computeRateComparison(results2, 'usdc-ngn');
 
-        expect(comparison1.bestRateId).toBe(comparison2.bestRateId)
-      })
-    )
-  })
+          expect(comparison1.bestRateId).toBe(comparison2.bestRateId);
+        }
+      )
+    );
+  });
 
   it('output rate array contains exactly as many items as non-rejected inputs', () => {
     fc.assert(
-      fc.property(fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), { minLength: 1 }), (totalReceivedValues) => {
-        const rates = totalReceivedValues.map((total, idx) =>
-          createMockRate(`anchor-${idx}`, total)
-        )
+      fc.property(
+        fc.array(fc.float({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true }), {
+          minLength: 1,
+        }),
+        (totalReceivedValues) => {
+          const rates = totalReceivedValues.map((total, idx) =>
+            createMockRate(`anchor-${idx}`, total)
+          );
 
-        const results = rates.map((r): PromiseFulfilledResult<AnchorRate> => ({
-          status: 'fulfilled',
-          value: r,
-        }))
+          const results = rates.map(
+            (r): PromiseFulfilledResult<AnchorRate> => ({
+              status: 'fulfilled',
+              value: r,
+            })
+          );
 
-        const comparison = computeRateComparison(results, 'usdc-ngn')
-        expect(comparison.rates).toHaveLength(totalReceivedValues.length)
-      })
-    )
-  })
-})
+          const comparison = computeRateComparison(results, 'usdc-ngn');
+          expect(comparison.rates).toHaveLength(totalReceivedValues.length);
+        }
+      )
+    );
+  });
+});

--- a/tests/rates-fallback.spec.tsx
+++ b/tests/rates-fallback.spec.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { RateTable } from '@/components/offramp/RateTable'
-import type { AnchorRate, RateComparison } from '@/types'
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RateTable } from '@/components/offramp/RateTable';
+import type { AnchorRate, RateComparison } from '@/types';
 
 const unavailableRate: AnchorRate = {
   anchorId: 'cowrie',
@@ -13,21 +13,21 @@ const unavailableRate: AnchorRate = {
   totalReceived: null,
   updatedAt: new Date(),
   source: 'unavailable',
-}
+};
 
 const unavailableRates: RateComparison = {
   corridorId: 'usdc-ngn',
   bestRateId: '',
   rates: [unavailableRate],
-}
+};
 
 describe('rates-fallback — source: unavailable', () => {
   it('source is "unavailable" and all rate fields are null', () => {
-    expect(unavailableRate.source).toBe('unavailable')
-    expect(unavailableRate.fee).toBeNull()
-    expect(unavailableRate.exchangeRate).toBeNull()
-    expect(unavailableRate.totalReceived).toBeNull()
-  })
+    expect(unavailableRate.source).toBe('unavailable');
+    expect(unavailableRate.fee).toBeNull();
+    expect(unavailableRate.exchangeRate).toBeNull();
+    expect(unavailableRate.totalReceived).toBeNull();
+  });
 
   it('renders "—" for fee, rate, and totalReceived when source is unavailable', () => {
     render(
@@ -37,10 +37,10 @@ describe('rates-fallback — source: unavailable', () => {
         error={undefined}
         onSelectAnchor={vi.fn()}
       />
-    )
-    const dashes = screen.getAllByText('—')
-    expect(dashes.length).toBeGreaterThanOrEqual(3)
-  })
+    );
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
 
   it('shows the "Unavailable" badge and no "Best Rate" badge', () => {
     render(
@@ -50,10 +50,10 @@ describe('rates-fallback — source: unavailable', () => {
         error={undefined}
         onSelectAnchor={vi.fn()}
       />
-    )
-    expect(screen.getByText('Unavailable')).toBeInTheDocument()
-    expect(screen.queryByText('Best Rate')).not.toBeInTheDocument()
-  })
+    );
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Best Rate')).not.toBeInTheDocument();
+  });
 
   it('disables the Off-ramp button for unavailable anchors', () => {
     render(
@@ -63,10 +63,10 @@ describe('rates-fallback — source: unavailable', () => {
         error={undefined}
         onSelectAnchor={vi.fn()}
       />
-    )
-    const button = screen.getByRole('button', { name: 'Off-ramp' })
-    expect(button).toBeDisabled()
-  })
+    );
+    const button = screen.getByRole('button', { name: 'Off-ramp' });
+    expect(button).toBeDisabled();
+  });
 
   it('does not render any numeric rate values for unavailable anchors', () => {
     const { container } = render(
@@ -76,9 +76,9 @@ describe('rates-fallback — source: unavailable', () => {
         error={undefined}
         onSelectAnchor={vi.fn()}
       />
-    )
-    const cellText = Array.from(container.querySelectorAll('td')).map((td) => td.textContent)
-    const hasNumericRate = cellText.some((t) => t !== null && /1 USDC =/.test(t))
-    expect(hasNumericRate).toBe(false)
-  })
-})
+    );
+    const cellText = Array.from(container.querySelectorAll('td')).map((td) => td.textContent);
+    const hasNumericRate = cellText.some((t) => t !== null && /1 USDC =/.test(t));
+    expect(hasNumericRate).toBe(false);
+  });
+});

--- a/tests/sep1-retry.spec.ts
+++ b/tests/sep1-retry.spec.ts
@@ -1,7 +1,6 @@
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { resolveToml, _clearTomlCache } from '@/lib/stellar/sep1'
-import type { TomlResult } from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveToml, _clearTomlCache } from '@/lib/stellar/sep1';
+import type { TomlResult } from '@/lib/stellar/sep1';
 
 // ─── Shared TOML fixture ───────────────────────────────────────────────────────
 
@@ -9,8 +8,10 @@ const GOOD_TOML = {
   TRANSFER_SERVER_SEP0024: 'https://anchor.example.com/sep24',
   WEB_AUTH_ENDPOINT: 'https://anchor.example.com/auth',
   SIGNING_KEY: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-  CURRENCIES: [{ code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' }],
-}
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
+};
 
 // ─── Module mock ──────────────────────────────────────────────────────────────
 vi.mock('@stellar/stellar-sdk', () => ({
@@ -19,197 +20,194 @@ vi.mock('@stellar/stellar-sdk', () => ({
       resolve: vi.fn(),
     },
   },
-}))
+}));
 
 // Mock the anchors list so resolveAllAnchors doesn't need real data in other tests.
 vi.mock('@/lib/stellar/anchors', () => ({
   ANCHORS: [],
-}))
+}));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 async function getMockedResolve() {
-  const { StellarToml } = await import('@stellar/stellar-sdk')
-  return StellarToml.Resolver.resolve as ReturnType<typeof vi.fn>
+  const { StellarToml } = await import('@stellar/stellar-sdk');
+  return StellarToml.Resolver.resolve as ReturnType<typeof vi.fn>;
 }
 
 /** Fast-forward fake timers by `ms` and flush the micro-task queue. */
 async function tick(ms: number) {
-  await vi.advanceTimersByTimeAsync(ms)
+  await vi.advanceTimersByTimeAsync(ms);
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
 
 describe('resolveToml — retry & typed result', () => {
   beforeEach(() => {
-    _clearTomlCache()
-    vi.clearAllMocks()
-    vi.useFakeTimers()
-  })
+    _clearTomlCache();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-    vi.useRealTimers()
-  })
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
 
   // ── 1. Happy path ──────────────────────────────────────────────────────────
 
   it('returns { ok: true, data } when the server responds immediately', async () => {
-    const mockResolve = await getMockedResolve()
-    mockResolve.mockResolvedValueOnce(GOOD_TOML)
+    const mockResolve = await getMockedResolve();
+    mockResolve.mockResolvedValueOnce(GOOD_TOML);
 
-    const promise = resolveToml('anchor.example.com')
-    await tick(0) // let the promise resolve
-    const result: TomlResult = await promise
+    const promise = resolveToml('anchor.example.com');
+    await tick(0); // let the promise resolve
+    const result: TomlResult = await promise;
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) throw new Error('type guard')
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('type guard');
 
-    expect(result.data.TRANSFER_SERVER_SEP0024).toBe(GOOD_TOML.TRANSFER_SERVER_SEP0024)
-    expect(result.data.WEB_AUTH_ENDPOINT).toBe(GOOD_TOML.WEB_AUTH_ENDPOINT)
-    expect(result.data.SIGNING_KEY).toBe(GOOD_TOML.SIGNING_KEY)
-    expect(mockResolve).toHaveBeenCalledTimes(1)
-  })
+    expect(result.data.TRANSFER_SERVER_SEP0024).toBe(GOOD_TOML.TRANSFER_SERVER_SEP0024);
+    expect(result.data.WEB_AUTH_ENDPOINT).toBe(GOOD_TOML.WEB_AUTH_ENDPOINT);
+    expect(result.data.SIGNING_KEY).toBe(GOOD_TOML.SIGNING_KEY);
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
 
   // ── 2. Flaky server (AC: resolves on retry 2) ─────────────────────────────
 
   it('resolves on the 3rd attempt when the first two fail', async () => {
-    const mockResolve = await getMockedResolve()
-    const networkError = new Error('ECONNRESET')
+    const mockResolve = await getMockedResolve();
+    const networkError = new Error('ECONNRESET');
 
     // Attempt 0 → fail, Attempt 1 → fail, Attempt 2 → succeed
     mockResolve
-      .mockRejectedValueOnce(networkError)   // attempt 0
-      .mockRejectedValueOnce(networkError)   // attempt 1 (retry 1)
-      .mockResolvedValueOnce(GOOD_TOML)      // attempt 2 (retry 2) ← resolves here
+      .mockRejectedValueOnce(networkError) // attempt 0
+      .mockRejectedValueOnce(networkError) // attempt 1 (retry 1)
+      .mockResolvedValueOnce(GOOD_TOML); // attempt 2 (retry 2) ← resolves here
 
-    const promise = resolveToml('flaky.anchor.io')
+    const promise = resolveToml('flaky.anchor.io');
 
+    await tick(250);
+    await tick(500);
 
-    await tick(250)   
-    await tick(500)   
+    const result = await promise;
 
-    const result = await promise
-
-    expect(result.ok).toBe(true)
-    expect(mockResolve).toHaveBeenCalledTimes(3)
-  })
+    expect(result.ok).toBe(true);
+    expect(mockResolve).toHaveBeenCalledTimes(3);
+  });
 
   // ── 3. Permanent failure — never throws, returns typed error ──────────────
 
   it('returns { ok: false, error } after all retries without throwing', async () => {
-    const mockResolve = await getMockedResolve()
-    mockResolve.mockRejectedValue(new Error('503 Service Unavailable'))
+    const mockResolve = await getMockedResolve();
+    mockResolve.mockRejectedValue(new Error('503 Service Unavailable'));
 
-    const promise = resolveToml('down.anchor.io')
+    const promise = resolveToml('down.anchor.io');
 
-   
-    await tick(250)   
-    await tick(500)   
-    
+    await tick(250);
+    await tick(500);
 
-    const result = await promise
+    const result = await promise;
 
-    expect(result.ok).toBe(false)
-    if (result.ok) throw new Error('type guard')
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('type guard');
 
-    expect(result.error).toMatch(/503 Service Unavailable/)
-    
-    expect(mockResolve).toHaveBeenCalledTimes(3)
-  })
+    expect(result.error).toMatch(/503 Service Unavailable/);
+
+    expect(mockResolve).toHaveBeenCalledTimes(3);
+  });
 
   it('result is a plain value — the promise itself never rejects', async () => {
-    const mockResolve = await getMockedResolve()
-    mockResolve.mockRejectedValue(new Error('always fails'))
+    const mockResolve = await getMockedResolve();
+    mockResolve.mockRejectedValue(new Error('always fails'));
 
-    const promise = resolveToml('always-down.anchor.io')
-    await tick(250)
-    await tick(500)
-    await expect(promise).resolves.toMatchObject({ ok: false })
-  })
+    const promise = resolveToml('always-down.anchor.io');
+    await tick(250);
+    await tick(500);
+    await expect(promise).resolves.toMatchObject({ ok: false });
+  });
 
   // ── 4. Missing required field → typed error, not exception ────────────────
 
   it('returns { ok: true } but sep24: false when TRANSFER_SERVER_SEP0024 is absent', async () => {
-    const mockResolve = await getMockedResolve()
+    const mockResolve = await getMockedResolve();
     mockResolve.mockResolvedValueOnce({
       WEB_AUTH_ENDPOINT: 'https://anchor.example.com/auth',
-    })
+    });
 
-    const promise = resolveToml('partial.anchor.io')
-    await tick(0)
-    const result = await promise
+    const promise = resolveToml('partial.anchor.io');
+    await tick(0);
+    const result = await promise;
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) throw new Error('type guard')
-    expect(result.data.capabilities.sep24).toBe(false)
-    expect(result.data.capabilities.sep10).toBe(true)
-    expect(mockResolve).toHaveBeenCalledTimes(1)
-  })
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('type guard');
+    expect(result.data.capabilities.sep24).toBe(false);
+    expect(result.data.capabilities.sep10).toBe(true);
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
 
   it('returns { ok: true } but sep10: false when WEB_AUTH_ENDPOINT is absent', async () => {
-    const mockResolve = await getMockedResolve()
+    const mockResolve = await getMockedResolve();
     mockResolve.mockResolvedValueOnce({
       TRANSFER_SERVER_SEP0024: 'https://anchor.example.com/sep24',
       // intentionally omit WEB_AUTH_ENDPOINT
-    })
+    });
 
-    const promise = resolveToml('noauth.anchor.io')
-    await tick(0)
-    const result = await promise
+    const promise = resolveToml('noauth.anchor.io');
+    await tick(0);
+    const result = await promise;
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) throw new Error('type guard')
-    expect(result.data.capabilities.sep10).toBe(false)
-    expect(result.data.capabilities.sep24).toBe(true)
-    expect(mockResolve).toHaveBeenCalledTimes(1)
-  })
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('type guard');
+    expect(result.data.capabilities.sep10).toBe(false);
+    expect(result.data.capabilities.sep24).toBe(true);
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
 
   // ── 5. Cache — second call uses cache, no extra network hit ───────────────
 
   it('returns cached data on the second call without calling the network again', async () => {
-    const mockResolve = await getMockedResolve()
-    mockResolve.mockResolvedValue(GOOD_TOML)
+    const mockResolve = await getMockedResolve();
+    mockResolve.mockResolvedValue(GOOD_TOML);
 
-    const promise1 = resolveToml('cached.anchor.io')
-    await tick(0)
-    const result1 = await promise1
+    const promise1 = resolveToml('cached.anchor.io');
+    await tick(0);
+    const result1 = await promise1;
 
-    const promise2 = resolveToml('cached.anchor.io')
-    await tick(0)
-    const result2 = await promise2
+    const promise2 = resolveToml('cached.anchor.io');
+    await tick(0);
+    const result2 = await promise2;
 
-    expect(result1.ok).toBe(true)
-    expect(result2.ok).toBe(true)
-    expect(mockResolve).toHaveBeenCalledTimes(1)
-  })
+    expect(result1.ok).toBe(true);
+    expect(result2.ok).toBe(true);
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
 
   // ── 6. Budget guard — stops retrying when wall-clock would exceed 5 s ─────
 
   it('stops retrying early if the budget would be exceeded by the next delay', async () => {
-    const mockResolve = await getMockedResolve()
+    const mockResolve = await getMockedResolve();
 
-    let callCount = 0
+    let callCount = 0;
     mockResolve.mockImplementation(() => {
-      callCount++
+      callCount++;
       if (callCount <= 2) {
         // Burn 4.6 s of wall-clock on attempt 2
         return new Promise((_, reject) =>
           setTimeout(() => reject(new Error('timeout')), callCount === 2 ? 4600 : 0)
-        )
+        );
       }
-      return Promise.resolve(GOOD_TOML)
-    })
+      return Promise.resolve(GOOD_TOML);
+    });
 
-    const promise = resolveToml('slow.anchor.io')
+    const promise = resolveToml('slow.anchor.io');
 
-    await tick(250)
-    await tick(4600)
+    await tick(250);
+    await tick(4600);
 
-    const result = await promise
+    const result = await promise;
 
-    expect(result.ok).toBe(false)
-    if (result.ok) throw new Error('type guard')
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('type guard');
     // Should have stopped at attempt 1 or 2 — never reached the good mock
-    expect(callCount).toBeLessThan(3)
-  })
-})
+    expect(callCount).toBeLessThan(3);
+  });
+});

--- a/tests/sep1.fixture.spec.ts
+++ b/tests/sep1.fixture.spec.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { StellarToml } from '@stellar/stellar-sdk'
-import { resolveToml, _clearTomlCache } from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StellarToml } from '@stellar/stellar-sdk';
+import { resolveToml, _clearTomlCache } from '@/lib/stellar/sep1';
 
 describe('SEP-1 Resolver Fixtures', () => {
   beforeEach(() => {
-    _clearTomlCache()
-    vi.restoreAllMocks()
-  })
+    _clearTomlCache();
+    vi.restoreAllMocks();
+  });
 
   const fixtures = [
     {
@@ -130,21 +130,22 @@ describe('SEP-1 Resolver Fixtures', () => {
         },
       },
     },
-  ]
+  ];
 
   fixtures.forEach(({ name, domain, toml, expected }) => {
     it(`correctly resolves capabilities and endpoints for ${name}`, async () => {
-      vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(toml as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.spyOn(StellarToml.Resolver, 'resolve').mockResolvedValue(toml as any);
 
-      const result = await resolveToml(domain)
+      const result = await resolveToml(domain);
 
-      expect(result.ok).toBe(true)
+      expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.data.TRANSFER_SERVER_SEP0024).toBe(expected.TRANSFER_SERVER_SEP0024)
-        expect(result.data.WEB_AUTH_ENDPOINT).toBe(expected.WEB_AUTH_ENDPOINT)
-        expect(result.data.SIGNING_KEY).toBe(expected.SIGNING_KEY)
-        expect(result.data.capabilities).toEqual(expected.capabilities)
+        expect(result.data.TRANSFER_SERVER_SEP0024).toBe(expected.TRANSFER_SERVER_SEP0024);
+        expect(result.data.WEB_AUTH_ENDPOINT).toBe(expected.WEB_AUTH_ENDPOINT);
+        expect(result.data.SIGNING_KEY).toBe(expected.SIGNING_KEY);
+        expect(result.data.capabilities).toEqual(expected.capabilities);
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -19,6 +19,12 @@ const mockResolvedAnchor = (domain: string) => ({
   TRANSFER_SERVER_SEP0024: `https://${domain}/sep24`,
   WEB_AUTH_ENDPOINT: `https://${domain}/auth`,
   SIGNING_KEY: 'G...',
+  domain: 'cowrie.exchange',
+  ANCHOR_QUOTE_SERVER: null,
+  NETWORK_PASSPHRASE: null,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 });
 

--- a/tests/sep10-cache.spec.ts
+++ b/tests/sep10-cache.spec.ts
@@ -1,14 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Networks } from '@stellar/stellar-sdk'
-import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10'
-import { clearJwtCache, setJwtCacheCapacity, getCachedJwt } from '@/lib/stellar/jwt-cache'
-import * as sep1 from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Networks } from '@stellar/stellar-sdk';
+import { authenticate, invalidateSep10Token } from '@/lib/stellar/sep10';
+import { clearJwtCache, setJwtCacheCapacity, getCachedJwt } from '@/lib/stellar/jwt-cache';
 
-const WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth'
-const ANCHOR = 'cowrie.exchange'
-const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789'
-const CHALLENGE_XDR = 'AAAAAQAAAAC...'
-const SIGNED_XDR = 'AAAAAQAAAAD...'
+const _WEB_AUTH_ENDPOINT = 'https://cowrie.exchange/auth';
+const ANCHOR = 'cowrie.exchange';
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234567890123456789';
+const CHALLENGE_XDR = 'AAAAAQAAAAC...';
+const SIGNED_XDR = 'AAAAAQAAAAD...';
 
 const mockResolvedAnchor = (domain: string) => ({
   id: domain.split('.')[0] || 'anchor',
@@ -21,26 +20,26 @@ const mockResolvedAnchor = (domain: string) => ({
   WEB_AUTH_ENDPOINT: `https://${domain}/auth`,
   SIGNING_KEY: 'G...',
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
-})
+});
 
 vi.mock('@stellar/freighter-api', () => ({
   signTransaction: vi.fn(),
-}))
+}));
 
 function makeJwt(expSeconds: number): string {
-  const b64url = (s: string) =>
-    btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
-  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
-  const payload = b64url(JSON.stringify({ exp: expSeconds }))
-  return `${header}.${payload}.signature`
+  const b64url = (s: string) => btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ exp: expSeconds }));
+  return `${header}.${payload}.signature`;
 }
 
 async function getFreighter() {
-  return await import('@stellar/freighter-api')
+  return await import('@stellar/freighter-api');
 }
 
 function stubChallengeAndJwt(jwt: string) {
-  const fetchMock = vi.fn()
+  const fetchMock = vi
+    .fn()
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({ transaction: CHALLENGE_XDR, network_passphrase: Networks.PUBLIC }),
@@ -48,104 +47,107 @@ function stubChallengeAndJwt(jwt: string) {
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({ token: jwt }),
-    })
-  vi.stubGlobal('fetch', fetchMock)
-  return fetchMock
+    });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
 }
 
 beforeEach(async () => {
-  vi.restoreAllMocks()
-  clearJwtCache()
-  setJwtCacheCapacity(32)
+  vi.restoreAllMocks();
+  clearJwtCache();
+  setJwtCacheCapacity(32);
 
-  const freighter = await getFreighter()
+  const freighter = await getFreighter();
   vi.mocked(freighter.signTransaction).mockResolvedValue({
     signedTxXdr: SIGNED_XDR,
     signerAddress: PUBLIC_KEY,
-  })
-})
+  });
+});
 
 describe('SEP-10 JWT cache', () => {
   it('second call within validity returns cached token without invoking Freighter', async () => {
-    const exp = Math.floor(Date.now() / 1000) + 3600
-    stubChallengeAndJwt(makeJwt(exp))
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    stubChallengeAndJwt(makeJwt(exp));
 
-    const first = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
+    const first = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
 
-    const freighter = await getFreighter()
-    vi.mocked(freighter.signTransaction).mockClear()
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      throw new Error('fetch should not be called on cache hit')
-    }))
+    const freighter = await getFreighter();
+    vi.mocked(freighter.signTransaction).mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('fetch should not be called on cache hit');
+      })
+    );
 
-    const second = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
+    const second = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
 
-    expect(second.jwt).toBe(first.jwt)
-    expect(second.expiresAt.getTime()).toBe(first.expiresAt.getTime())
-    expect(freighter.signTransaction).not.toHaveBeenCalled()
-  })
+    expect(second.jwt).toBe(first.jwt);
+    expect(second.expiresAt.getTime()).toBe(first.expiresAt.getTime());
+    expect(freighter.signTransaction).not.toHaveBeenCalled();
+  });
 
   it('expired cached token triggers a fresh sign flow', async () => {
-    const shortExp = Math.floor(Date.now() / 1000) + 1
-    stubChallengeAndJwt(makeJwt(shortExp))
+    const shortExp = Math.floor(Date.now() / 1000) + 1;
+    stubChallengeAndJwt(makeJwt(shortExp));
 
-    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
 
     // Advance past expiry
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date((shortExp + 5) * 1000))
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date((shortExp + 5) * 1000));
 
-    const freighter = await getFreighter()
-    vi.mocked(freighter.signTransaction).mockClear()
+    const freighter = await getFreighter();
+    vi.mocked(freighter.signTransaction).mockClear();
 
-    const newExp = Math.floor(Date.now() / 1000) + 3600
-    stubChallengeAndJwt(makeJwt(newExp))
+    const newExp = Math.floor(Date.now() / 1000) + 3600;
+    stubChallengeAndJwt(makeJwt(newExp));
 
-    const fresh = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
+    const fresh = await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
 
-    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
-    expect(fresh.expiresAt.getTime()).toBe(newExp * 1000)
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1);
+    expect(fresh.expiresAt.getTime()).toBe(newExp * 1000);
 
-    vi.useRealTimers()
-  })
+    vi.useRealTimers();
+  });
 
   it('invalidateSep10Token forces re-authentication on next call', async () => {
-    const exp = Math.floor(Date.now() / 1000) + 3600
-    stubChallengeAndJwt(makeJwt(exp))
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    stubChallengeAndJwt(makeJwt(exp));
 
-    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
-    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeDefined()
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeDefined();
 
     // Simulate downstream 401 response → invalidate
-    invalidateSep10Token(ANCHOR, PUBLIC_KEY)
-    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeUndefined()
+    invalidateSep10Token(ANCHOR, PUBLIC_KEY);
+    expect(getCachedJwt(ANCHOR, PUBLIC_KEY)).toBeUndefined();
 
-    const freighter = await getFreighter()
-    vi.mocked(freighter.signTransaction).mockClear()
-    stubChallengeAndJwt(makeJwt(exp))
+    const freighter = await getFreighter();
+    vi.mocked(freighter.signTransaction).mockClear();
+    stubChallengeAndJwt(makeJwt(exp));
 
-    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY)
-    expect(freighter.signTransaction).toHaveBeenCalledTimes(1)
-  })
+    await authenticate(mockResolvedAnchor(ANCHOR), PUBLIC_KEY);
+    expect(freighter.signTransaction).toHaveBeenCalledTimes(1);
+  });
 
   it('LRU evicts the least-recently-used entry past capacity', async () => {
-    setJwtCacheCapacity(2)
-    const exp = Math.floor(Date.now() / 1000) + 3600
+    setJwtCacheCapacity(2);
+    const exp = Math.floor(Date.now() / 1000) + 3600;
 
-    stubChallengeAndJwt(makeJwt(exp))
-    await authenticate(mockResolvedAnchor('a.example'), PUBLIC_KEY)
+    stubChallengeAndJwt(makeJwt(exp));
+    await authenticate(mockResolvedAnchor('a.example'), PUBLIC_KEY);
 
-    stubChallengeAndJwt(makeJwt(exp))
-    await authenticate(mockResolvedAnchor('b.example'), PUBLIC_KEY)
+    stubChallengeAndJwt(makeJwt(exp));
+    await authenticate(mockResolvedAnchor('b.example'), PUBLIC_KEY);
 
     // Touch 'a' so 'b' becomes the LRU
-    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined();
 
-    stubChallengeAndJwt(makeJwt(exp))
-    await authenticate(mockResolvedAnchor('c.example'), PUBLIC_KEY)
+    stubChallengeAndJwt(makeJwt(exp));
+    await authenticate(mockResolvedAnchor('c.example'), PUBLIC_KEY);
 
-    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined()
-    expect(getCachedJwt('c.example', PUBLIC_KEY)).toBeDefined()
-    expect(getCachedJwt('b.example', PUBLIC_KEY)).toBeUndefined()
-  })
-})
+    expect(getCachedJwt('a.example', PUBLIC_KEY)).toBeDefined();
+    expect(getCachedJwt('c.example', PUBLIC_KEY)).toBeDefined();
+    expect(getCachedJwt('b.example', PUBLIC_KEY)).toBeUndefined();
+  });
+});

--- a/tests/sep10-state.spec.ts
+++ b/tests/sep10-state.spec.ts
@@ -1,13 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Networks, TransactionBuilder, Keypair } from '@stellar/stellar-sdk'
-import {
-  fetchSep10Challenge,
-  signSep10Challenge,
-  exchangeSep10Token,
-  ChallengeError,
-  Sep10AuthError,
-} from '@/lib/stellar/sep10'
-import type { Sep10Challenge } from '@/lib/stellar/sep10'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Networks, TransactionBuilder, Keypair } from '@stellar/stellar-sdk';
+import { fetchSep10Challenge, ChallengeError, Sep10AuthError } from '@/lib/stellar/sep10';
+import type { Sep10Challenge } from '@/lib/stellar/sep10';
 
 /**
  * Tests for SEP-10 authentication state machine.
@@ -21,15 +15,15 @@ import type { Sep10Challenge } from '@/lib/stellar/sep10'
 
 // ─── Test data ─────────────────────────────────────────────────────────────────
 
-const WEB_AUTH_ENDPOINT = 'https://anchor.example.com/auth'
-const PUBLIC_KEY = Keypair.random().publicKey()
-const HOME_DOMAIN = 'anchor.example.com'
+const WEB_AUTH_ENDPOINT = 'https://anchor.example.com/auth';
+const PUBLIC_KEY = Keypair.random().publicKey();
+const HOME_DOMAIN = 'anchor.example.com';
 
 const VALID_CHALLENGE_XDR =
-  'AAAABQAAAACdIFgKKF2vx6r8VJwDi61SEfA/P6kyxyXjKKwwlsxPkwAAAGQAJ4AaAAAAJQAAAAAAAAAAAAAAAEAAAAC3AAAAAAAAAA0AAAABJNfYx0XwJ6hkX2B70u5T51/4LqAPCdAVRmKy6A0YBMsAAAAAAAAAAQAAAAA'
+  'AAAABQAAAACdIFgKKF2vx6r8VJwDi61SEfA/P6kyxyXjKKwwlsxPkwAAAGQAJ4AaAAAAJQAAAAAAAAAAAAAAAEAAAAC3AAAAAAAAAA0AAAABJNfYx0XwJ6hkX2B70u5T51/4LqAPCdAVRmKy6A0YBMsAAAAAAAAAAQAAAAA';
 
 function createMockChallenge(overrides?: Partial<Sep10Challenge>): Sep10Challenge {
-  const keypair = Keypair.random()
+  const keypair = Keypair.random();
   const txBuilder = new TransactionBuilder(
     {
       accountId: keypair.publicKey(),
@@ -37,7 +31,7 @@ function createMockChallenge(overrides?: Partial<Sep10Challenge>): Sep10Challeng
       incrementSequenceNumber: false,
     },
     { base_fee: 100, networkPassphrase: Networks.PUBLIC_NETWORK_PASSPHRASE }
-  )
+  );
 
   const tx = txBuilder
     .addMemo({ type: 'id', value: 12345 })
@@ -47,413 +41,459 @@ function createMockChallenge(overrides?: Partial<Sep10Challenge>): Sep10Challeng
       dataValue: Buffer.from('test-challenge'),
     })
     .setTimeout(300)
-    .build()
+    .build();
 
   return {
     transaction: VALID_CHALLENGE_XDR,
     network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
     parsed: tx,
     ...overrides,
-  }
+  };
 }
 
 // ─── Mock fetch ───────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  vi.clearAllMocks()
-  vi.unstubAllGlobals()
-})
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
 
 // ─── State 1: Challenge fetch ─────────────────────────────────────────────────
 
 describe('SEP-10 state machine — challenge fetch', () => {
   it('fetches challenge from web auth endpoint with account and home_domain params', async () => {
-    let capturedUrl = ''
-    let capturedMethod = ''
+    const _capturedUrl = '';
+    let capturedMethod = '';
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      capturedUrl = url
-      capturedMethod = opts?.method ?? 'GET'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        capturedUrl = url;
+        capturedMethod = opts?.method ?? 'GET';
 
-      return {
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
+
+    await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
+
+    expect(capturedUrl).toContain(WEB_AUTH_ENDPOINT);
+    expect(capturedUrl).toContain(`account=${encodeURIComponent(PUBLIC_KEY)}`);
+    expect(capturedUrl).toContain(`home_domain=${encodeURIComponent(HOME_DOMAIN)}`);
+    expect(capturedMethod).toBe('GET');
+  });
+
+  it('returns a Sep10Challenge with parsed transaction', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
         ok: true,
         json: async () => ({
           transaction: VALID_CHALLENGE_XDR,
           network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
         }),
-      }
-    }))
+      }))
+    );
 
-    await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
+    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
 
-    expect(capturedUrl).toContain(WEB_AUTH_ENDPOINT)
-    expect(capturedUrl).toContain(`account=${encodeURIComponent(PUBLIC_KEY)}`)
-    expect(capturedUrl).toContain(`home_domain=${encodeURIComponent(HOME_DOMAIN)}`)
-    expect(capturedMethod).toBe('GET')
-  })
-
-  it('returns a Sep10Challenge with parsed transaction', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        transaction: VALID_CHALLENGE_XDR,
-        network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-      }),
-    })))
-
-    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-
-    expect(challenge).toHaveProperty('transaction')
-    expect(challenge).toHaveProperty('network_passphrase')
-    expect(challenge).toHaveProperty('parsed')
-    expect(challenge.network_passphrase).toBe(Networks.PUBLIC_NETWORK_PASSPHRASE)
-  })
+    expect(challenge).toHaveProperty('transaction');
+    expect(challenge).toHaveProperty('network_passphrase');
+    expect(challenge).toHaveProperty('parsed');
+    expect(challenge.network_passphrase).toBe(Networks.PUBLIC_NETWORK_PASSPHRASE);
+  });
 
   it('throws ChallengeError with FETCH_FAILED on network error', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      throw new Error('Network error')
-    }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('Network error');
+      })
+    );
 
-    await expect(
-      fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    ).rejects.toThrow(ChallengeError)
+    await expect(fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)).rejects.toThrow(
+      ChallengeError
+    );
 
     try {
-      await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
+      await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
     } catch (err) {
-      expect(err).toBeInstanceOf(ChallengeError)
+      expect(err).toBeInstanceOf(ChallengeError);
       if (err instanceof ChallengeError) {
-        expect(err.code).toBe('FETCH_FAILED')
+        expect(err.code).toBe('FETCH_FAILED');
       }
     }
-  })
+  });
 
   it('throws ChallengeError with MISSING_FIELD on incomplete response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        // missing transaction
-        network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-      }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          // missing transaction
+          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+        }),
+      }))
+    );
 
-    await expect(
-      fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    ).rejects.toThrow(ChallengeError)
-  })
+    await expect(fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)).rejects.toThrow(
+      ChallengeError
+    );
+  });
 
   it('throws ChallengeError on HTTP error response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 400,
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 400,
+      }))
+    );
 
-    await expect(
-      fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    ).rejects.toThrow(ChallengeError)
-  })
-})
+    await expect(fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)).rejects.toThrow(
+      ChallengeError
+    );
+  });
+});
 
 // ─── State 2: Sign ────────────────────────────────────────────────────────────
 
 describe('SEP-10 state machine — sign', () => {
   it('signs the challenge transaction with the user key', async () => {
-    const userKeypair = Keypair.random()
-    const challenge = createMockChallenge()
+    const _userKeypair = Keypair.random();
+    const _challenge = createMockChallenge();
 
-    let capturedXdr = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (url.includes('/auth') && opts?.method === 'POST') {
-        capturedXdr = JSON.parse(opts.body as string).transaction
-      }
-      return { ok: true, json: async () => ({ token: 'test-jwt' }) }
-    }))
+    let _capturedXdr = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (url.includes('/auth') && opts?.method === 'POST') {
+          _capturedXdr = JSON.parse(opts.body as string).transaction;
+        }
+        return { ok: true, json: async () => ({ token: 'test-jwt' }) };
+      })
+    );
 
     // Mock Freighter signing
-    const mockFreighterSign = vi.fn(async (xdr: string) => {
-      const tx = TransactionBuilder.fromXDR(xdr, Networks.PUBLIC_NETWORK_PASSPHRASE)
-      tx.addSignature(userKeypair.publicKey(), userKeypair.sign(Buffer.from(xdr)).toString('base64'))
-      return tx.toXDR()
-    })
+    const _mockFreighterSign = vi.fn(async (xdr: string) => {
+      const tx = TransactionBuilder.fromXDR(xdr, Networks.PUBLIC_NETWORK_PASSPHRASE);
+      tx.addSignature(
+        _userKeypair.publicKey(),
+        _userKeypair.sign(Buffer.from(xdr)).toString('base64')
+      );
+      return tx.toXDR();
+    });
 
     // This tests the general flow; the actual signing is delegated to Freighter API
-    expect(userKeypair).toBeDefined()
-  })
+    expect(_userKeypair).toBeDefined();
+  });
 
   it('does not modify the challenge on signing', async () => {
-    const challenge = createMockChallenge()
-    const originalXdr = challenge.transaction
+    const _challenge = createMockChallenge();
+    const originalXdr = _challenge.transaction;
 
     // The XDR should not change during the sign step (only signatures are added)
-    expect(challenge.transaction).toBe(originalXdr)
-  })
-})
+    expect(_challenge.transaction).toBe(originalXdr);
+  });
+});
 
 // ─── State 3: Exchange ────────────────────────────────────────────────────────
 
 describe('SEP-10 state machine — exchange', () => {
   it('exchanges signed challenge for JWT by POSTing to web auth endpoint', async () => {
-    let capturedUrl = ''
-    let capturedMethod = ''
-    let capturedBody: Record<string, unknown> = {}
+    const _capturedUrl = '';
+    let capturedMethod = '';
+    const _capturedBody: Record<string, unknown> = {};
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      capturedUrl = url
-      capturedMethod = opts?.method ?? 'GET'
-      if (opts?.body) {
-        capturedBody = JSON.parse(opts.body as string)
-      }
-
-      if (capturedMethod === 'POST' && url.includes(WEB_AUTH_ENDPOINT)) {
-        return {
-          ok: true,
-          json: async () => ({
-            token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test',
-          }),
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        capturedUrl = url;
+        capturedMethod = opts?.method ?? 'GET';
+        if (opts?.body) {
+          capturedBody = JSON.parse(opts.body as string);
         }
-      }
 
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
+        if (capturedMethod === 'POST' && url.includes(WEB_AUTH_ENDPOINT)) {
+          return {
+            ok: true,
+            json: async () => ({
+              token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test',
+            }),
+          };
+        }
 
-    const userKeypair = Keypair.random()
-    const challenge = createMockChallenge()
-
-    // Simulate exchange by verifying the POST structure
-    expect(challenge.transaction).toBeDefined()
-  })
-
-  it('returns Sep10Auth with JWT and expiration on success', async () => {
-    const jwtToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test'
-
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.includes('/auth') && url.includes('account=')) {
         return {
           ok: true,
           json: async () => ({
             transaction: VALID_CHALLENGE_XDR,
             network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
           }),
+        };
+      })
+    );
+
+    const _userKeypair = Keypair.random();
+    const _challenge = createMockChallenge();
+
+    // Simulate exchange by verifying the POST structure
+    expect(challenge.transaction).toBeDefined();
+  });
+
+  it('returns Sep10Auth with JWT and expiration on success', async () => {
+    const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/auth') && url.includes('account=')) {
+          return {
+            ok: true,
+            json: async () => ({
+              transaction: VALID_CHALLENGE_XDR,
+              network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+            }),
+          };
         }
-      }
-      return {
-        ok: true,
-        json: async () => ({ token: jwtToken }),
-      }
-    }))
-
-    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    expect(challenge).toBeDefined()
-  })
-
-  it('throws Sep10AuthError on exchange HTTP error', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
-        return {
-          ok: false,
-          status: 401,
-        }
-      }
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
-
-    // The exchange error handling is tested implicitly through the exchange phase
-    expect(Sep10AuthError).toBeDefined()
-  })
-
-  it('handles invalid JWT response gracefully', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
         return {
           ok: true,
-          json: async () => ({}), // missing token
-        }
-      }
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
+          json: async () => ({ token: jwtToken }),
+        };
+      })
+    );
 
-    expect(true).toBe(true)
-  })
-})
+    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
+    expect(challenge).toBeDefined();
+  });
+
+  it('throws Sep10AuthError on exchange HTTP error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          return {
+            ok: false,
+            status: 401,
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
+
+    // The exchange error handling is tested implicitly through the exchange phase
+    expect(Sep10AuthError).toBeDefined();
+  });
+
+  it('handles invalid JWT response gracefully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({}), // missing token
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
+
+    expect(true).toBe(true);
+  });
+});
 
 // ─── State machine transitions ────────────────────────────────────────────────
 
 describe('SEP-10 state machine — transitions', () => {
   it('completes full challenge → sign → exchange flow', async () => {
-    const jwtToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test'
-    let callCount = 0
+    const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test';
+    let callCount = 0;
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      callCount++
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        callCount++;
 
-      // First call: challenge fetch
-      if (opts?.method !== 'POST') {
+        // First call: challenge fetch
+        if (opts?.method !== 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              transaction: VALID_CHALLENGE_XDR,
+              network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+            }),
+          };
+        }
+
+        // Second call: exchange
+        return {
+          ok: true,
+          json: async () => ({ token: jwtToken }),
+        };
+      })
+    );
+
+    // Verify flow can be initiated
+    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
+    expect(challenge).toBeDefined();
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  it('prevents bypass of challenge verification', async () => {
+    // Ensure challenge is fetched fresh, not cached or skipped
+    const callTracker = { getChallengeCount: 0, exchangeCount: 0 };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          callTracker.exchangeCount++;
+        } else {
+          callTracker.getChallengeCount++;
+        }
+
+        if (opts?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test',
+            }),
+          };
+        }
+
         return {
           ok: true,
           json: async () => ({
             transaction: VALID_CHALLENGE_XDR,
             network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
           }),
-        }
-      }
+        };
+      })
+    );
 
-      // Second call: exchange
-      return {
-        ok: true,
-        json: async () => ({ token: jwtToken }),
-      }
-    }))
-
-    // Verify flow can be initiated
-    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    expect(challenge).toBeDefined()
-    expect(callCount).toBeGreaterThan(0)
-  })
-
-  it('prevents bypass of challenge verification', async () => {
-    // Ensure challenge is fetched fresh, not cached or skipped
-    const callTracker = { getChallengeCount: 0, exchangeCount: 0 }
-
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
-        callTracker.exchangeCount++
-      } else {
-        callTracker.getChallengeCount++
-      }
-
-      if (opts?.method === 'POST') {
-        return {
-          ok: true,
-          json: async () => ({
-            token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test',
-          }),
-        }
-      }
-
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
-
-    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    expect(challenge).toBeDefined()
-    expect(callTracker.getChallengeCount).toBeGreaterThan(0)
-  })
+    const challenge = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
+    expect(challenge).toBeDefined();
+    expect(callTracker.getChallengeCount).toBeGreaterThan(0);
+  });
 
   it('fails gracefully if network changes mid-flow', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      throw new Error('Network change detected')
-    }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('Network change detected');
+      })
+    );
 
-    await expect(
-      fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    ).rejects.toThrow()
-  })
-})
+    await expect(fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)).rejects.toThrow();
+  });
+});
 
 // ─── Cache behavior (implicit in successful exchange) ──────────────────────────
 
 describe('SEP-10 state machine — JWT caching', () => {
   it('returns JWT with valid expiration claim', async () => {
-    const futureExp = Math.floor(Date.now() / 1000) + 3600
-    const jwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64')}.test`
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const jwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64')}.test`;
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ token: jwtToken }),
+          };
+        }
         return {
           ok: true,
-          json: async () => ({ token: jwtToken }),
-        }
-      }
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
 
-    expect(jwtToken).toContain('.')
-    expect(jwtToken.split('.')[2]).toBe('test')
-  })
+    expect(jwtToken).toContain('.');
+    expect(jwtToken.split('.')[2]).toBe('test');
+  });
 
   it('JWT should not be returned if exchange fails', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
-        return {
-          ok: false,
-          status: 500,
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          return {
+            ok: false,
+            status: 500,
+          };
         }
-      }
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
-
-    expect(Sep10AuthError).toBeDefined()
-  })
-
-  it('subsequent requests should reuse JWT from cache within expiry', async () => {
-    const jwtToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test'
-    let postCount = 0
-
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST') {
-        postCount++
-      }
-
-      if (opts?.method === 'POST') {
         return {
           ok: true,
-          json: async () => ({ token: jwtToken }),
-        }
-      }
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
 
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: VALID_CHALLENGE_XDR,
-          network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
-        }),
-      }
-    }))
+    expect(Sep10AuthError).toBeDefined();
+  });
+
+  it('subsequent requests should reuse JWT from cache within expiry', async () => {
+    const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.test';
+    let postCount = 0;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts?: RequestInit) => {
+        if (opts?.method === 'POST') {
+          postCount++;
+        }
+
+        if (opts?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ token: jwtToken }),
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: VALID_CHALLENGE_XDR,
+            network_passphrase: Networks.PUBLIC_NETWORK_PASSPHRASE,
+          }),
+        };
+      })
+    );
 
     // First call
-    const challenge1 = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN)
-    expect(challenge1).toBeDefined()
+    const challenge1 = await fetchSep10Challenge(WEB_AUTH_ENDPOINT, PUBLIC_KEY, HOME_DOMAIN);
+    expect(challenge1).toBeDefined();
 
     // JWT would be cached in a real implementation
     // Verify postCount shows we called POST (exchange)
-    expect(postCount).toBeGreaterThanOrEqual(0)
-  })
-})
+    expect(postCount).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/sep24-asset-format.spec.ts
+++ b/tests/sep24-asset-format.spec.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolveAssetParams, getSep24Fee, fetchAnchorFee, initiateWithdraw, _clearInfoCache } from '@/lib/stellar/sep24'
-import * as sep1 from '@/lib/stellar/sep1'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  resolveAssetParams,
+  getSep24Fee,
+  initiateWithdraw,
+  _clearInfoCache,
+} from '@/lib/stellar/sep24';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
 
 function buildMockInfo(newStyle: boolean) {
   if (newStyle) {
@@ -12,7 +16,7 @@ function buildMockInfo(newStyle: boolean) {
       fee: { enabled: true },
       transaction: { enabled: true },
       transactions: { enabled: true },
-    }
+    };
   }
   return {
     deposit: { USDC: { enabled: true } },
@@ -20,46 +24,52 @@ function buildMockInfo(newStyle: boolean) {
     fee: { enabled: true },
     transaction: { enabled: true },
     transactions: { enabled: true },
-  }
+  };
 }
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-  _clearInfoCache()
-  process.env.TEST_SEP24_INFO = '1'
-})
+  vi.restoreAllMocks();
+  _clearInfoCache();
+  process.env.TEST_SEP24_INFO = '1';
+});
 
 describe('resolveAssetParams', () => {
   it('returns old style params if info does not use SEP-38 format', () => {
-    const info = buildMockInfo(false)
-    const params = resolveAssetParams(info as any, 'withdraw', 'USDC', 'GA5Z...')
-    expect(params).toEqual({ asset_code: 'USDC', asset_issuer: 'GA5Z...' })
-  })
+    const info = buildMockInfo(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params = resolveAssetParams(info as any, 'withdraw', 'USDC', 'GA5Z...');
+    expect(params).toEqual({ asset_code: 'USDC', asset_issuer: 'GA5Z...' });
+  });
 
   it('returns new style param if info uses SEP-38 format', () => {
-    const info = buildMockInfo(true)
-    const params = resolveAssetParams(info as any, 'withdraw', 'USDC', 'GA5Z...')
-    expect(params).toEqual({ asset: 'stellar:USDC:GA5Z...' })
-  })
+    const info = buildMockInfo(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params = resolveAssetParams(info as any, 'withdraw', 'USDC', 'GA5Z...');
+    expect(params).toEqual({ asset: 'stellar:USDC:GA5Z...' });
+  });
 
   it('handles XLM properly', () => {
     const info = {
       deposit: { 'stellar:native': { enabled: true } },
       withdraw: { 'stellar:native': { enabled: true } },
-    }
-    const params = resolveAssetParams(info as any, 'withdraw', 'XLM', undefined)
-    expect(params).toEqual({ asset: 'stellar:native' })
-  })
-})
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params = resolveAssetParams(info as any, 'withdraw', 'XLM', undefined);
+    expect(params).toEqual({ asset: 'stellar:native' });
+  });
+});
 
 describe('getSep24Fee asset formats', () => {
   it('encodes correctly for old style anchor', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(false) }
-      capturedUrl = url
-      return { ok: true, json: async () => ({ fee: 5 }) }
-    }))
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(false) };
+        capturedUrl = url;
+        return { ok: true, json: async () => ({ fee: 5 }) };
+      })
+    );
 
     await getSep24Fee({
       transferServer: TRANSFER_SERVER,
@@ -67,21 +77,24 @@ describe('getSep24Fee asset formats', () => {
       assetIssuer: 'GA5Z...',
       amount: '100',
       type: 'bank_account',
-    })
+    });
 
-    const parsedUrl = new URL(capturedUrl)
-    expect(parsedUrl.searchParams.get('asset_code')).toBe('USDC')
-    expect(parsedUrl.searchParams.get('asset_issuer')).toBe('GA5Z...')
-    expect(parsedUrl.searchParams.has('asset')).toBe(false)
-  })
+    const parsedUrl = new URL(capturedUrl);
+    expect(parsedUrl.searchParams.get('asset_code')).toBe('USDC');
+    expect(parsedUrl.searchParams.get('asset_issuer')).toBe('GA5Z...');
+    expect(parsedUrl.searchParams.has('asset')).toBe(false);
+  });
 
   it('encodes correctly for new style anchor', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(true) }
-      capturedUrl = url
-      return { ok: true, json: async () => ({ fee: 5 }) }
-    }))
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(true) };
+        capturedUrl = url;
+        return { ok: true, json: async () => ({ fee: 5 }) };
+      })
+    );
 
     await getSep24Fee({
       transferServer: TRANSFER_SERVER,
@@ -89,22 +102,28 @@ describe('getSep24Fee asset formats', () => {
       assetIssuer: 'GA5Z...',
       amount: '100',
       type: 'bank_account',
-    })
+    });
 
-    const parsedUrl = new URL(capturedUrl)
-    expect(parsedUrl.searchParams.get('asset')).toBe('stellar:USDC:GA5Z...')
-    expect(parsedUrl.searchParams.has('asset_code')).toBe(false)
-  })
-})
+    const parsedUrl = new URL(capturedUrl);
+    expect(parsedUrl.searchParams.get('asset')).toBe('stellar:USDC:GA5Z...');
+    expect(parsedUrl.searchParams.has('asset_code')).toBe(false);
+  });
+});
 
 describe('initiateWithdraw asset formats', () => {
   it('sends correct body for old style anchor', async () => {
-    let capturedBody = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: any) => {
-      if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(false) }
-      capturedBody = init?.body
-      return { ok: true, json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }) }
-    }))
+    let capturedBody = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(false) };
+        capturedBody = init?.body;
+        return {
+          ok: true,
+          json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }),
+        };
+      })
+    );
 
     await initiateWithdraw({
       transferServer: TRANSFER_SERVER,
@@ -113,21 +132,27 @@ describe('initiateWithdraw asset formats', () => {
       assetIssuer: 'GA5Z...',
       amount: '100',
       account: 'GABC',
-    })
+    });
 
-    const body = JSON.parse(capturedBody)
-    expect(body.asset_code).toBe('USDC')
-    expect(body.asset_issuer).toBe('GA5Z...')
-    expect(body.asset).toBeUndefined()
-  })
+    const body = JSON.parse(capturedBody);
+    expect(body.asset_code).toBe('USDC');
+    expect(body.asset_issuer).toBe('GA5Z...');
+    expect(body.asset).toBeUndefined();
+  });
 
   it('sends correct body for new style anchor', async () => {
-    let capturedBody = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: any) => {
-      if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(true) }
-      capturedBody = init?.body
-      return { ok: true, json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }) }
-    }))
+    let capturedBody = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(true) };
+        capturedBody = init?.body;
+        return {
+          ok: true,
+          json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }),
+        };
+      })
+    );
 
     await initiateWithdraw({
       transferServer: TRANSFER_SERVER,
@@ -136,10 +161,10 @@ describe('initiateWithdraw asset formats', () => {
       assetIssuer: 'GA5Z...',
       amount: '100',
       account: 'GABC',
-    })
+    });
 
-    const body = JSON.parse(capturedBody)
-    expect(body.asset).toBe('stellar:USDC:GA5Z...')
-    expect(body.asset_code).toBeUndefined()
-  })
-})
+    const body = JSON.parse(capturedBody);
+    expect(body.asset).toBe('stellar:USDC:GA5Z...');
+    expect(body.asset_code).toBeUndefined();
+  });
+});

--- a/tests/sep24-asset-format.spec.ts
+++ b/tests/sep24-asset-format.spec.ts
@@ -117,7 +117,7 @@ describe('initiateWithdraw asset formats', () => {
       'fetch',
       vi.fn(async (url: string, init?: RequestInit) => {
         if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(false) };
-        capturedBody = init?.body;
+        capturedBody = (init?.body ?? '') as string;
         return {
           ok: true,
           json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }),
@@ -146,7 +146,7 @@ describe('initiateWithdraw asset formats', () => {
       'fetch',
       vi.fn(async (url: string, init?: RequestInit) => {
         if (url.endsWith('/info')) return { ok: true, json: async () => buildMockInfo(true) };
-        capturedBody = init?.body;
+        capturedBody = (init?.body ?? '') as string;
         return {
           ok: true,
           json: async () => ({ type: 'interactive_customer_info_needed', url: 'test', id: '123' }),

--- a/tests/sep24-fee.spec.ts
+++ b/tests/sep24-fee.spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { getSep24Fee } from '@/lib/stellar/sep24'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getSep24Fee } from '@/lib/stellar/sep24';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
 
 const BASE_PARAMS = {
   transferServer: TRANSFER_SERVER,
@@ -9,106 +9,124 @@ const BASE_PARAMS = {
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
   amount: '100',
   type: 'bank_account',
-}
+};
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 // ─── getSep24Fee ──────────────────────────────────────────────────────────────
 
 describe('getSep24Fee', () => {
   it('returns { ok: true, fee } on a valid anchor response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ fee: 2 }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ fee: 2 }),
+      }))
+    );
 
-    const result = await getSep24Fee(BASE_PARAMS)
-    expect(result).toEqual({ ok: true, fee: 2 })
-  })
+    const result = await getSep24Fee(BASE_PARAMS);
+    expect(result).toEqual({ ok: true, fee: 2 });
+  });
 
   it('builds the correct URL with all required query parameters', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      capturedUrl = url
-      return { ok: true, status: 200, json: async () => ({ fee: 1 }) }
-    }))
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return { ok: true, status: 200, json: async () => ({ fee: 1 }) };
+      })
+    );
 
-    await getSep24Fee({ ...BASE_PARAMS, amount: '50', type: 'bank_account' })
+    await getSep24Fee({ ...BASE_PARAMS, amount: '50', type: 'bank_account' });
 
-    expect(capturedUrl).toContain('operation=withdraw')
-    expect(capturedUrl).toContain('asset_code=USDC')
-    expect(capturedUrl).toContain('amount=50')
-    expect(capturedUrl).toContain('type=bank_account')
-  })
+    expect(capturedUrl).toContain('operation=withdraw');
+    expect(capturedUrl).toContain('asset_code=USDC');
+    expect(capturedUrl).toContain('amount=50');
+    expect(capturedUrl).toContain('type=bank_account');
+  });
 
   it('returns { ok: false, reason: "unsupported" } on 404 without throwing', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 404,
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 404,
+      }))
+    );
 
-    const result = await getSep24Fee(BASE_PARAMS)
-    expect(result).toEqual({ ok: false, reason: 'unsupported' })
-  })
+    const result = await getSep24Fee(BASE_PARAMS);
+    expect(result).toEqual({ ok: false, reason: 'unsupported' });
+  });
 
   it('retries once on network failure and succeeds on second attempt', async () => {
-    let calls = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      calls++
-      if (calls === 1) throw new Error('network error')
-      return { ok: true, status: 200, json: async () => ({ fee: 3 }) }
-    }))
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new Error('network error');
+        return { ok: true, status: 200, json: async () => ({ fee: 3 }) };
+      })
+    );
 
-    const result = await getSep24Fee(BASE_PARAMS)
-    expect(calls).toBe(2)
-    expect(result).toEqual({ ok: true, fee: 3 })
-  })
+    const result = await getSep24Fee(BASE_PARAMS);
+    expect(calls).toBe(2);
+    expect(result).toEqual({ ok: true, fee: 3 });
+  });
 
   it('throws after two consecutive network failures', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      throw new Error('network error')
-    }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network error');
+      })
+    );
 
-    await expect(getSep24Fee(BASE_PARAMS)).rejects.toThrow('network error')
-  })
+    await expect(getSep24Fee(BASE_PARAMS)).rejects.toThrow('network error');
+  });
 
   it('aborts after 5 seconds and retries a second time', async () => {
-    vi.useFakeTimers()
-    let calls = 0
+    vi.useFakeTimers();
+    let calls = 0;
 
-    vi.stubGlobal('fetch', vi.fn((_url: string, opts: { signal: AbortSignal }) => {
-      calls++
-      return new Promise<Response>((_resolve, reject) => {
-        opts.signal.addEventListener('abort', () => {
-          const err = new Error('The operation was aborted')
-          ;(err as NodeJS.ErrnoException).name = 'AbortError'
-          reject(err)
-        })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, opts: { signal: AbortSignal }) => {
+        calls++;
+        return new Promise<Response>((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            (err as NodeJS.ErrnoException).name = 'AbortError';
+            reject(err);
+          });
+        });
       })
-    }))
+    );
 
-    const promise = getSep24Fee(BASE_PARAMS)
+    const promise = getSep24Fee(BASE_PARAMS);
     // Run timers and catch rejection concurrently so neither is unhandled
-    await Promise.all([
-      vi.runAllTimersAsync(),
-      expect(promise).rejects.toBeDefined(),
-    ])
-    expect(calls).toBe(2)
+    await Promise.all([vi.runAllTimersAsync(), expect(promise).rejects.toBeDefined()]);
+    expect(calls).toBe(2);
 
-    vi.useRealTimers()
-  })
+    vi.useRealTimers();
+  });
 
   it('returns { ok: false, reason: "unsupported" } when fee field is missing', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ some_other_field: 'oops' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ some_other_field: 'oops' }),
+      }))
+    );
 
-    const result = await getSep24Fee(BASE_PARAMS)
-    expect(result).toEqual({ ok: false, reason: 'unsupported' })
-  })
-})
+    const result = await getSep24Fee(BASE_PARAMS);
+    expect(result).toEqual({ ok: false, reason: 'unsupported' });
+  });
+});

--- a/tests/sep24-info.spec.ts
+++ b/tests/sep24-info.spec.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { getSep24Info, _clearInfoCache } from '@/lib/stellar/sep24'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getSep24Info, _clearInfoCache } from '@/lib/stellar/sep24';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
-const TRANSFER_SERVER_B = 'https://anclap.com/sep24'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
+const TRANSFER_SERVER_B = 'https://anclap.com/sep24';
 
-const MOCK_INFO: ReturnType<typeof buildMockInfo> = buildMockInfo()
+const MOCK_INFO: ReturnType<typeof buildMockInfo> = buildMockInfo();
 
 function buildMockInfo() {
   return {
@@ -13,100 +13,121 @@ function buildMockInfo() {
     fee: { enabled: true },
     transaction: { enabled: true, authentication_required: true },
     transactions: { enabled: true, authentication_required: true },
-  }
+  };
 }
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-  _clearInfoCache()
-  process.env.TEST_SEP24_INFO = '1'
-})
+  vi.restoreAllMocks();
+  _clearInfoCache();
+  process.env.TEST_SEP24_INFO = '1';
+});
 
 // ─── getSep24Info ─────────────────────────────────────────────────────────────
 
 describe('getSep24Info', () => {
   it('returns parsed info for a known anchor', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => MOCK_INFO,
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => MOCK_INFO,
+      }))
+    );
 
-    const result = await getSep24Info(TRANSFER_SERVER)
-    expect(result.withdraw['USDC']?.enabled).toBe(true)
-    expect(result.fee.enabled).toBe(true)
-  })
+    const result = await getSep24Info(TRANSFER_SERVER);
+    expect(result.withdraw['USDC']?.enabled).toBe(true);
+    expect(result.fee.enabled).toBe(true);
+  });
 
   it('fetches /info at the correct URL', async () => {
-    let capturedUrl = ''
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      capturedUrl = url
-      return { ok: true, json: async () => MOCK_INFO }
-    }))
+    let capturedUrl = '';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return { ok: true, json: async () => MOCK_INFO };
+      })
+    );
 
-    await getSep24Info(TRANSFER_SERVER)
-    expect(capturedUrl).toBe(`${TRANSFER_SERVER}/info`)
-  })
+    await getSep24Info(TRANSFER_SERVER);
+    expect(capturedUrl).toBe(`${TRANSFER_SERVER}/info`);
+  });
 
   it('returns cached data on repeated calls without re-fetching', async () => {
-    let fetchCount = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      fetchCount++
-      return { ok: true, json: async () => MOCK_INFO }
-    }))
+    let fetchCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        fetchCount++;
+        return { ok: true, json: async () => MOCK_INFO };
+      })
+    );
 
-    await getSep24Info(TRANSFER_SERVER)
-    await getSep24Info(TRANSFER_SERVER)
-    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER);
+    await getSep24Info(TRANSFER_SERVER);
+    await getSep24Info(TRANSFER_SERVER);
 
-    expect(fetchCount).toBe(1)
-  })
+    expect(fetchCount).toBe(1);
+  });
 
   it('re-fetches after cache is explicitly cleared', async () => {
-    let fetchCount = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      fetchCount++
-      return { ok: true, json: async () => MOCK_INFO }
-    }))
+    let fetchCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        fetchCount++;
+        return { ok: true, json: async () => MOCK_INFO };
+      })
+    );
 
-    await getSep24Info(TRANSFER_SERVER)
-    _clearInfoCache()
-    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER);
+    _clearInfoCache();
+    await getSep24Info(TRANSFER_SERVER);
 
-    expect(fetchCount).toBe(2)
-  })
+    expect(fetchCount).toBe(2);
+  });
 
   it('maintains separate cache entries per transfer server', async () => {
-    let fetchCount = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      fetchCount++
-      return { ok: true, json: async () => MOCK_INFO }
-    }))
+    let fetchCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        fetchCount++;
+        return { ok: true, json: async () => MOCK_INFO };
+      })
+    );
 
-    await getSep24Info(TRANSFER_SERVER)
-    await getSep24Info(TRANSFER_SERVER_B)
-    await getSep24Info(TRANSFER_SERVER)   // cache hit for first
+    await getSep24Info(TRANSFER_SERVER);
+    await getSep24Info(TRANSFER_SERVER_B);
+    await getSep24Info(TRANSFER_SERVER); // cache hit for first
 
-    expect(fetchCount).toBe(2)
-  })
+    expect(fetchCount).toBe(2);
+  });
 
   it('expires cache after 5 minutes', async () => {
-    vi.useFakeTimers()
-    let fetchCount = 0
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      fetchCount++
-      return { ok: true, json: async () => MOCK_INFO }
-    }))
+    vi.useFakeTimers();
+    let fetchCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        fetchCount++;
+        return { ok: true, json: async () => MOCK_INFO };
+      })
+    );
 
-    await getSep24Info(TRANSFER_SERVER)
-    vi.advanceTimersByTime(5 * 60 * 1_000 + 1)
-    await getSep24Info(TRANSFER_SERVER)
+    await getSep24Info(TRANSFER_SERVER);
+    vi.advanceTimersByTime(5 * 60 * 1_000 + 1);
+    await getSep24Info(TRANSFER_SERVER);
 
-    expect(fetchCount).toBe(2)
-    vi.useRealTimers()
-  })
+    expect(fetchCount).toBe(2);
+    vi.useRealTimers();
+  });
 
   it('throws on a non-ok HTTP response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500 })))
-    await expect(getSep24Info(TRANSFER_SERVER)).rejects.toThrow(/HTTP 500/)
-  })
-})
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500 }))
+    );
+    await expect(getSep24Info(TRANSFER_SERVER)).rejects.toThrow(/HTTP 500/);
+  });
+});

--- a/tests/sep24-poll.spec.ts
+++ b/tests/sep24-poll.spec.ts
@@ -1,133 +1,159 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { getSep24Transaction, TERMINAL_STATES } from '@/lib/stellar/sep24'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getSep24Transaction, TERMINAL_STATES } from '@/lib/stellar/sep24';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
-const TRANSACTION_ID = 'txn-abc123'
-const JWT = 'test-jwt'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
+const TRANSACTION_ID = 'txn-abc123';
+const JWT = 'test-jwt';
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 // ─── getSep24Transaction ──────────────────────────────────────────────────────
 
 describe('getSep24Transaction', () => {
   it('fetches the correct endpoint with Authorization header', async () => {
-    let capturedUrl = ''
-    let capturedHeaders: Record<string, string> = {}
+    let capturedUrl = '';
+    let capturedHeaders: Record<string, string> = {};
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string, opts: RequestInit) => {
-      capturedUrl = url
-      capturedHeaders = opts.headers as Record<string, string>
-      return {
-        ok: true,
-        json: async () => ({
-          transaction: { id: TRANSACTION_ID, status: 'pending_external' },
-        }),
-      }
-    }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, opts: RequestInit) => {
+        capturedUrl = url;
+        capturedHeaders = opts.headers as Record<string, string>;
+        return {
+          ok: true,
+          json: async () => ({
+            transaction: { id: TRANSACTION_ID, status: 'pending_external' },
+          }),
+        };
+      })
+    );
 
-    await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
+    await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
 
-    expect(capturedUrl).toBe(`${TRANSFER_SERVER}/transaction?id=${TRANSACTION_ID}`)
-    expect(capturedHeaders['Authorization']).toBe(`Bearer ${JWT}`)
-  })
+    expect(capturedUrl).toBe(`${TRANSFER_SERVER}/transaction?id=${TRANSACTION_ID}`);
+    expect(capturedHeaders['Authorization']).toBe(`Bearer ${JWT}`);
+  });
 
   it('returns a WithdrawStatus with all mapped fields on a well-formed response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        transaction: {
-          id: TRANSACTION_ID,
-          status: 'completed',
-          amount_in: '100.00',
-          amount_out: '155000.00',
-          amount_fee: '2.00',
-          stellar_transaction_id: 'stellar-hash-xyz',
-        },
-      }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          transaction: {
+            id: TRANSACTION_ID,
+            status: 'completed',
+            amount_in: '100.00',
+            amount_out: '155000.00',
+            amount_fee: '2.00',
+            stellar_transaction_id: 'stellar-hash-xyz',
+          },
+        }),
+      }))
+    );
 
-    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
+    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
 
-    expect(result.id).toBe(TRANSACTION_ID)
-    expect(result.status).toBe('completed')
-    expect(result.amountIn).toBe('100.00')
-    expect(result.amountOut).toBe('155000.00')
-    expect(result.amountFee).toBe('2.00')
-    expect(result.stellarTransactionId).toBe('stellar-hash-xyz')
-    expect(result.updatedAt).toBeInstanceOf(Date)
-  })
+    expect(result.id).toBe(TRANSACTION_ID);
+    expect(result.status).toBe('completed');
+    expect(result.amountIn).toBe('100.00');
+    expect(result.amountOut).toBe('155000.00');
+    expect(result.amountFee).toBe('2.00');
+    expect(result.stellarTransactionId).toBe('stellar-hash-xyz');
+    expect(result.updatedAt).toBeInstanceOf(Date);
+  });
 
   it('maps a known status string correctly', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: { id: TRANSACTION_ID, status: 'pending_anchor' } }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ transaction: { id: TRANSACTION_ID, status: 'pending_anchor' } }),
+      }))
+    );
 
-    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    expect(result.status).toBe('pending_anchor')
-  })
+    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
+    expect(result.status).toBe('pending_anchor');
+  });
 
   it('defaults an unknown anchor status to "pending_external" without throwing', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: { id: TRANSACTION_ID, status: 'some_custom_anchor_state' } }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          transaction: { id: TRANSACTION_ID, status: 'some_custom_anchor_state' },
+        }),
+      }))
+    );
 
-    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    expect(result.status).toBe('pending_external')
-  })
+    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
+    expect(result.status).toBe('pending_external');
+  });
 
   it('defaults a missing status to "pending_external"', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: { id: TRANSACTION_ID } }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ transaction: { id: TRANSACTION_ID } }),
+      }))
+    );
 
-    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    expect(result.status).toBe('pending_external')
-  })
+    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
+    expect(result.status).toBe('pending_external');
+  });
 
   it('uses the transactionId as fallback when id is absent from the response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ transaction: { status: 'pending_external' } }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ transaction: { status: 'pending_external' } }),
+      }))
+    );
 
-    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    expect(result.id).toBe(TRANSACTION_ID)
-  })
+    const result = await getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT);
+    expect(result.id).toBe(TRANSACTION_ID);
+  });
 
   it('throws a descriptive error on a non-ok HTTP response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404 }))
+    );
 
-    await expect(
-      getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    ).rejects.toThrow(/HTTP 404/)
-  })
+    await expect(getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)).rejects.toThrow(
+      /HTTP 404/
+    );
+  });
 
   it('throws on a 401 Unauthorized response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 401 })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 401 }))
+    );
 
-    await expect(
-      getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)
-    ).rejects.toThrow(/HTTP 401/)
-  })
-})
+    await expect(getSep24Transaction(TRANSFER_SERVER, TRANSACTION_ID, JWT)).rejects.toThrow(
+      /HTTP 401/
+    );
+  });
+});
 
 // ─── TERMINAL_STATES ──────────────────────────────────────────────────────────
 
 describe('TERMINAL_STATES', () => {
   it('includes completed, error, and refunded', () => {
-    expect(TERMINAL_STATES.has('completed')).toBe(true)
-    expect(TERMINAL_STATES.has('error')).toBe(true)
-    expect(TERMINAL_STATES.has('refunded')).toBe(true)
-  })
+    expect(TERMINAL_STATES.has('completed')).toBe(true);
+    expect(TERMINAL_STATES.has('error')).toBe(true);
+    expect(TERMINAL_STATES.has('refunded')).toBe(true);
+  });
 
   it('does not include non-terminal statuses', () => {
-    expect(TERMINAL_STATES.has('pending_external')).toBe(false)
-    expect(TERMINAL_STATES.has('pending_anchor')).toBe(false)
-    expect(TERMINAL_STATES.has('incomplete')).toBe(false)
-  })
-})
+    expect(TERMINAL_STATES.has('pending_external')).toBe(false);
+    expect(TERMINAL_STATES.has('pending_anchor')).toBe(false);
+    expect(TERMINAL_STATES.has('incomplete')).toBe(false);
+  });
+});

--- a/tests/sep24-status-map.spec.ts
+++ b/tests/sep24-status-map.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { STATUS_MAP, mapToCanonical } from '@/lib/stellar/sep24-status-map'
-import type { WithdrawStatusValue, WithdrawStatus } from '@/types'
+import { describe, it, expect } from 'vitest';
+import { STATUS_MAP, mapToCanonical } from '@/lib/stellar/sep24-status-map';
+import type { WithdrawStatusValue, WithdrawStatus } from '@/types';
 
 /**
  * Tests for SEP-24 status map exhaustiveness.
@@ -30,17 +30,17 @@ describe('STATUS_MAP — exhaustiveness', () => {
       'too_small',
       'too_large',
       'expired',
-    ]
+    ];
 
     for (const status of expectedStatuses) {
-      expect(STATUS_MAP).toHaveProperty(status)
+      expect(STATUS_MAP).toHaveProperty(status);
     }
-  })
+  });
 
   it('has exactly 15 entries matching WithdrawStatusValue count', () => {
-    const mapKeys = Object.keys(STATUS_MAP)
-    expect(mapKeys).toHaveLength(15)
-  })
+    const mapKeys = Object.keys(STATUS_MAP);
+    expect(mapKeys).toHaveLength(15);
+  });
 
   it('maps each entry to a valid WithdrawStatus', () => {
     const validStatuses: WithdrawStatus[] = [
@@ -53,89 +53,89 @@ describe('STATUS_MAP — exhaustiveness', () => {
       'refunded',
       'expired',
       'error',
-    ]
+    ];
 
     for (const raw of Object.keys(STATUS_MAP) as WithdrawStatusValue[]) {
-      const canonical = STATUS_MAP[raw]
-      expect(validStatuses).toContain(canonical)
+      const canonical = STATUS_MAP[raw];
+      expect(validStatuses).toContain(canonical);
     }
-  })
-})
+  });
+});
 
 // ─── Individual mappings ──────────────────────────────────────────────────────
 
 describe('STATUS_MAP — individual mappings', () => {
   it('maps pending_user_* statuses to pending_user_action', () => {
-    expect(STATUS_MAP.incomplete).toBe('pending_user_action')
-    expect(STATUS_MAP.pending_user_transfer_start).toBe('pending_user_action')
-    expect(STATUS_MAP.pending_user_transfer_complete).toBe('pending_user_action')
-    expect(STATUS_MAP.pending_user).toBe('pending_user_action')
-  })
+    expect(STATUS_MAP.incomplete).toBe('pending_user_action');
+    expect(STATUS_MAP.pending_user_transfer_start).toBe('pending_user_action');
+    expect(STATUS_MAP.pending_user_transfer_complete).toBe('pending_user_action');
+    expect(STATUS_MAP.pending_user).toBe('pending_user_action');
+  });
 
   it('maps pending_anchor and pending_trust to pending_anchor', () => {
-    expect(STATUS_MAP.pending_anchor).toBe('pending_anchor')
-    expect(STATUS_MAP.pending_trust).toBe('pending_anchor')
-  })
+    expect(STATUS_MAP.pending_anchor).toBe('pending_anchor');
+    expect(STATUS_MAP.pending_trust).toBe('pending_anchor');
+  });
 
   it('maps pending_stellar to pending_stellar', () => {
-    expect(STATUS_MAP.pending_stellar).toBe('pending_stellar')
-  })
+    expect(STATUS_MAP.pending_stellar).toBe('pending_stellar');
+  });
 
   it('maps pending_external to pending_external', () => {
-    expect(STATUS_MAP.pending_external).toBe('pending_external')
-  })
+    expect(STATUS_MAP.pending_external).toBe('pending_external');
+  });
 
   it('maps terminal statuses correctly', () => {
-    expect(STATUS_MAP.completed).toBe('completed')
-    expect(STATUS_MAP.refunded).toBe('refunded')
-    expect(STATUS_MAP.expired).toBe('expired')
-  })
+    expect(STATUS_MAP.completed).toBe('completed');
+    expect(STATUS_MAP.refunded).toBe('refunded');
+    expect(STATUS_MAP.expired).toBe('expired');
+  });
 
   it('maps error statuses to error', () => {
-    expect(STATUS_MAP.error).toBe('error')
-    expect(STATUS_MAP.too_small).toBe('error')
-    expect(STATUS_MAP.too_large).toBe('error')
-  })
+    expect(STATUS_MAP.error).toBe('error');
+    expect(STATUS_MAP.too_small).toBe('error');
+    expect(STATUS_MAP.too_large).toBe('error');
+  });
 
   it('maps no_market to no_market', () => {
-    expect(STATUS_MAP.no_market).toBe('no_market')
-  })
-})
+    expect(STATUS_MAP.no_market).toBe('no_market');
+  });
+});
 
 // ─── mapToCanonical function ───────────────────────────────────────────────────
 
 describe('mapToCanonical', () => {
   it('returns the correct canonical status for a known raw status', () => {
-    expect(mapToCanonical('pending_anchor')).toBe('pending_anchor')
-    expect(mapToCanonical('completed')).toBe('completed')
-    expect(mapToCanonical('error')).toBe('error')
-  })
+    expect(mapToCanonical('pending_anchor')).toBe('pending_anchor');
+    expect(mapToCanonical('completed')).toBe('completed');
+    expect(mapToCanonical('error')).toBe('error');
+  });
 
   it('returns the correct grouping for pending_user statuses', () => {
-    expect(mapToCanonical('incomplete')).toBe('pending_user_action')
-    expect(mapToCanonical('pending_user_transfer_start')).toBe('pending_user_action')
-    expect(mapToCanonical('pending_user_transfer_complete')).toBe('pending_user_action')
-    expect(mapToCanonical('pending_user')).toBe('pending_user_action')
-  })
+    expect(mapToCanonical('incomplete')).toBe('pending_user_action');
+    expect(mapToCanonical('pending_user_transfer_start')).toBe('pending_user_action');
+    expect(mapToCanonical('pending_user_transfer_complete')).toBe('pending_user_action');
+    expect(mapToCanonical('pending_user')).toBe('pending_user_action');
+  });
 
   it('returns the correct grouping for anchor-pending statuses', () => {
-    expect(mapToCanonical('pending_anchor')).toBe('pending_anchor')
-    expect(mapToCanonical('pending_trust')).toBe('pending_anchor')
-  })
+    expect(mapToCanonical('pending_anchor')).toBe('pending_anchor');
+    expect(mapToCanonical('pending_trust')).toBe('pending_anchor');
+  });
 
   it('returns the correct grouping for error statuses', () => {
-    expect(mapToCanonical('too_small')).toBe('error')
-    expect(mapToCanonical('too_large')).toBe('error')
-    expect(mapToCanonical('error')).toBe('error')
-  })
+    expect(mapToCanonical('too_small')).toBe('error');
+    expect(mapToCanonical('too_large')).toBe('error');
+    expect(mapToCanonical('error')).toBe('error');
+  });
 
   it('is deterministic — same input yields same output', () => {
-    const status: WithdrawStatusValue = 'pending_stellar'
-    const result1 = mapToCanonical(status)
-    const result2 = mapToCanonical(status)
-    expect(result1).toBe(result2)
-  })
-})
+    const status: WithdrawStatusValue = 'pending_stellar';
+    const result1 = mapToCanonical(status);
+    const result2 = mapToCanonical(status);
+    expect(result1).toBe(result2);
+  });
+});
 
 // ─── Compile-time exhaustiveness check ─────────────────────────────────────────
 
@@ -145,20 +145,20 @@ describe('STATUS_MAP — compile-time checks', () => {
     // at compile time. The STATUS_MAP type annotation ensures this.
     // If a new WithdrawStatusValue is added without a corresponding entry,
     // TypeScript will fail to compile.
-    const _assertType: Record<WithdrawStatusValue, WithdrawStatus> = STATUS_MAP
-    expect(_assertType).toBeDefined()
-  })
+    const _assertType: Record<WithdrawStatusValue, WithdrawStatus> = STATUS_MAP;
+    expect(_assertType).toBeDefined();
+  });
 
   it('ensures no unmapped raw statuses can slip through', () => {
     // Verify that all properties in STATUS_MAP are used and correct
-    const statusValues: WithdrawStatusValue[] = Object.keys(STATUS_MAP) as WithdrawStatusValue[]
-    const canonicalValues: WithdrawStatus[] = Object.values(STATUS_MAP)
+    const statusValues: WithdrawStatusValue[] = Object.keys(STATUS_MAP) as WithdrawStatusValue[];
+    const canonicalValues: WithdrawStatus[] = Object.values(STATUS_MAP);
 
     // All statuses should map to valid canonical values
     statusValues.forEach((raw) => {
-      const canonical = STATUS_MAP[raw]
-      expect(canonical).toBeDefined()
-      expect(canonicalValues).toContain(canonical)
-    })
-  })
-})
+      const canonical = STATUS_MAP[raw];
+      expect(canonical).toBeDefined();
+      expect(canonicalValues).toContain(canonical);
+    });
+  });
+});

--- a/tests/sep24-withdraw.spec.ts
+++ b/tests/sep24-withdraw.spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { initiateWithdraw, Sep24WithdrawError } from '@/lib/stellar/sep24'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { initiateWithdraw, Sep24WithdrawError } from '@/lib/stellar/sep24';
 
-const TRANSFER_SERVER = 'https://cowrie.exchange/sep24'
+const TRANSFER_SERVER = 'https://cowrie.exchange/sep24';
 
 const MOCK_ANCHOR = {
   id: 'cowrie',
@@ -10,7 +10,7 @@ const MOCK_ANCHOR = {
   corridors: ['usdc-ngn'],
   assetCode: 'USDC',
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
-}
+};
 
 const RESOLVED_ANCHOR = {
   ...MOCK_ANCHOR,
@@ -18,7 +18,7 @@ const RESOLVED_ANCHOR = {
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'G...',
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
-}
+};
 
 const PARAMS = {
   jwt: 'test-jwt',
@@ -26,110 +26,133 @@ const PARAMS = {
   assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
   amount: '100',
   account: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ',
-}
+};
 
 beforeEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
 // ─── initiateWithdraw ─────────────────────────────────────────────────────────
 
 describe('initiateWithdraw — POST /transactions/withdraw/interactive', () => {
   it('returns typed { id, url, type } on a valid anchor response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        type: 'interactive_customer_info_needed',
-        url: 'https://anchor.io/kyc/session-abc',
-        id: 'txn-xyz',
-      }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          type: 'interactive_customer_info_needed',
+          url: 'https://anchor.io/kyc/session-abc',
+          id: 'txn-xyz',
+        }),
+      }))
+    );
 
-    const result = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
-    expect(result.id).toBe('txn-xyz')
-    expect(result.url).toBe('https://anchor.io/kyc/session-abc')
-    expect(result.type).toBe('interactive_customer_info_needed')
-  })
+    const result = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS);
+    expect(result.id).toBe('txn-xyz');
+    expect(result.url).toBe('https://anchor.io/kyc/session-abc');
+    expect(result.type).toBe('interactive_customer_info_needed');
+  });
 
   it('sends correct POST body: asset_code, asset_issuer, amount, account', async () => {
-    let body: Record<string, unknown> = {}
-    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => {
-      body = JSON.parse(opts.body as string) as Record<string, unknown>
-      return {
-        ok: true,
-        json: async () => ({
-          type: 'interactive_customer_info_needed',
-          url: 'https://u',
-          id: 'id1',
-        }),
-      }
-    }))
+    let body: Record<string, unknown> = {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts: RequestInit) => {
+        body = JSON.parse(opts.body as string) as Record<string, unknown>;
+        return {
+          ok: true,
+          json: async () => ({
+            type: 'interactive_customer_info_needed',
+            url: 'https://u',
+            id: 'id1',
+          }),
+        };
+      })
+    );
 
-    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
-    expect(body['asset_code']).toBe('USDC')
-    expect(body['asset_issuer']).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN')
-    expect(body['amount']).toBe('100')
-    expect(body['account']).toBe('GABCDEFGHIJKLMNOPQRSTUVWXYZ')
-  })
+    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS);
+    expect(body['asset_code']).toBe('USDC');
+    expect(body['asset_issuer']).toBe('GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+    expect(body['amount']).toBe('100');
+    expect(body['account']).toBe('GABCDEFGHIJKLMNOPQRSTUVWXYZ');
+  });
 
   it('sends Authorization: Bearer <jwt> header', async () => {
-    let headers: Record<string, string> = {}
-    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => {
-      headers = opts.headers as Record<string, string>
-      return {
-        ok: true,
-        json: async () => ({
-          type: 'interactive_customer_info_needed',
-          url: 'https://u',
-          id: 'id1',
-        }),
-      }
-    }))
+    let headers: Record<string, string> = {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts: RequestInit) => {
+        headers = opts.headers as Record<string, string>;
+        return {
+          ok: true,
+          json: async () => ({
+            type: 'interactive_customer_info_needed',
+            url: 'https://u',
+            id: 'id1',
+          }),
+        };
+      })
+    );
 
-    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS)
-    expect(headers['Authorization']).toBe('Bearer test-jwt')
-  })
+    await initiateWithdraw(RESOLVED_ANCHOR, PARAMS);
+    expect(headers['Authorization']).toBe('Bearer test-jwt');
+  });
 
   it('throws Sep24WithdrawError on non-200, preserving status code and anchor body', async () => {
-    const anchorBody = { error: 'unsupported asset' }
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 422,
-      json: async () => anchorBody,
-    })))
+    const anchorBody = { error: 'unsupported asset' };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 422,
+        json: async () => anchorBody,
+      }))
+    );
 
-    const caught = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS).catch((e: unknown) => e)
-    expect(caught).toBeInstanceOf(Sep24WithdrawError)
-    const err = caught as Sep24WithdrawError
-    expect(err.status).toBe(422)
-    expect(err.anchorBody).toEqual(anchorBody)
-  })
+    const caught = await initiateWithdraw(RESOLVED_ANCHOR, PARAMS).catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(Sep24WithdrawError);
+    const err = caught as Sep24WithdrawError;
+    expect(err.status).toBe(422);
+    expect(err.anchorBody).toEqual(anchorBody);
+  });
 
   it('Sep24WithdrawError message includes the HTTP status code', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 403,
-      json: async () => ({ error: 'forbidden' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'forbidden' }),
+      }))
+    );
 
-    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/403/)
-  })
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/403/);
+  });
 
   it('throws when response type is not interactive_customer_info_needed', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ type: 'error', error: 'not supported' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ type: 'error', error: 'not supported' }),
+      }))
+    );
 
-    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/Unexpected response type/)
-  })
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(
+      /Unexpected response type/
+    );
+  });
 
   it('throws when url field is absent from the response', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
-    })))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ type: 'interactive_customer_info_needed', id: 'txn-1' }),
+      }))
+    );
 
-    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/"url"/)
-  })
-})
+    await expect(initiateWithdraw(RESOLVED_ANCHOR, PARAMS)).rejects.toThrow(/"url"/);
+  });
+});

--- a/tests/sep24-withdraw.spec.ts
+++ b/tests/sep24-withdraw.spec.ts
@@ -17,6 +17,12 @@ const RESOLVED_ANCHOR = {
   TRANSFER_SERVER_SEP0024: TRANSFER_SERVER,
   WEB_AUTH_ENDPOINT: 'https://cowrie.exchange/auth',
   SIGNING_KEY: 'G...',
+  domain: 'cowrie.exchange',
+  ANCHOR_QUOTE_SERVER: null,
+  NETWORK_PASSPHRASE: null,
+  CURRENCIES: [
+    { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+  ],
   capabilities: { sep10: true, sep24: true, sep38: false, sep12: false },
 };
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';

--- a/tests/useAnchorAuth.spec.tsx
+++ b/tests/useAnchorAuth.spec.tsx
@@ -1,20 +1,20 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, waitFor, act } from '@testing-library/react'
-import { useAnchorAuth } from '@/hooks/useAnchorAuth'
-import * as sep10 from '@/lib/stellar/sep10'
-import type { Sep10Auth } from '@/types'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useAnchorAuth } from '@/hooks/useAnchorAuth';
+import * as sep10 from '@/lib/stellar/sep10';
+import type { Sep10Auth } from '@/types';
 
 // ─── Mock SEP-10 module ────────────────────────────────────────────────────────
 
 vi.mock('@/lib/stellar/sep10', () => ({
   authenticate: vi.fn(),
   invalidateSep10Token: vi.fn(),
-}))
+}));
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
-const ANCHOR = 'cowrie.exchange'
-const PUBLIC_KEY = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
+const ANCHOR = 'cowrie.exchange';
+const PUBLIC_KEY = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77';
 
 function createMockAuth(): Sep10Auth {
   return {
@@ -22,141 +22,141 @@ function createMockAuth(): Sep10Auth {
     anchorDomain: ANCHOR,
     publicKey: PUBLIC_KEY,
     expiresAt: new Date(Date.now() + 3600 * 1000),
-  }
+  };
 }
 
 beforeEach(() => {
-  vi.clearAllMocks()
-  vi.mocked(sep10.authenticate).mockResolvedValue(createMockAuth())
-})
+  vi.clearAllMocks();
+  vi.mocked(sep10.authenticate).mockResolvedValue(createMockAuth());
+});
 
 afterEach(() => {
-  vi.clearAllMocks()
-})
+  vi.clearAllMocks();
+});
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useAnchorAuth', () => {
   describe('initial state', () => {
     it('returns initial state with null jwt and no error', () => {
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
-      expect(result.current.jwt).toBeNull()
-      expect(result.current.isAuthenticating).toBe(false)
-      expect(result.current.error).toBeNull()
-      expect(result.current.authenticate).toBeDefined()
-    })
+      expect(result.current.jwt).toBeNull();
+      expect(result.current.isAuthenticating).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.authenticate).toBeDefined();
+    });
 
     it('returns authenticate function immediately', () => {
-      const { result: result1 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
-      const { result: result2 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result: result1 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
+      const { result: result2 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
-      expect(result1.current.authenticate).toBeDefined()
-      expect(result2.current.authenticate).toBeDefined()
-    })
-  })
+      expect(result1.current.authenticate).toBeDefined();
+      expect(result2.current.authenticate).toBeDefined();
+    });
+  });
 
   describe('authentication flow', () => {
     it('sets jwt and clears error on successful authentication', async () => {
-      const mockAuth = createMockAuth()
-      vi.mocked(sep10.authenticate).mockResolvedValueOnce(mockAuth)
+      const mockAuth = createMockAuth();
+      vi.mocked(sep10.authenticate).mockResolvedValueOnce(mockAuth);
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
 
-      expect(result.current.jwt).toBe(mockAuth.jwt)
-      expect(result.current.error).toBeNull()
-    })
+      expect(result.current.jwt).toBe(mockAuth.jwt);
+      expect(result.current.error).toBeNull();
+    });
 
     it('sets error and clears jwt on failed authentication', async () => {
-      const testError = new Error('Authentication failed')
-      vi.mocked(sep10.authenticate).mockRejectedValueOnce(testError)
+      const testError = new Error('Authentication failed');
+      vi.mocked(sep10.authenticate).mockRejectedValueOnce(testError);
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
 
-      expect(result.current.jwt).toBeNull()
-      expect(result.current.error).toBe('Authentication failed')
-    })
+      expect(result.current.jwt).toBeNull();
+      expect(result.current.error).toBe('Authentication failed');
+    });
 
     it('shows isAuthenticating=true during authentication', async () => {
       vi.mocked(sep10.authenticate).mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve(createMockAuth()), 100))
-      )
+        () => new Promise((resolve) => setTimeout(() => resolve(createMockAuth()), 100))
+      );
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
-      expect(result.current.isAuthenticating).toBe(true)
+      expect(result.current.isAuthenticating).toBe(true);
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
-    })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
+    });
 
     it('passes correct arguments to authenticate function', async () => {
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
 
-      expect(sep10.authenticate).toHaveBeenCalledWith(ANCHOR, PUBLIC_KEY)
-    })
+      expect(sep10.authenticate).toHaveBeenCalledWith(ANCHOR, PUBLIC_KEY);
+    });
 
     it('returns error message when missing anchor domain', async () => {
-      const { result } = renderHook(() => useAnchorAuth(null, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(null, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
-      expect(result.current.error).toBe('Missing anchor domain or public key')
-      expect(result.current.jwt).toBeNull()
-    })
+      expect(result.current.error).toBe('Missing anchor domain or public key');
+      expect(result.current.jwt).toBeNull();
+    });
 
     it('returns error message when missing public key', async () => {
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, null))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, null));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
-      expect(result.current.error).toBe('Missing anchor domain or public key')
-      expect(result.current.jwt).toBeNull()
-    })
-  })
+      expect(result.current.error).toBe('Missing anchor domain or public key');
+      expect(result.current.jwt).toBeNull();
+    });
+  });
 
   describe('callback stability', () => {
     it('returns same authenticate callback reference across re-renders', () => {
-      const { result, rerender } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
-      const firstCallback = result.current.authenticate
+      const { result, rerender } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
+      const firstCallback = result.current.authenticate;
 
-      rerender()
+      rerender();
 
-      expect(result.current.authenticate).toBe(firstCallback)
-    })
+      expect(result.current.authenticate).toBe(firstCallback);
+    });
 
     it('updates authenticate callback when dependencies change', () => {
       const { result, rerender } = renderHook(
@@ -164,166 +164,171 @@ describe('useAnchorAuth', () => {
         {
           initialProps: { anchor: ANCHOR, key: PUBLIC_KEY },
         }
-      )
-      const firstCallback = result.current.authenticate
+      );
+      const firstCallback = result.current.authenticate;
 
-      rerender({ anchor: 'different.anchor', key: PUBLIC_KEY })
+      rerender({ anchor: 'different.anchor', key: PUBLIC_KEY });
 
-      expect(result.current.authenticate).not.toBe(firstCallback)
-    })
-  })
+      expect(result.current.authenticate).not.toBe(firstCallback);
+    });
+  });
 
   describe('state persistence', () => {
     it('state survives re-renders', async () => {
-      const mockAuth = createMockAuth()
-      vi.mocked(sep10.authenticate).mockResolvedValueOnce(mockAuth)
+      const mockAuth = createMockAuth();
+      vi.mocked(sep10.authenticate).mockResolvedValueOnce(mockAuth);
 
-      const { result, rerender } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result, rerender } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.jwt).toBe(mockAuth.jwt)
-      })
+        expect(result.current.jwt).toBe(mockAuth.jwt);
+      });
 
-      rerender()
+      rerender();
 
-      expect(result.current.jwt).toBe(mockAuth.jwt)
-      expect(result.current.error).toBeNull()
-    })
+      expect(result.current.jwt).toBe(mockAuth.jwt);
+      expect(result.current.error).toBeNull();
+    });
 
     it('maintains separate state for different anchors', async () => {
-      const mockAuth1 = createMockAuth()
-      const mockAuth2 = { ...createMockAuth(), anchorDomain: 'other.exchange', jwt: 'different-jwt' }
+      const mockAuth1 = createMockAuth();
+      const mockAuth2 = {
+        ...createMockAuth(),
+        anchorDomain: 'other.exchange',
+        jwt: 'different-jwt',
+      };
 
       vi.mocked(sep10.authenticate)
         .mockResolvedValueOnce(mockAuth1)
-        .mockResolvedValueOnce(mockAuth2)
+        .mockResolvedValueOnce(mockAuth2);
 
-      const { result: result1 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
-      const { result: result2 } = renderHook(() => useAnchorAuth('other.exchange', PUBLIC_KEY))
-
-      act(() => {
-        result1.current.authenticate()
-      })
-
-      await waitFor(() => {
-        expect(result1.current.jwt).toBe(mockAuth1.jwt)
-      })
+      const { result: result1 } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
+      const { result: result2 } = renderHook(() => useAnchorAuth('other.exchange', PUBLIC_KEY));
 
       act(() => {
-        result2.current.authenticate()
-      })
+        result1.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result2.current.jwt).toBe(mockAuth2.jwt)
-      })
+        expect(result1.current.jwt).toBe(mockAuth1.jwt);
+      });
 
-      expect(result1.current.jwt).toBe(mockAuth1.jwt)
-      expect(result2.current.jwt).toBe(mockAuth2.jwt)
-    })
-  })
+      act(() => {
+        result2.current.authenticate();
+      });
+
+      await waitFor(() => {
+        expect(result2.current.jwt).toBe(mockAuth2.jwt);
+      });
+
+      expect(result1.current.jwt).toBe(mockAuth1.jwt);
+      expect(result2.current.jwt).toBe(mockAuth2.jwt);
+    });
+  });
 
   describe('unmount cleanup', () => {
     it('cancels pending request on unmount', async () => {
-      let resolveAuth: ((value: Sep10Auth) => void) | null = null
+      let resolveAuth: ((value: Sep10Auth) => void) | null = null;
       vi.mocked(sep10.authenticate).mockImplementation(
         () =>
-          new Promise(resolve => {
-            resolveAuth = resolve
+          new Promise((resolve) => {
+            resolveAuth = resolve;
           })
-      )
+      );
 
-      const { result, unmount } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result, unmount } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
-      expect(result.current.isAuthenticating).toBe(true)
+      expect(result.current.isAuthenticating).toBe(true);
 
       // Unmount before request resolves
-      unmount()
+      unmount();
 
       // Resolve the request after unmount
       if (resolveAuth) {
-       (resolveAuth as any)(createMockAuth());  
-        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (resolveAuth as any)(createMockAuth());
+      }
 
       // State should remain unchanged (no memory leaks)
-      expect(result.current.isAuthenticating).toBe(true)
-      expect(result.current.jwt).toBeNull()
-    })
+      expect(result.current.isAuthenticating).toBe(true);
+      expect(result.current.jwt).toBeNull();
+    });
 
     it('multiple authentications with cancellation of pending requests', async () => {
-      vi.mocked(sep10.authenticate).mockResolvedValue(createMockAuth())
+      vi.mocked(sep10.authenticate).mockResolvedValue(createMockAuth());
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       // First request
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       // Immediately fire second request (cancels first)
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
 
-      expect(result.current.jwt).not.toBeNull()
-      expect(result.current.error).toBeNull()
-    })
-  })
+      expect(result.current.jwt).not.toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+  });
 
   describe('error handling', () => {
     it('handles non-Error objects thrown', async () => {
-      vi.mocked(sep10.authenticate).mockRejectedValueOnce('String error')
+      vi.mocked(sep10.authenticate).mockRejectedValueOnce('String error');
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.isAuthenticating).toBe(false)
-      })
+        expect(result.current.isAuthenticating).toBe(false);
+      });
 
-      expect(result.current.error).toBe('String error')
-    })
+      expect(result.current.error).toBe('String error');
+    });
 
     it('clears error on successful authentication after failure', async () => {
       vi.mocked(sep10.authenticate)
         .mockRejectedValueOnce(new Error('First attempt failed'))
-        .mockResolvedValueOnce(createMockAuth())
+        .mockResolvedValueOnce(createMockAuth());
 
-      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY))
+      const { result } = renderHook(() => useAnchorAuth(ANCHOR, PUBLIC_KEY));
 
       // First attempt fails
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.error).toBe('First attempt failed')
-      })
+        expect(result.current.error).toBe('First attempt failed');
+      });
 
       // Second attempt succeeds
       act(() => {
-        result.current.authenticate()
-      })
+        result.current.authenticate();
+      });
 
       await waitFor(() => {
-        expect(result.current.jwt).not.toBeNull()
-      })
+        expect(result.current.jwt).not.toBeNull();
+      });
 
-      expect(result.current.error).toBeNull()
-    })
-  })
-})
+      expect(result.current.error).toBeNull();
+    });
+  });
+});

--- a/tests/useFreighter.spec.tsx
+++ b/tests/useFreighter.spec.tsx
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, renderHook, waitFor } from '@testing-library/react'
-import { useFreighter } from '@/hooks/useFreighter'
-import type { FreighterState } from '@/types'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFreighter } from '@/hooks/useFreighter';
 
 /**
  * Tests for useFreighter hook lifecycle.
@@ -22,18 +21,18 @@ const mockFreighterApi = vi.hoisted(() => ({
   requestAccess: vi.fn(),
   signTransaction: vi.fn(),
   WatchWalletChanges: class {
-    watch = vi.fn()
-    stop = vi.fn()
-  }
-}))
+    watch = vi.fn();
+    stop = vi.fn();
+  },
+}));
 
-vi.mock('@stellar/freighter-api', () => mockFreighterApi)
+vi.mock('@stellar/freighter-api', () => mockFreighterApi);
 
-import { WalletProvider } from '@/contexts/WalletContext'
+import { WalletProvider } from '@/contexts/WalletContext';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <WalletProvider>{children}</WalletProvider>
-)
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -41,297 +40,297 @@ function mockFreighterInstalled(isConnected: boolean, network?: string, publicKe
   mockFreighterApi.isConnected.mockResolvedValue({
     isConnected,
     error: null,
-  })
+  });
 
   if (isConnected) {
     mockFreighterApi.getAddress.mockResolvedValue({
       publicKey: publicKey ?? 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77',
       error: null,
-    })
+    });
 
     mockFreighterApi.getNetwork.mockResolvedValue({
       network: network ?? 'PUBLIC',
       error: null,
-    })
+    });
   } else {
     mockFreighterApi.getAddress.mockResolvedValue({
       error: 'Not connected',
-    })
+    });
     mockFreighterApi.getNetwork.mockResolvedValue({
       error: 'Not connected',
-    })
+    });
   }
 }
 
 function mockFreighterNotInstalled() {
-  mockFreighterApi.isConnected.mockRejectedValue(new Error('Freighter not found'))
+  mockFreighterApi.isConnected.mockRejectedValue(new Error('Freighter not found'));
 }
 
 beforeEach(() => {
-  vi.clearAllMocks()
-})
+  vi.clearAllMocks();
+});
 
 afterEach(() => {
-  vi.clearAllMocks()
-})
+  vi.clearAllMocks();
+});
 
 // ─── Lifecycle 1: Detect ──────────────────────────────────────────────────────
 
 describe('useFreighter — detect', () => {
   it('detects when Freighter extension is installed', async () => {
-    mockFreighterInstalled(false)
+    mockFreighterInstalled(false);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true)
-    })
-  })
+      expect(result.current.isInstalled).toBe(true);
+    });
+  });
 
   it('sets isInstalled to false when Freighter is not available', async () => {
-    mockFreighterNotInstalled()
+    mockFreighterNotInstalled();
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     // Even if API is unavailable, initial state should reflect that
-    expect(result.current.isInstalled).toBe(false)
-  })
+    expect(result.current.isInstalled).toBe(false);
+  });
 
   it('sets isConnected to false initially when detected but not connected', async () => {
-    mockFreighterInstalled(false)
+    mockFreighterInstalled(false);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true)
-      expect(result.current.isConnected).toBe(false)
-    })
-  })
+      expect(result.current.isInstalled).toBe(true);
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
 
   it('sets publicKey to null when extension is detected but not connected', async () => {
-    mockFreighterInstalled(false)
+    mockFreighterInstalled(false);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBeNull()
-    })
-  })
-})
+      expect(result.current.publicKey).toBeNull();
+    });
+  });
+});
 
 // ─── Lifecycle 2: Connect ─────────────────────────────────────────────────────
 
 describe('useFreighter — connect', () => {
   it('retrieves publicKey when connected to mainnet', async () => {
-    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
-    mockFreighterInstalled(true, 'PUBLIC', testKey)
+    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77';
+    mockFreighterInstalled(true, 'PUBLIC', testKey);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true)
-      expect(result.current.publicKey).toBe(testKey)
-    })
-  })
+      expect(result.current.isConnected).toBe(true);
+      expect(result.current.publicKey).toBe(testKey);
+    });
+  });
 
   it('sets network to PUBLIC when connected on mainnet', async () => {
-    mockFreighterInstalled(true, 'PUBLIC')
+    mockFreighterInstalled(true, 'PUBLIC');
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC')
-    })
-  })
+      expect(result.current.network).toBe('PUBLIC');
+    });
+  });
 
   it('reflects connected state when extension API reports connected', async () => {
-    mockFreighterInstalled(true, 'PUBLIC')
+    mockFreighterInstalled(true, 'PUBLIC');
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true)
-      expect(result.current.isConnected).toBe(true)
-    })
-  })
+      expect(result.current.isInstalled).toBe(true);
+      expect(result.current.isConnected).toBe(true);
+    });
+  });
 
   it('clears error state on successful connection', async () => {
-    mockFreighterInstalled(true, 'PUBLIC')
+    mockFreighterInstalled(true, 'PUBLIC');
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.error).toBeNull()
-    })
-  })
-})
+      expect(result.current.error).toBeNull();
+    });
+  });
+});
 
 // ─── Lifecycle 3: Disconnect ──────────────────────────────────────────────────
 
 describe('useFreighter — disconnect', () => {
   it('clears publicKey when disconnected', async () => {
     // Start connected
-    mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
+    mockFreighterInstalled(true, 'PUBLIC');
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true)
-      expect(result.current.publicKey).not.toBeNull()
-    })
+      expect(result.current.isConnected).toBe(true);
+      expect(result.current.publicKey).not.toBeNull();
+    });
 
     // Simulate disconnect
-    mockFreighterInstalled(false)
-    rerender()
+    mockFreighterInstalled(false);
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(false)
-      expect(result.current.publicKey).toBeNull()
-    })
-  })
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.publicKey).toBeNull();
+    });
+  });
 
   it('sets isConnected to false when user disconnects', async () => {
-    mockFreighterInstalled(false)
+    mockFreighterInstalled(false);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(false)
-    })
-  })
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
 
   it('clears network when disconnected', async () => {
     // Start connected
-    mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
+    mockFreighterInstalled(true, 'PUBLIC');
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC')
-    })
+      expect(result.current.network).toBe('PUBLIC');
+    });
 
     // Simulate disconnect
-    mockFreighterInstalled(false)
-    rerender()
+    mockFreighterInstalled(false);
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.network).toBeNull()
-    })
-  })
-})
+      expect(result.current.network).toBeNull();
+    });
+  });
+});
 
 // ─── Lifecycle 4: Network change ──────────────────────────────────────────────
 
 describe('useFreighter — network-change', () => {
   it('updates network when switched away from mainnet', async () => {
     // Start on PUBLIC (mainnet)
-    mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
+    mockFreighterInstalled(true, 'PUBLIC');
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC')
-    })
+      expect(result.current.network).toBe('PUBLIC');
+    });
 
     // Switch to TESTNET
-    mockFreighterInstalled(true, 'TESTNET')
-    rerender()
+    mockFreighterInstalled(true, 'TESTNET');
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.network).toBe('TESTNET')
-    })
-  })
+      expect(result.current.network).toBe('TESTNET');
+    });
+  });
 
   it('detects network mismatch (non-mainnet)', async () => {
-    mockFreighterInstalled(true, 'TESTNET')
+    mockFreighterInstalled(true, 'TESTNET');
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true)
-      expect(result.current.network).toBe('TESTNET')
-    })
-  })
+      expect(result.current.isConnected).toBe(true);
+      expect(result.current.network).toBe('TESTNET');
+    });
+  });
 
   it('maintains publicKey across network changes', async () => {
-    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
+    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77';
 
     // Start on PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC', testKey)
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
+    mockFreighterInstalled(true, 'PUBLIC', testKey);
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBe(testKey)
-    })
+      expect(result.current.publicKey).toBe(testKey);
+    });
 
     // Switch to TESTNET with same key
-    mockFreighterInstalled(true, 'TESTNET', testKey)
-    rerender()
+    mockFreighterInstalled(true, 'TESTNET', testKey);
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBe(testKey)
-    })
-  })
+      expect(result.current.publicKey).toBe(testKey);
+    });
+  });
 
   it('restores mainnet-connected state when network switched back', async () => {
     // Start on PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC')
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
+    mockFreighterInstalled(true, 'PUBLIC');
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC')
-    })
+      expect(result.current.network).toBe('PUBLIC');
+    });
 
     // Switch to TESTNET
-    mockFreighterInstalled(true, 'TESTNET')
-    rerender()
+    mockFreighterInstalled(true, 'TESTNET');
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.network).toBe('TESTNET')
-    })
+      expect(result.current.network).toBe('TESTNET');
+    });
 
     // Switch back to PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC')
-    rerender()
+    mockFreighterInstalled(true, 'PUBLIC');
+    rerender();
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC')
-    })
-  })
-})
+      expect(result.current.network).toBe('PUBLIC');
+    });
+  });
+});
 
 // ─── Error handling ───────────────────────────────────────────────────────────
 
 describe('useFreighter — error handling', () => {
   it('handles extension detection errors gracefully', async () => {
-    mockFreighterNotInstalled()
+    mockFreighterNotInstalled();
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     await waitFor(() => {
       // Should not throw, should set isInstalled to false
-      expect(result.current.isInstalled).toBe(false)
-    })
-  })
+      expect(result.current.isInstalled).toBe(false);
+    });
+  });
 
   it('does not update state after unmount', async () => {
-    mockFreighterInstalled(true, 'PUBLIC')
+    mockFreighterInstalled(true, 'PUBLIC');
 
-    const { result, unmount } = renderHook(() => useFreighter(), { wrapper })
+    const { result, unmount } = renderHook(() => useFreighter(), { wrapper });
 
-    unmount()
+    unmount();
 
     // Should not throw errors about state updates on unmounted component
-    expect(result.current).toBeDefined()
-  })
+    expect(result.current).toBeDefined();
+  });
 
   it('maintains initial state until API resolves', () => {
-    mockFreighterInstalled(false)
+    mockFreighterInstalled(false);
 
-    const { result } = renderHook(() => useFreighter(), { wrapper })
+    const { result } = renderHook(() => useFreighter(), { wrapper });
 
     // Initial state before resolution
-    expect(result.current.isInstalled).toBe(false)
-    expect(result.current.isConnected).toBe(false)
-    expect(result.current.publicKey).toBeNull()
-    expect(result.current.network).toBeNull()
-    expect(result.current.error).toBeNull()
-  })
-})
+    expect(result.current.isInstalled).toBe(false);
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.network).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/types/intent.ts
+++ b/types/intent.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+// ─── Off-ramp intent payload ───────────────────────────────────────────────────
+
+/** The inner intent object that describes a single off-ramp operation. */
+export const OfframpIntentSchema = z.object({
+  anchorId: z.string().min(1, { message: 'anchorId is required' }),
+  corridorId: z.string().min(1, { message: 'corridorId is required' }),
+  amount: z.string().regex(/^\d+(\.\d{1,7})?$/, {
+    message: 'amount must be a positive decimal with up to 7 decimal places',
+  }),
+  /** Stellar public key of the user initiating the off-ramp. */
+  publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
+    message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
+  }),
+})
+
+export type OfframpIntent = z.infer<typeof OfframpIntentSchema>
+
+// ─── SignedIntent envelope ─────────────────────────────────────────────────────
+
+/**
+ * Signed envelope that wraps an off-ramp intent for server verification.
+ *
+ * Construction:
+ *   1. Canonicalize `intent` (keys sorted, JSON stringified).
+ *   2. SHA-256 the canonical bytes → `hash` (hex).
+ *   3. Ed25519-sign `hash` bytes with the user's Stellar private key → `signature` (base64).
+ *   4. Include the matching Stellar `publicKey`.
+ *
+ * The server verifies the signature before routing the intent.
+ */
+export const SignedIntentEnvelopeSchema = z.object({
+  intent: OfframpIntentSchema,
+  /** Hex-encoded SHA-256 of the canonicalized intent JSON. */
+  hash: z.string().regex(/^[0-9a-f]{64}$/, {
+    message: 'hash must be a lowercase hex-encoded SHA-256 (64 chars)',
+  }),
+  /** Base64-encoded Ed25519 signature over the hash bytes. */
+  signature: z.string().min(1, { message: 'signature is required' }),
+  /** Stellar public key whose corresponding private key produced the signature. */
+  publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
+    message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
+  }),
+})
+
+export type SignedIntentEnvelope = z.infer<typeof SignedIntentEnvelopeSchema>

--- a/types/intent.ts
+++ b/types/intent.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 // ─── Off-ramp intent payload ───────────────────────────────────────────────────
 
@@ -6,16 +6,19 @@ import { z } from 'zod'
 export const OfframpIntentSchema = z.object({
   anchorId: z.string().min(1, { message: 'anchorId is required' }),
   corridorId: z.string().min(1, { message: 'corridorId is required' }),
-  amount: z.string().regex(/^\d+(\.\d{1,7})?$/, {
-    message: 'amount must be a positive decimal with up to 7 decimal places',
-  }),
+  amount: z
+    .string()
+    .regex(/^\d+(\.\d{1,7})?$/, {
+      message: 'amount must be a positive decimal with up to 7 decimal places',
+    })
+    .refine((val) => parseFloat(val) > 0, { message: 'amount must be greater than zero' }),
   /** Stellar public key of the user initiating the off-ramp. */
   publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
     message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
   }),
-})
+});
 
-export type OfframpIntent = z.infer<typeof OfframpIntentSchema>
+export type OfframpIntent = z.infer<typeof OfframpIntentSchema>;
 
 // ─── SignedIntent envelope ─────────────────────────────────────────────────────
 
@@ -23,25 +26,30 @@ export type OfframpIntent = z.infer<typeof OfframpIntentSchema>
  * Signed envelope that wraps an off-ramp intent for server verification.
  *
  * Construction:
- *   1. Canonicalize `intent` (keys sorted, JSON stringified).
+ *   1. Canonicalize `intent` (keys sorted recursively, JSON stringified).
  *   2. SHA-256 the canonical bytes → `hash` (hex).
- *   3. Ed25519-sign `hash` bytes with the user's Stellar private key → `signature` (base64).
- *   4. Include the matching Stellar `publicKey`.
+ *   3. Ed25519-sign the canonical JSON bytes via Freighter → `signature` (base64).
+ *   4. Include the matching Stellar `publicKey` (returned by Freighter).
  *
  * The server verifies the signature before routing the intent.
  */
-export const SignedIntentEnvelopeSchema = z.object({
-  intent: OfframpIntentSchema,
-  /** Hex-encoded SHA-256 of the canonicalized intent JSON. */
-  hash: z.string().regex(/^[0-9a-f]{64}$/, {
-    message: 'hash must be a lowercase hex-encoded SHA-256 (64 chars)',
-  }),
-  /** Base64-encoded Ed25519 signature over the hash bytes. */
-  signature: z.string().min(1, { message: 'signature is required' }),
-  /** Stellar public key whose corresponding private key produced the signature. */
-  publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
-    message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
-  }),
-})
+export const SignedIntentEnvelopeSchema = z
+  .object({
+    intent: OfframpIntentSchema,
+    /** Hex-encoded SHA-256 of the canonicalized intent JSON. */
+    hash: z.string().regex(/^[0-9a-f]{64}$/, {
+      message: 'hash must be a lowercase hex-encoded SHA-256 (64 chars)',
+    }),
+    /** Base64-encoded Ed25519 signature over the canonical intent JSON bytes. */
+    signature: z.string().min(1, { message: 'signature is required' }),
+    /** Stellar public key whose corresponding private key produced the signature. */
+    publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
+      message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
+    }),
+  })
+  .refine((data) => data.publicKey === data.intent.publicKey, {
+    message: 'envelope publicKey must match intent publicKey',
+    path: ['publicKey'],
+  });
 
-export type SignedIntentEnvelope = z.infer<typeof SignedIntentEnvelopeSchema>
+export type SignedIntentEnvelope = z.infer<typeof SignedIntentEnvelopeSchema>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -20,4 +20,4 @@ export default defineConfig({
       '@': path.resolve(__dirname, '.'),
     },
   },
-})
+});


### PR DESCRIPTION

## Summary

closes #195 closes #196 closes #197 closes #207

### #195 — Keyboard-only navigation (`tests/e2e/keyboard-nav.spec.ts`)
- Playwright spec covering the full `/offramp` tab order using `page.keyboard` exclusively — zero mouse events.
- Asserts focus stops on WalletButton, `<select>` (CorridorSelector), AmountInput, amount chips ($50/$100), and Off-ramp table buttons.
- Verifies Tailwind `focus:ring-2` box-shadow is present on every focused element.
- Dedicated "no element traps focus" guard ensures Tab always advances.

### #196 — Slow-3G network profile (`tests/e2e/slow-network.spec.ts`)
- Opens a Playwright CDP session per test and calls `Network.emulateNetworkConditions` with Chrome's Slow 3G preset (400 Kbps, 400 ms latency).
- Asserts `.animate-pulse` skeleton rows are visible before data arrives.
- Waits up to 90 s for the rate table or empty/error state to settle.
- Restores network conditions in `afterEach` and guards against unhandled JS errors.

### #197 — Freighter not installed (`tests/e2e/no-freighter.spec.ts`)
- Uses `page.addInitScript` to clear Freighter window globals and patch webpack's module cache so `isConnected` throws, triggering `useFreighter`'s catch branch (`isInstalled` stays `false`).
- Also uses `page.route` to intercept and patch `_next/static/chunks/**` that contain the freighter-api bundle as a belt-and-suspenders fallback.
- Asserts the "Install Freighter" anchor (with correct `href`/`rel`) or the "Connect Wallet" button is visible; asserts zero unhandled JS errors.

### #207 — SignedIntent envelope (`types/intent.ts`, `lib/intent/envelope.ts`, `app/api/intent/offramp/route.ts`)
- **`types/intent.ts`** — Zod schemas (`OfframpIntentSchema`, `SignedIntentEnvelopeSchema`) with field-level validation messages. Envelope shape: `{ intent, hash (hex SHA-256), signature (base64 Ed25519), publicKey (Stellar G…) }`.
- **`lib/intent/envelope.ts`** — `buildEnvelope(intent, keypair)` for the client and `verifyEnvelope(envelope)` for the server. Canonicalizes by sorting keys → JSON → SHA-256; signs/verifies with Stellar SDK `Keypair.sign` / `Keypair.verify`.
- **`app/api/intent/offramp/route.ts`** — `POST /api/intent/offramp`: parses body → Zod validates → `verifyEnvelope` → 401 on invalid signature → 200 with intent forwarded to router stub. Returns typed `ApiError` objects on 400/401.

## Test plan
- [ ] Install Playwright: `npm install -D @playwright/test && npx playwright install chromium`
- [ ] Add `"test:e2e": "playwright test"` to `package.json` scripts
- [ ] Run `npm run dev` then `npm run test:e2e` — all three specs should pass in headless Chromium
- [ ] Verify `POST /api/intent/offramp` with a valid envelope returns 200; tampered signature returns 401
- [ ] Run existing Vitest suite (`npm test`) to confirm no regressions
