### PR TITLE
feat(rates): auto-refresh trigger when any quote row has <5s validity (#087)

### DIFF
--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -4,6 +4,25 @@ import type { ApiRatesResponse, RateComparison } from '@/types';
 
 const RATES_REFRESH_INTERVAL_MS = 30_000;
 
+/**
+ * How long a fetched quote is considered valid before a refresh is needed.
+ * Anchors typically issue quotes valid for 30 seconds.
+ */
+export const QUOTE_VALIDITY_MS = 30_000;
+
+/**
+ * Refresh is triggered when any row has less than this many milliseconds of
+ * validity remaining. Set to 5 000 ms per Issue #087.
+ */
+export const REFRESH_THRESHOLD_MS = 5_000;
+
+/**
+ * How often the watcher polls updatedAt timestamps to check for near-expiry.
+ * Kept at 1 s so the trigger fires within 1 s of the threshold being crossed
+ * without causing excessive re-renders.
+ */
+export const EXPIRY_POLL_INTERVAL_MS = 1_000;
+
 function getVisibilitySnapshot(): boolean {
   return typeof document === 'undefined' || !document.hidden;
 }
@@ -67,6 +86,51 @@ export function useAnchorRates(corridorId: string, amount: string): UseAnchorRat
     }
 
     wasDocumentVisible.current = isDocumentVisible;
+  }, [hasRateQuery, isDocumentVisible, mutate]);
+
+  // ─── Auto-refresh watcher (near-expiry) ──────────────────────────────────────
+  //
+  // Polls every EXPIRY_POLL_INTERVAL_MS. When ANY rate row has less than
+  // REFRESH_THRESHOLD_MS of its QUOTE_VALIDITY_MS window remaining, a refresh is
+  // triggered for the whole corridor. A ref flag prevents concurrent or
+  // back-to-back refresh spam: once a refresh is in-flight the watcher skips
+  // until the data updates. The watcher only runs while the document is visible
+  // so it honours the tab-hidden pause behaviour.
+  const dataRef = useRef<RateComparison | undefined>(data);
+  dataRef.current = data;
+
+  const refreshingRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasRateQuery || !isDocumentVisible) return;
+
+    const intervalId = setInterval(() => {
+      const current = dataRef.current;
+      if (!current || refreshingRef.current) return;
+
+      const now = Date.now();
+      const anyNearExpiry = current.rates.some((rate) => {
+        if (!rate.updatedAt) return false;
+        const age = now - new Date(rate.updatedAt).getTime();
+        const remaining = QUOTE_VALIDITY_MS - age;
+        return remaining < REFRESH_THRESHOLD_MS;
+      });
+
+      if (anyNearExpiry) {
+        refreshingRef.current = true;
+
+        mutate()
+          .catch(() => {
+            // Silently swallow refresh errors — the existing stale data remains
+            // displayed and the next poll cycle will retry.
+          })
+          .finally(() => {
+            refreshingRef.current = false;
+          });
+      }
+    }, EXPIRY_POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
   }, [hasRateQuery, isDocumentVisible, mutate]);
 
   const refresh = useCallback(async () => {

--- a/tests/hooks/useAnchorRates.test.ts
+++ b/tests/hooks/useAnchorRates.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
 import { SWRConfig } from 'swr';
-import { useAnchorRates } from '@/hooks/useAnchorRates';
+import {
+  useAnchorRates,
+  QUOTE_VALIDITY_MS,
+  REFRESH_THRESHOLD_MS,
+  EXPIRY_POLL_INTERVAL_MS,
+} from '@/hooks/useAnchorRates';
 import type { RateComparison } from '@/types';
 
 // Fresh SWR cache per test — prevents cross-test cache pollution
@@ -153,5 +158,178 @@ describe('useAnchorRates', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Auto-refresh watcher (#087 / PR #252) ──────────────────────────────────────
+
+// Dedicated wrapper that disables SWR's own background refresh so only the
+// hook's near-expiry watcher interval drives fetches in these tests.
+const watcherWrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(
+    SWRConfig,
+    {
+      value: { provider: () => new Map(), refreshInterval: 0, revalidateOnFocus: false },
+    },
+    children
+  );
+
+function makeMockRates(updatedAt: Date): RateComparison {
+  return {
+    corridorId: 'usdc-ngn',
+    bestRateId: 'cowrie',
+    rates: [
+      {
+        anchorId: 'cowrie',
+        anchorName: 'Cowrie Exchange',
+        corridorId: 'usdc-ngn',
+        fee: 2,
+        feeType: 'flat',
+        exchangeRate: 1580,
+        totalReceived: 153_660,
+        source: 'sep24-fee' as const,
+        updatedAt,
+      },
+    ],
+  };
+}
+
+function fetchOk(updatedAt: Date) {
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      rates: makeMockRates(updatedAt),
+      fetchedAt: new Date().toISOString(),
+    }),
+  }));
+}
+
+describe('useAnchorRates — exported constants', () => {
+  it('QUOTE_VALIDITY_MS is 30 000', () => {
+    expect(QUOTE_VALIDITY_MS).toBe(30_000);
+  });
+
+  it('REFRESH_THRESHOLD_MS is 5 000', () => {
+    expect(REFRESH_THRESHOLD_MS).toBe(5_000);
+  });
+
+  it('EXPIRY_POLL_INTERVAL_MS is 1 000', () => {
+    expect(EXPIRY_POLL_INTERVAL_MS).toBe(1_000);
+  });
+});
+
+describe('useAnchorRates — auto-refresh watcher', () => {
+  // These tests use real timers. The watcher polls every EXPIRY_POLL_INTERVAL_MS
+  // (1 s) so we wait up to 3 s for the trigger/no-trigger assertion.
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it(
+    'triggers a refresh when any rate row has <5s validity remaining',
+    async () => {
+      // Quote is 26 seconds old — 4 s validity left, under the 5 s threshold
+      const staleUpdatedAt = new Date(
+        Date.now() - (QUOTE_VALIDITY_MS - REFRESH_THRESHOLD_MS + 1_000)
+      );
+
+      vi.stubGlobal('fetch', fetchOk(staleUpdatedAt));
+      const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), {
+        wrapper: watcherWrapper,
+      });
+      await waitFor(() => expect(result.current.rates).toBeDefined());
+
+      // Swap in the auto-refresh spy
+      const refreshFetch = fetchOk(new Date());
+      vi.stubGlobal('fetch', refreshFetch);
+
+      // Wait for watcher to poll (up to 3 × poll interval)
+      await waitFor(() => expect(refreshFetch).toHaveBeenCalledTimes(1), {
+        timeout: EXPIRY_POLL_INTERVAL_MS * 3 + 500,
+      });
+    },
+    EXPIRY_POLL_INTERVAL_MS * 5
+  );
+
+  it(
+    'does NOT trigger auto-refresh when quotes are still fresh',
+    async () => {
+      // Quote is brand new — far from expiry
+      vi.stubGlobal('fetch', fetchOk(new Date()));
+      const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), {
+        wrapper: watcherWrapper,
+      });
+      await waitFor(() => expect(result.current.rates).toBeDefined());
+
+      const watcherFetch = fetchOk(new Date());
+      vi.stubGlobal('fetch', watcherFetch);
+
+      // Wait 3 poll cycles — no refresh should fire
+      await new Promise((resolve) => setTimeout(resolve, EXPIRY_POLL_INTERVAL_MS * 3 + 100));
+
+      expect(watcherFetch).not.toHaveBeenCalled();
+    },
+    EXPIRY_POLL_INTERVAL_MS * 5
+  );
+
+  it(
+    'does NOT spam — concurrent refreshes are skipped',
+    async () => {
+      const staleUpdatedAt = new Date(
+        Date.now() - (QUOTE_VALIDITY_MS - REFRESH_THRESHOLD_MS + 2_000)
+      );
+
+      vi.stubGlobal('fetch', fetchOk(staleUpdatedAt));
+      const { result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), {
+        wrapper: watcherWrapper,
+      });
+      await waitFor(() => expect(result.current.rates).toBeDefined());
+
+      // Slow fetch that hangs for 5 poll cycles — simulates in-flight refresh
+      const slowFetch = vi.fn(
+        () =>
+          new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: async () => ({
+                    rates: makeMockRates(new Date()),
+                    fetchedAt: new Date().toISOString(),
+                  }),
+                }),
+              EXPIRY_POLL_INTERVAL_MS * 5
+            )
+          )
+      );
+      vi.stubGlobal('fetch', slowFetch);
+
+      // Wait for the first poll to trigger exactly one in-flight refresh …
+      await waitFor(() => expect(slowFetch).toHaveBeenCalledTimes(1), {
+        timeout: EXPIRY_POLL_INTERVAL_MS * 3 + 500,
+      });
+
+      // … then wait 2 more poll cycles to confirm no additional calls
+      await new Promise((resolve) => setTimeout(resolve, EXPIRY_POLL_INTERVAL_MS * 2 + 100));
+
+      expect(slowFetch).toHaveBeenCalledTimes(1);
+    },
+    EXPIRY_POLL_INTERVAL_MS * 10
+  );
+
+  it('cleans up the interval on unmount', async () => {
+    vi.stubGlobal('fetch', fetchOk(new Date()));
+
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+    const { unmount, result } = renderHook(() => useAnchorRates('usdc-ngn', '100'), {
+      wrapper: watcherWrapper,
+    });
+    await waitFor(() => expect(result.current.rates).toBeDefined());
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds an expiry-watcher `setInterval` to `useAnchorRates` that polls every `EXPIRY_POLL_INTERVAL_MS` (1 s)
- When **any** `AnchorRate` row has less than `REFRESH_THRESHOLD_MS` (5 s) of its `QUOTE_VALIDITY_MS` (30 s) window remaining, a corridor-wide refresh fires via SWR `mutate()`
- Anti-spam: a `refreshingRef` flag ensures only one refresh can be in-flight at a time — subsequent poll ticks are no-ops until it resolves
- Interval is cleaned up on unmount
- New exports: `QUOTE_VALIDITY_MS`, `REFRESH_THRESHOLD_MS`, `EXPIRY_POLL_INTERVAL_MS`

## Test plan

- [ ] `npx vitest run tests/hooks/useAnchorRates.test.ts` — 10/10 pass
- [ ] No new TS errors in changed files
- [ ] Verify: refresh fires at <5s remaining; does not fire when quotes are fresh; does not spam while in-flight
- [ ] CI green

Closes #178