### PR TITLE
feat(router): fallback re-solve when anchor rejects quote (#215)

### DIFF
--- a/lib/router/solve.ts
+++ b/lib/router/solve.ts
@@ -1,0 +1,132 @@
+/**
+ * lib/router/solve.ts
+ *
+ * Intent router — picks the best anchor for a corridor/amount pair and
+ * handles quote rejection with up to MAX_FALLBACK_ATTEMPTS re-solves.
+ *
+ * Issue #215: fallback re-solve when first anchor rejects quote.
+ */
+
+import { fetchAllAnchorFees, computeRateComparison } from '@/lib/stellar/sep24'
+import type { AnchorRate, RateComparison } from '@/types'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Maximum number of fallback re-solve attempts after the primary anchor fails. */
+export const MAX_FALLBACK_ATTEMPTS = 2
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Reason a quote was rejected or expired. */
+export type QuoteRejectionReason = 'expired' | 'rejected' | 'unavailable'
+
+/** A single solve attempt recorded for reputation tracking. */
+export interface SolveAttempt {
+  /** The anchor that was tried. */
+  anchorId: string
+  /** Whether this attempt succeeded (quote accepted) or failed. */
+  succeeded: boolean
+  /** Populated when the attempt failed. */
+  rejectionReason?: QuoteRejectionReason
+  /** ISO timestamp of the attempt. */
+  attemptedAt: string
+}
+
+/** The result returned by solveWithFallback. */
+export interface SolveResult {
+  /** The winning anchor rate, or null if all candidates failed. */
+  winner: AnchorRate | null
+  /** Full rate comparison from the final successful solve, or null. */
+  comparison: RateComparison | null
+  /** Ordered log of every attempt made (primary + fallbacks). */
+  attempts: SolveAttempt[]
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches rates for the given corridor/amount and returns the best anchor
+ * excluding any anchor IDs in `excludeIds`.
+ */
+async function fetchBestRate(
+  corridorId: string,
+  amount: string,
+  excludeIds: Set<string>
+): Promise<{ winner: AnchorRate; comparison: RateComparison } | null> {
+  const settled = await fetchAllAnchorFees(amount, corridorId)
+
+  // Filter out previously-rejected anchors
+  const filtered = settled.map((result): PromiseSettledResult<AnchorRate> => {
+    if (result.status === 'fulfilled' && excludeIds.has(result.value.anchorId)) {
+      return { status: 'rejected', reason: new Error(`Anchor ${result.value.anchorId} excluded`) }
+    }
+    return result
+  })
+
+  const comparison = computeRateComparison(filtered, corridorId)
+
+  if (!comparison.bestRateId) return null
+
+  const winner = comparison.rates.find((r) => r.anchorId === comparison.bestRateId)
+  if (!winner) return null
+
+  return { winner, comparison }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Solves for the best anchor for a given corridor and amount.
+ *
+ * If the primary anchor's quote is rejected or expires, re-solves with the
+ * remaining candidates. At most MAX_FALLBACK_ATTEMPTS (2) fallback attempts
+ * are made. All attempts are logged for reputation tracking.
+ *
+ * @param corridorId  - e.g. 'usdc-ngn'
+ * @param amount      - amount in USDC as a string, e.g. '100'
+ * @param isRejected  - optional predicate; given the winning AnchorRate, returns
+ *                      true if the quote should be treated as rejected/expired.
+ *                      Defaults to always accepting the quote.
+ * @returns SolveResult with winner, comparison, and full attempt log.
+ */
+export async function solveWithFallback(
+  corridorId: string,
+  amount: string,
+  isRejected: (rate: AnchorRate) => boolean = () => false
+): Promise<SolveResult> {
+  const attempts: SolveAttempt[] = []
+  const excludeIds = new Set<string>()
+
+  // Primary attempt + up to MAX_FALLBACK_ATTEMPTS fallbacks
+  const maxRounds = 1 + MAX_FALLBACK_ATTEMPTS
+
+  for (let round = 0; round < maxRounds; round++) {
+    const result = await fetchBestRate(corridorId, amount, excludeIds)
+
+    if (!result) {
+      // No more candidates available
+      break
+    }
+
+    const { winner, comparison } = result
+    const rejected = isRejected(winner)
+
+    attempts.push({
+      anchorId: winner.anchorId,
+      succeeded: !rejected,
+      ...(rejected && { rejectionReason: 'rejected' as QuoteRejectionReason }),
+      attemptedAt: new Date().toISOString(),
+    })
+
+    if (!rejected) {
+      // Quote accepted — return immediately
+      return { winner, comparison, attempts }
+    }
+
+    // Exclude this anchor from subsequent rounds
+    excludeIds.add(winner.anchorId)
+  }
+
+  // All attempts exhausted
+  return { winner: null, comparison: null, attempts }
+}

--- a/tests/router-fallback.spec.ts
+++ b/tests/router-fallback.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * tests/router-fallback.spec.ts
+ *
+ * Tests for lib/router/solve.ts — issue #215
+ * Verifies fallback re-solve behaviour when the primary anchor rejects a quote.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { solveWithFallback, MAX_FALLBACK_ATTEMPTS } from '@/lib/router/solve'
+import * as sep24 from '@/lib/stellar/sep24'
+import type { AnchorRate, RateComparison } from '@/types'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRate(anchorId: string, totalReceived: number): AnchorRate {
+  return {
+    anchorId,
+    anchorName: `Anchor ${anchorId}`,
+    corridorId: 'usdc-ngn',
+    fee: 2,
+    feeType: 'flat',
+    exchangeRate: 1580,
+    totalReceived,
+    source: 'sep24-fee',
+    updatedAt: new Date(),
+  }
+}
+
+function makeSettled(rate: AnchorRate): PromiseFulfilledResult<AnchorRate> {
+  return { status: 'fulfilled', value: rate }
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── Happy path ───────────────────────────────────────────────────────────────
+
+describe('solveWithFallback — happy path', () => {
+  it('returns the best anchor when the primary quote is accepted', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([
+      makeSettled(rateA),
+      makeSettled(rateB),
+    ])
+
+    const result = await solveWithFallback('usdc-ngn', '100')
+
+    expect(result.winner?.anchorId).toBe('anchor-a')
+    expect(result.attempts).toHaveLength(1)
+    expect(result.attempts[0]?.succeeded).toBe(true)
+    expect(result.attempts[0]?.anchorId).toBe('anchor-a')
+  })
+
+  it('records a single attempt with no rejectionReason on success', async () => {
+    const rate = makeRate('anchor-a', 15800)
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([makeSettled(rate)])
+
+    const result = await solveWithFallback('usdc-ngn', '100')
+
+    expect(result.attempts[0]?.rejectionReason).toBeUndefined()
+  })
+
+  it('returns the full RateComparison alongside the winner', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([
+      makeSettled(rateA),
+      makeSettled(rateB),
+    ])
+
+    const result = await solveWithFallback('usdc-ngn', '100')
+
+    expect(result.comparison).not.toBeNull()
+    expect(result.comparison?.bestRateId).toBe('anchor-a')
+    expect(result.comparison?.rates).toHaveLength(2)
+  })
+})
+
+// ─── Fallback behaviour ───────────────────────────────────────────────────────
+
+describe('solveWithFallback — fallback on rejection', () => {
+  it('re-solves with the next best anchor when the primary is rejected', async () => {
+    const rateA = makeRate('anchor-a', 15800) // best, but will be rejected
+    const rateB = makeRate('anchor-b', 14000) // fallback
+
+    // First call: both anchors available
+    // Second call: anchor-a excluded, only anchor-b returned
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    // Reject anchor-a's quote
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    expect(result.winner?.anchorId).toBe('anchor-b')
+    expect(result.attempts).toHaveLength(2)
+    expect(result.attempts[0]?.anchorId).toBe('anchor-a')
+    expect(result.attempts[0]?.succeeded).toBe(false)
+    expect(result.attempts[0]?.rejectionReason).toBe('rejected')
+    expect(result.attempts[1]?.anchorId).toBe('anchor-b')
+    expect(result.attempts[1]?.succeeded).toBe(true)
+  })
+
+  it('user sees a single unified result — only the winner is surfaced', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    // The winner is a single AnchorRate — not an array of attempts
+    expect(result.winner).not.toBeNull()
+    expect(Array.isArray(result.winner)).toBe(false)
+    expect(result.winner?.anchorId).toBe('anchor-b')
+  })
+
+  it('logs both attempts for reputation tracking', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    // Both attempts are logged
+    expect(result.attempts).toHaveLength(2)
+    const anchorIds = result.attempts.map((a) => a.anchorId)
+    expect(anchorIds).toContain('anchor-a')
+    expect(anchorIds).toContain('anchor-b')
+
+    // Each attempt has an ISO timestamp
+    for (const attempt of result.attempts) {
+      expect(() => new Date(attempt.attemptedAt)).not.toThrow()
+      expect(new Date(attempt.attemptedAt).toISOString()).toBe(attempt.attemptedAt)
+    }
+  })
+
+  it('excludes the rejected anchor from the fallback solve', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    const fetchSpy = vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    await solveWithFallback('usdc-ngn', '100', (rate) => rate.anchorId === 'anchor-a')
+
+    // fetchAllAnchorFees is called twice (primary + 1 fallback)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ─── MAX_FALLBACK_ATTEMPTS cap ────────────────────────────────────────────────
+
+describe('solveWithFallback — max fallback attempts', () => {
+  it('stops after MAX_FALLBACK_ATTEMPTS fallbacks even if more anchors exist', async () => {
+    // Three anchors: all will be rejected
+    const rates = [
+      makeRate('anchor-a', 15800),
+      makeRate('anchor-b', 14000),
+      makeRate('anchor-c', 12000),
+    ]
+
+    // Each call returns all three; the solver excludes previously-rejected ones
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue(rates.map(makeSettled))
+
+    // Reject every anchor
+    const result = await solveWithFallback('usdc-ngn', '100', () => true)
+
+    // 1 primary + MAX_FALLBACK_ATTEMPTS fallbacks = 3 total rounds max
+    expect(result.attempts.length).toBeLessThanOrEqual(1 + MAX_FALLBACK_ATTEMPTS)
+    expect(result.winner).toBeNull()
+  })
+
+  it('MAX_FALLBACK_ATTEMPTS is 2', () => {
+    expect(MAX_FALLBACK_ATTEMPTS).toBe(2)
+  })
+
+  it('makes exactly 1 + MAX_FALLBACK_ATTEMPTS calls when all anchors reject', async () => {
+    const rates = [
+      makeRate('anchor-a', 15800),
+      makeRate('anchor-b', 14000),
+      makeRate('anchor-c', 12000),
+    ]
+
+    const fetchSpy = vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue(rates.map(makeSettled))
+
+    await solveWithFallback('usdc-ngn', '100', () => true)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1 + MAX_FALLBACK_ATTEMPTS)
+  })
+})
+
+// ─── No candidates ────────────────────────────────────────────────────────────
+
+describe('solveWithFallback — no candidates', () => {
+  it('returns null winner when no anchors are available', async () => {
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([])
+
+    const result = await solveWithFallback('usdc-ngn', '100')
+
+    expect(result.winner).toBeNull()
+    expect(result.comparison).toBeNull()
+    expect(result.attempts).toHaveLength(0)
+  })
+
+  it('returns null winner when all anchor fetches are rejected', async () => {
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([
+      { status: 'rejected', reason: new Error('timeout') },
+      { status: 'rejected', reason: new Error('network error') },
+    ])
+
+    const result = await solveWithFallback('usdc-ngn', '100')
+
+    expect(result.winner).toBeNull()
+    expect(result.comparison).toBeNull()
+    expect(result.attempts).toHaveLength(0)
+  })
+
+  it('returns null winner when all candidates are exhausted after fallbacks', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    // Only two anchors; both get rejected
+    vi.spyOn(sep24, 'fetchAllAnchorFees').mockResolvedValue([
+      makeSettled(rateA),
+      makeSettled(rateB),
+    ])
+
+    const result = await solveWithFallback('usdc-ngn', '100', () => true)
+
+    expect(result.winner).toBeNull()
+    expect(result.attempts.every((a) => !a.succeeded)).toBe(true)
+  })
+})
+
+// ─── Attempt log integrity ────────────────────────────────────────────────────
+
+describe('solveWithFallback — attempt log integrity', () => {
+  it('each attempt has anchorId, succeeded, and attemptedAt fields', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    for (const attempt of result.attempts) {
+      expect(typeof attempt.anchorId).toBe('string')
+      expect(typeof attempt.succeeded).toBe('boolean')
+      expect(typeof attempt.attemptedAt).toBe('string')
+    }
+  })
+
+  it('failed attempts carry a rejectionReason; successful ones do not', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    const failed = result.attempts.filter((a) => !a.succeeded)
+    const succeeded = result.attempts.filter((a) => a.succeeded)
+
+    expect(failed.every((a) => a.rejectionReason !== undefined)).toBe(true)
+    expect(succeeded.every((a) => a.rejectionReason === undefined)).toBe(true)
+  })
+
+  it('attempts are ordered chronologically (primary first)', async () => {
+    const rateA = makeRate('anchor-a', 15800)
+    const rateB = makeRate('anchor-b', 14000)
+
+    vi.spyOn(sep24, 'fetchAllAnchorFees')
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+      .mockResolvedValueOnce([makeSettled(rateA), makeSettled(rateB)])
+
+    const result = await solveWithFallback(
+      'usdc-ngn',
+      '100',
+      (rate) => rate.anchorId === 'anchor-a'
+    )
+
+    // Primary attempt is anchor-a (highest totalReceived), fallback is anchor-b
+    expect(result.attempts[0]?.anchorId).toBe('anchor-a')
+    expect(result.attempts[1]?.anchorId).toBe('anchor-b')
+  })
+})


### PR DESCRIPTION
- Add lib/router/solve.ts with solveWithFallback()
  - Picks best anchor by highest totalReceived
  - On quote rejection, re-solves with remaining candidates
  - Enforces MAX_FALLBACK_ATTEMPTS = 2 cap
  - Logs every attempt (anchorId, succeeded, rejectionReason, attemptedAt) for reputation tracking
- Add tests/router-fallback.spec.ts with 16 tests covering:
  - Happy path: primary quote accepted, single attempt logged
  - Fallback: rejection triggers re-solve with next best anchor
  - Unified UX: winner is a single AnchorRate, not an array
  - Attempt log integrity: fields, ordering, rejectionReason presence
  - MAX_FALLBACK_ATTEMPTS cap enforced
  - No-candidates edge cases

<!--
Thanks for opening a PR!

Before you submit:
  • Conventional Commits title — the PR title is linted (feat / fix / docs /
    refactor / test / chore / ci / perf / build / style / revert, with an
    optional scope and a short description). See .github/workflows/pr-title.yml.
  • One logical change per PR. If you have an unrelated cleanup, split it.
  • Fill in every section below. Delete none of them — leave "N/A" if a
    section genuinely doesn't apply and say *why*.
-->

## Summary

<!--
One or two sentences on **what changed and why**. Lead with the why.
Well-named identifiers already explain the what — don't restate the diff.
-->

## Linked issue

<!--
Every PR must link an issue. Use a closing keyword (Closes / Fixes /
Resolves) so the issue auto-closes on merge. If the work spans multiple
issues, close the primary and reference the others.

If there is genuinely no issue (e.g. typo fix, chore), say so here and
name the reason.
-->

Closes #

## Changes

<!--
A tight bullet list of the material changes. Not a diff summary — a
reader-oriented explanation. Reference files with backticks, reference
symbols with file_path:line_number when it helps.

Example:
  - `lib/stellar/sep10.ts:54` — assert mainnet network passphrase at parse time
  - `components/offramp/ExecuteDrawer.tsx` — propagate `{ transactionId, jwt }`
    to the page on success so `StatusTracker` mounts (fixes #002)
-->

-
-
-

## Testing notes

<!--
What you ran locally, what you added, and what a reviewer should run to
reproduce. At minimum:

  - The name of the new test(s), with file path.
  - The command(s) you ran (`npm run test -- stellar/sep10`, etc).
  - Any manual verification steps — especially if this touches a real
    anchor, a real Stellar transaction, or Freighter.

If you did not add a test, justify it. "Trivial refactor" or "doc-only" are
valid. "Hard to test" is not.
-->

**Automated**
- `npm run typecheck` · ⏳ not run / ✅ green / ❌ failing
- `npm run lint` · ⏳ not run / ✅ green / ❌ failing
- `npm run test` · ⏳ not run / ✅ green / ❌ failing
- `npm run build` · ⏳ not run / ✅ green / ❌ failing

**New / modified tests**
-

**Manual verification** (if applicable)
<!-- e.g. "Connected Freighter on mainnet, executed USDC→NGN for $5 via
MoneyGram testnet deployment, observed StatusTracker reach `completed` in
3m12s. Stellar Expert link: …" -->
-

## Screenshots / recordings

<!--
REQUIRED for any user-visible change. Drop in:
  - Before + After screenshots for UI diffs.
  - A short Loom or a <30s GIF for flow changes (drawer, tracker, drawer-
    to-tracker hoist, split routing visualisation).
  - Relevant terminal output for CLI / API changes.

For pure backend / doc / CI PRs, write "N/A — no user-visible change".
-->

| Before | After |
| --- | --- |
|  |  |

## Checklist

<!--
Every box must be ticked or explicitly "N/A — why". A reviewer will not
merge a PR with an unaddressed box.
-->

**Correctness**
- [ ] The PR title follows Conventional Commits (auto-linted)
- [ ] One logical change; unrelated cleanup was split into a separate PR
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes with **zero new warnings** (we run `--max-warnings 0` in CI)
- [ ] `npm run test` passes; new behaviour has a test
- [ ] `npm run build` passes

**Data integrity**
- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
- [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
- [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
- [ ] If touching SEP-10: network passphrase assertion is intact (mainnet only)
- [ ] If touching SEP-24: the 10s `AbortController` timeout is intact on anchor fetches
- [ ] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop

**Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
- [ ] No new code path holds user keys, user funds, or long-lived anchor JWTs
- [ ] Every signing action is performed by the user's wallet (Freighter today)
- [ ] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`

**Docs**
- [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
- [ ] API / schema change → relevant `docs/*.md` updated in the same PR
- [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
- [ ] Public-facing feature → screenshot added to `docs/showcase/images/` when relevant
- [ ] New env var → `.env.example` + README env table updated

**Release hygiene**
- [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
- [ ] No dependency added without justification in the PR description
- [ ] No breaking change hidden inside a non-breaking commit

## Breaking changes

<!--
If this PR breaks a public API, the MCP surface, an env var contract,
or a shipped UI URL, say so here with:
  - What breaks.
  - Who is affected.
  - The migration path (code snippet or doc link).

Also prefix the PR title with "!" (e.g. `feat!: remove legacy rate endpoint`)
to make the break visible to release tooling.

If none: write "None."
-->

None.

## For reviewers

<!--
Optional. Use this to call out:
  - Areas where you want a careful read ("look at the quote-expiry math").
  - Tradeoffs you considered and rejected ("chose SWR over a manual poll
    because …").
  - Things you explicitly did NOT do in this PR and are leaving for a
    follow-up (link the follow-up issue).
-->

<!--
One last thing: this PR template is part of the product. If any section
above feels wrong or missing, open a PR against `.github/PULL_REQUEST_TEMPLATE.md`
itself — meta-PRs are welcome.
-->
