### PR TITLE
fix(status-tracker): add stellar.expert link for on-chain tx (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `StatusTracker`: when `stellar_transaction_id` is a valid 64-char hex, render a link to `{STELLAR_EXPERT_URL}/tx/{id}` opening in a new tab (`target="_blank" rel="noopener noreferrer"`) ([#47](https://github.com/Ezedike-Evan/stellar-intel/issues/47))
+
 [Unreleased]: https://github.com/Ezedike-Evan/stellar-intel/commits/main

--- a/components/offramp/StatusTracker.tsx
+++ b/components/offramp/StatusTracker.tsx
@@ -1,25 +1,26 @@
-'use client'
-import type { WithdrawStatusValue, Sep24Transaction } from '@/types'
-import { formatDeliveredAmount } from '@/lib/format'
-import { Timeline } from './Timeline'
+'use client';
+import type { WithdrawStatusValue, Sep24Transaction } from '@/types';
+import { formatDeliveredAmount } from '@/lib/format';
+import { Timeline } from './Timeline';
+import { STELLAR_EXPERT_URL } from '@/constants';
 
 interface StatusTrackerProps {
-  transactionId: string
-  status: WithdrawStatusValue | undefined
-  amountIn: string | undefined
-  amountInAsset: string | undefined
-  amountOut: string | undefined
-  amountOutAsset: string | undefined
-  amountFee: string | undefined
+  transactionId: string;
+  status: WithdrawStatusValue | undefined;
+  amountIn: string | undefined;
+  amountInAsset: string | undefined;
+  amountOut: string | undefined;
+  amountOutAsset: string | undefined;
+  amountFee: string | undefined;
   /** ISO 4217 currency code for the destination corridor (e.g. "NGN", "KES"). */
-  currencyCode: string
-  stellarTransactionId: string | undefined
-  externalTransactionId: string | undefined
-  refunds?: Sep24Transaction['refunds']
-  isLoading: boolean
-  error: string | undefined
-  onRetryAnchor?: () => void
-  onAdjust?: () => void
+  currencyCode: string;
+  stellarTransactionId: string | undefined;
+  externalTransactionId: string | undefined;
+  refunds?: Sep24Transaction['refunds'];
+  isLoading: boolean;
+  error: string | undefined;
+  onRetryAnchor?: () => void;
+  onAdjust?: () => void;
 }
 
 const STATUS_LABELS: Record<WithdrawStatusValue, string> = {
@@ -38,25 +39,33 @@ const STATUS_LABELS: Record<WithdrawStatusValue, string> = {
   too_small: 'Amount too small',
   too_large: 'Amount too large',
   expired: 'Transaction expired',
-}
+};
 
-const TERMINAL: WithdrawStatusValue[] = ['completed', 'refunded', 'error', 'no_market', 'too_small', 'too_large', 'expired']
+const TERMINAL: WithdrawStatusValue[] = [
+  'completed',
+  'refunded',
+  'error',
+  'no_market',
+  'too_small',
+  'too_large',
+  'expired',
+];
 
 function statusColor(status: WithdrawStatusValue | undefined): string {
-  if (!status) return 'text-gray-500'
-  if (status === 'completed') return 'text-green-600 dark:text-green-400'
+  if (!status) return 'text-gray-500';
+  if (status === 'completed') return 'text-green-600 dark:text-green-400';
   if (['error', 'no_market', 'too_small', 'too_large'].includes(status))
-    return 'text-red-600 dark:text-red-400'
-  if (status === 'refunded') return 'text-yellow-600 dark:text-yellow-400'
-  return 'text-blue-600 dark:text-blue-400'
+    return 'text-red-600 dark:text-red-400';
+  if (status === 'refunded') return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-blue-600 dark:text-blue-400';
 }
 
 function statusDot(status: WithdrawStatusValue | undefined): string {
-  if (!status) return 'bg-gray-300'
-  if (status === 'completed') return 'bg-green-500'
-  if (['error', 'no_market', 'too_small', 'too_large'].includes(status)) return 'bg-red-500'
-  if (status === 'refunded') return 'bg-yellow-500'
-  return 'bg-blue-500 animate-pulse'
+  if (!status) return 'bg-gray-300';
+  if (status === 'completed') return 'bg-green-500';
+  if (['error', 'no_market', 'too_small', 'too_large'].includes(status)) return 'bg-red-500';
+  if (status === 'refunded') return 'bg-yellow-500';
+  return 'bg-blue-500 animate-pulse';
 }
 
 export function StatusTracker({
@@ -74,8 +83,8 @@ export function StatusTracker({
   isLoading,
   error,
 }: StatusTrackerProps) {
-  const isTerminal = status ? TERMINAL.includes(status) : false
-  const isCompleted = status === 'completed'
+  const isTerminal = status ? TERMINAL.includes(status) : false;
+  const isCompleted = status === 'completed';
 
   return (
     <div
@@ -87,7 +96,9 @@ export function StatusTracker({
     >
       <div className="mb-4 flex items-start justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Transaction Status</h3>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Transaction Status
+          </h3>
           <p className="mt-0.5 font-mono text-xs text-gray-400">{transactionId}</p>
         </div>
         {!isTerminal && (
@@ -158,7 +169,9 @@ export function StatusTracker({
       {/* Refund details */}
       {status === 'refunded' && refunds && (
         <div className="mb-4 mt-2 rounded-lg bg-yellow-50 p-4 dark:bg-yellow-900/20">
-          <h4 className="mb-2 text-sm font-semibold text-yellow-800 dark:text-yellow-300">Refund Details</h4>
+          <h4 className="mb-2 text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+            Refund Details
+          </h4>
           <dl className="space-y-1.5 text-sm">
             {refunds.amount_refunded && (
               <div className="flex justify-between">
@@ -177,21 +190,27 @@ export function StatusTracker({
               </div>
             )}
           </dl>
-          
+
           {refunds.payments && refunds.payments.length > 0 && (
             <div className="mt-3 pt-3 border-t border-yellow-200/50 dark:border-yellow-700/50">
-              <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-300 mb-2">Refund Payments</p>
+              <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-300 mb-2">
+                Refund Payments
+              </p>
               <div className="space-y-2">
                 {refunds.payments.map((p, i) => (
                   <div key={i} className="text-xs bg-white/50 dark:bg-black/20 rounded p-2">
                     <div className="flex justify-between mb-1">
                       <span className="text-yellow-700 dark:text-yellow-400">Amount</span>
-                      <span className="font-medium text-yellow-900 dark:text-yellow-200">{p.amount}</span>
+                      <span className="font-medium text-yellow-900 dark:text-yellow-200">
+                        {p.amount}
+                      </span>
                     </div>
                     {p.fee && (
                       <div className="flex justify-between mb-1">
                         <span className="text-yellow-700 dark:text-yellow-400">Fee</span>
-                        <span className="font-medium text-yellow-900 dark:text-yellow-200">{p.fee}</span>
+                        <span className="font-medium text-yellow-900 dark:text-yellow-200">
+                          {p.fee}
+                        </span>
                       </div>
                     )}
                     <div className="mt-1 pt-1 border-t border-yellow-200/30 dark:border-yellow-700/30">
@@ -220,25 +239,34 @@ export function StatusTracker({
       )}
 
       {/* Stellar tx link */}
-      {stellarTransactionId && (
+      {stellarTransactionId && isValidStellarTxId(stellarTransactionId) && (
         <p className="text-xs text-gray-500">
           Stellar tx:{' '}
-          <span className="font-mono text-gray-700 dark:text-gray-300">
+          <a
+            href={`${STELLAR_EXPERT_URL}/tx/${stellarTransactionId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+          >
             {stellarTransactionId.slice(0, 16)}…
-          </span>
+          </a>
         </p>
       )}
 
       {/* Vertical Timeline */}
       <Timeline status={status} />
     </div>
-  )
+  );
+}
+
+function isValidStellarTxId(id: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(id);
 }
 
 function parseAsset(assetStr: string | undefined): string | null {
-  if (!assetStr) return null
-  if (assetStr === 'stellar:native') return 'XLM'
+  if (!assetStr) return null;
+  if (assetStr === 'stellar:native') return 'XLM';
   // stellar:USDC:GA5Z... -> USDC
-  const parts = assetStr.split(':')
-  return parts[1] ?? null
+  const parts = assetStr.split(':');
+  return parts[1] ?? null;
 }

--- a/tests/components/StatusTracker.test.tsx
+++ b/tests/components/StatusTracker.test.tsx
@@ -1,91 +1,93 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { StatusTracker } from '@/components/offramp/StatusTracker'
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusTracker } from '@/components/offramp/StatusTracker';
 
 const BASE_PROPS = {
   transactionId: 'txn-abc-123',
   status: undefined,
   amountIn: undefined,
+  amountInAsset: undefined,
   amountOut: undefined,
+  amountOutAsset: undefined,
+  amountFee: undefined,
   currencyCode: 'NGN',
   stellarTransactionId: undefined,
+  externalTransactionId: undefined,
   isLoading: false,
   error: undefined,
-} as const
+} as const;
 
 describe('StatusTracker', () => {
   it('renders the transaction ID', () => {
-    render(<StatusTracker {...BASE_PROPS} />)
-    expect(screen.getByText('txn-abc-123')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} />);
+    expect(screen.getByText('txn-abc-123')).toBeInTheDocument();
+  });
 
   it('shows "Fetching status…" when isLoading is true and status is undefined', () => {
-    render(<StatusTracker {...BASE_PROPS} isLoading={true} />)
-    expect(screen.getByText('Fetching status…')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} isLoading={true} />);
+    expect(screen.getByText('Fetching status…')).toBeInTheDocument();
+  });
 
   it('shows "Completed" label when status is completed', () => {
-    render(<StatusTracker {...BASE_PROPS} status="completed" />)
-    expect(screen.getByText('Completed')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="completed" />);
+    expect(screen.getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
+  });
 
   it('shows "Awaiting your payment" for pending_user_transfer_start status', () => {
-    render(<StatusTracker {...BASE_PROPS} status="pending_user_transfer_start" />)
-    expect(screen.getByText('Awaiting your payment')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="pending_user_transfer_start" />);
+    expect(screen.getByText('Awaiting your payment')).toBeInTheDocument();
+  });
 
   it('shows completion celebration banner with localized amount when completed', () => {
-    render(
-      <StatusTracker
-        {...BASE_PROPS}
-        status="completed"
-        amountIn="100"
-        amountOut="154840"
-      />
-    )
-    expect(screen.getByText('Delivered')).toBeInTheDocument()
+    render(<StatusTracker {...BASE_PROPS} status="completed" amountIn="100" amountOut="154840" />);
+    expect(screen.getByText('Delivered')).toBeInTheDocument();
     // The formatted amount should contain the numeric value
-    expect(screen.getByText(/154,840|154840/)).toBeInTheDocument()
+    expect(screen.getByText(/154,840|154840/)).toBeInTheDocument();
     // The raw amount detail row should not be shown when completed
-    expect(screen.queryByText('You receive')).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText('You receive')).not.toBeInTheDocument();
+  });
 
   it('shows amount details when status is not completed', () => {
     render(
-      <StatusTracker
-        {...BASE_PROPS}
-        status="pending_external"
-        amountIn="100"
-        amountOut="154840"
-      />
-    )
-    expect(screen.getByText('100 USDC')).toBeInTheDocument()
-    expect(screen.getByText('You receive')).toBeInTheDocument()
-  })
+      <StatusTracker {...BASE_PROPS} status="pending_external" amountIn="100" amountOut="154840" />
+    );
+    expect(screen.getByText('100 USDC')).toBeInTheDocument();
+    expect(screen.getByText('You receive')).toBeInTheDocument();
+  });
 
   it('shows the error message when error is provided', () => {
-    render(<StatusTracker {...BASE_PROPS} error="Status poll failed: HTTP 401" />)
-    expect(screen.getByText('Status poll failed: HTTP 401')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} error="Status poll failed: HTTP 401" />);
+    expect(screen.getByText('Status poll failed: HTTP 401')).toBeInTheDocument();
+  });
 
-  it('shows the stellar transaction ID (truncated) when provided', () => {
+  it('renders a stellar.expert link when stellarTransactionId is a valid 64-char hex', () => {
+    const txId = 'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899';
+    render(<StatusTracker {...BASE_PROPS} status="completed" stellarTransactionId={txId} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `https://api.stellar.expert/explorer/public/tx/${txId}`);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveTextContent('aabbccddeeff0011…');
+  });
+
+  it('does not render a stellar.expert link when stellarTransactionId is not a valid 64-char hex', () => {
     render(
       <StatusTracker
         {...BASE_PROPS}
         status="completed"
         stellarTransactionId="abc123def456789012345678"
       />
-    )
-    expect(screen.getByText(/abc123def456789/)).toBeInTheDocument()
-  })
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
 
   it('shows "Live" indicator when status is not terminal', () => {
-    render(<StatusTracker {...BASE_PROPS} status="pending_anchor" />)
-    expect(screen.getByText('Live')).toBeInTheDocument()
-  })
+    render(<StatusTracker {...BASE_PROPS} status="pending_anchor" />);
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
 
   it('hides "Live" indicator when status is completed', () => {
-    render(<StatusTracker {...BASE_PROPS} status="completed" />)
-    expect(screen.queryByText('Live')).not.toBeInTheDocument()
-  })
-})
+    render(<StatusTracker {...BASE_PROPS} status="completed" />);
+    expect(screen.queryByText('Live')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Renders a clickable stellar.expert link in [StatusTracker](cci:1://file:///home/dsotec/Documents/stellar-intel/components/offramp/StatusTracker.tsx:62:0-241:1) whenever the anchor
returns a valid `stellar_transaction_id`. Previously the field showed a plain
truncated span with no link.

## Linked issue

Closes #47

## Changes

- [components/offramp/StatusTracker.tsx](cci:7://file:///home/dsotec/Documents/stellar-intel/components/offramp/StatusTracker.tsx:0:0-0:0) — import `STELLAR_EXPERT_URL`; replace
  plain `<span>` stub with `<a href="{STELLAR_EXPERT_URL}/tx/{id}" target="_blank"
  rel="noopener noreferrer">`; add `isValidStellarTxId()` guard (`/^[0-9a-fA-F]{64}$/`)
- [tests/components/StatusTracker.test.tsx](cci:7://file:///home/dsotec/Documents/stellar-intel/tests/components/StatusTracker.test.tsx:0:0-0:0) — add two new tests (valid hex → link
  renders with correct href/target/rel; invalid hex → no link); fix pre-existing
  `BASE_PROPS` missing required props (caused `tsc` strict error); fix pre-existing
  `getByText('Completed')` multiple-match error from Timeline step label
- [CHANGELOG.md](cci:7://file:///home/dsotec/Documents/stellar-intel/CHANGELOG.md:0:0-0:0) — `[Unreleased] ### Added` entry

## Testing notes

**Automated**
- `npm run typecheck` · ✅ green (0 new errors in touched files)
- `npm run lint` · ⏳ local env broken (`@typescript-eslint` pkg missing); CI uses clean install
- `npm run test` · ✅ green — 11/11 pass (`npm run test -- tests/components/StatusTracker.test.tsx`)
- `npm run build` · ⏳ not run locally

**New / modified tests**
- [tests/components/StatusTracker.test.tsx](cci:7://file:///home/dsotec/Documents/stellar-intel/tests/components/StatusTracker.test.tsx:0:0-0:0) — "renders a stellar.expert link when
  stellarTransactionId is a valid 64-char hex" / "does not render a stellar.expert
  link when stellarTransactionId is not a valid 64-char hex"

## Breaking changes

None.