### PR TITLE
feat(wallet): subscribe to Freighter network changes, poll 5s fallback, disable Execute on wrong network (#42)

### DIFF
--- a/components/offramp/RateTable.tsx
+++ b/components/offramp/RateTable.tsx
@@ -45,6 +45,7 @@ interface RateTableProps {
   refreshInflight?: boolean;
   error: string | undefined;
   onSelectAnchor: (rate: AnchorRate) => void;
+  executeDisabled?: boolean;
   onRefresh?: () => void;
 }
 
@@ -54,6 +55,7 @@ export function RateTable({
   refreshInflight,
   error,
   onSelectAnchor,
+  executeDisabled,
   onRefresh,
 }: RateTableProps) {
   useEffect(() => {
@@ -196,7 +198,7 @@ export function RateTable({
                     <td className="px-4 py-3 text-right">
                       <button
                         onClick={() => onSelectAnchor(rate)}
-                        disabled={isUnavailable}
+                        disabled={isUnavailable || executeDisabled}
                         className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
                       >
                         Off-ramp

--- a/components/ui/WalletButton.tsx
+++ b/components/ui/WalletButton.tsx
@@ -1,10 +1,10 @@
-'use client';
-import { useFreighter } from '@/hooks/useFreighter';
-import { truncatePublicKey } from '@/lib/utils';
-import { Button } from './Button';
+'use client'
+import { useWallet } from '@/contexts/WalletContext'
+import { truncatePublicKey } from '@/lib/utils'
+import { Button } from './Button'
 
 export function WalletButton() {
-  const { isInstalled, isConnected, publicKey, network, connect, error } = useFreighter();
+  const { isInstalled, isConnected, publicKey, network, connect, error } = useWallet()
 
   // State 1: not-detected — Freighter extension is not installed
   if (!isInstalled) {
@@ -17,7 +17,7 @@ export function WalletButton() {
       >
         Install Freighter
       </a>
-    );
+    )
   }
 
   // State 2: disconnected — extension present, wallet not connected
@@ -33,7 +33,7 @@ export function WalletButton() {
           </p>
         )}
       </div>
-    );
+    )
   }
 
   // State 3: wrong-network — connected but not on Mainnet
@@ -60,7 +60,7 @@ export function WalletButton() {
           </a>
         </p>
       </div>
-    );
+    )
   }
 
   // State 4: connected — on Mainnet with a valid public key
@@ -73,5 +73,5 @@ export function WalletButton() {
         Mainnet
       </span>
     </div>
-  );
+  )
 }

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -1,26 +1,24 @@
-'use client';
+'use client'
 
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
-import type { FreighterState } from '@/types';
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
+import type { FreighterState } from '@/types'
 
 import {
   UserRejectedError,
   NetworkError,
   ConnectionError,
   UnknownWalletError,
-} from '@/lib/stellar/errors';
-
-import { WatchWalletChanges } from '@stellar/freighter-api';
+} from '@/lib/stellar/errors'
 
 // Freighter API is a browser extension — import lazily to avoid SSR errors
 async function getFreighterApi() {
-  const mod = await import('@stellar/freighter-api');
-  return mod;
+  const mod = await import('@stellar/freighter-api')
+  return mod
 }
 
 interface WalletContextType extends FreighterState {
-  connect: () => Promise<void>;
-  disconnect: () => void;
+  connect: () => Promise<void>
+  disconnect: () => void
 }
 
 const INITIAL_STATE: FreighterState = {
@@ -29,42 +27,43 @@ const INITIAL_STATE: FreighterState = {
   publicKey: null,
   network: null,
   error: null,
-};
+}
 
-const WalletContext = createContext<WalletContextType | undefined>(undefined);
+const WalletContext = createContext<WalletContextType | undefined>(undefined)
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<FreighterState>(INITIAL_STATE);
-  const mountedRef = useRef(true);
+  const [state, setState] = useState<FreighterState>(INITIAL_STATE)
+  const mountedRef = useRef(true)
 
   useEffect(() => {
-    mountedRef.current = true;
+    mountedRef.current = true
     return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+      mountedRef.current = false
+    }
+  }, [])
 
   // Check extension presence on mount
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
 
     async function checkInstalled() {
       try {
-        const { isConnected, getAddress, getNetwork } = await getFreighterApi();
-        const connResult = await isConnected();
+        const { isConnected, getAddress, getNetwork } = await getFreighterApi()
+        const connResult = await isConnected()
 
-        if (cancelled) return;
+        if (cancelled) return
 
         if (connResult.error || !connResult.isConnected) {
-          setState((s) => ({ ...s, isInstalled: true, isConnected: false }));
-          return;
+          setState((s) => ({ ...s, isInstalled: true, isConnected: false }))
+          return
         }
 
-        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
-        if (cancelled) return;
+        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
+        if (cancelled) return
 
-        const networkName = netResult.network ?? null;
-        const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
+        const networkName = netResult.network ?? null
+        const networkError =
+          networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
 
         setState({
           isInstalled: true,
@@ -72,61 +71,80 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           publicKey: addrResult.address ?? null,
           network: networkName,
           error: networkError,
-        });
+        })
       } catch {
-        if (cancelled) return;
-        setState({ ...INITIAL_STATE, isInstalled: false });
+        if (cancelled) return
+        setState({ ...INITIAL_STATE, isInstalled: false })
       }
     }
 
-    checkInstalled();
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    let watcher: { stop: () => void } | null = null
 
-    // Watch for live changes (account/network switches)
-    const watcher = new WatchWalletChanges(2000);
-    watcher.watch((result: { address?: string; network?: string }) => {
-      if (!mountedRef.current) return;
+    async function init() {
+      await checkInstalled()
+      if (cancelled) return
 
-      const networkName = result.network ?? null;
-      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
+      // Subscribe to live wallet changes; fall back to 5s polling if unavailable
+      try {
+        const { WatchWalletChanges } = await getFreighterApi()
+        if (cancelled) return
 
-      setState((s: FreighterState) => {
-        // Only update if something actually changed to prevent re-render loops
-        if (
-          s.publicKey === result.address &&
-          s.network === networkName &&
-          s.error === networkError
-        ) {
-          return s;
-        }
+        const w = new WatchWalletChanges(5000)
+        watcher = w
+        w.watch((result: { address?: string; network?: string }) => {
+          if (!mountedRef.current) return
 
-        return {
-          ...s,
-          isConnected: !!result.address,
-          publicKey: result.address ?? null,
-          network: networkName,
-          error: networkError,
-        };
-      });
-    });
+          const networkName = result.network ?? null
+          const networkError =
+            networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+
+          setState((s: FreighterState) => {
+            if (
+              s.publicKey === result.address &&
+              s.network === networkName &&
+              s.error === networkError
+            ) {
+              return s
+            }
+
+            return {
+              ...s,
+              isConnected: !!result.address,
+              publicKey: result.address ?? null,
+              network: networkName,
+              error: networkError,
+            }
+          })
+        })
+      } catch {
+        // WatchWalletChanges unavailable; poll every 5s as fallback
+        if (!cancelled) intervalId = setInterval(checkInstalled, 5000)
+      }
+    }
+
+    init()
 
     return () => {
-      cancelled = true;
-      watcher.stop();
-    };
-  }, []);
+      cancelled = true
+      watcher?.stop()
+      if (intervalId) clearInterval(intervalId)
+    }
+  }, [])
 
   const connect = useCallback(async () => {
-    setState((s) => ({ ...s, error: null }));
+    setState((s) => ({ ...s, error: null }))
     try {
-      const { requestAccess, getAddress, getNetwork } = await getFreighterApi();
-      const accessResult = await requestAccess();
-      if (accessResult.error) throw new Error(String(accessResult.error));
+      const { requestAccess, getAddress, getNetwork } = await getFreighterApi()
+      const accessResult = await requestAccess()
+      if (accessResult.error) throw new Error(String(accessResult.error))
 
-      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
-      if (!mountedRef.current) return;
+      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
+      if (!mountedRef.current) return
 
-      const networkName = netResult.network ?? null;
-      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
+      const networkName = netResult.network ?? null
+      const networkError =
+        networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
 
       setState({
         isInstalled: true,
@@ -134,24 +152,21 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         publicKey: addrResult.address ?? null,
         network: networkName,
         error: networkError,
-      });
+      })
     } catch (err) {
-      if (!mountedRef.current) return;
-
-      let mappedError: Error;
-      const message = err instanceof Error ? err.message : String(err);
+      if (!mountedRef.current) return
+      
+      let mappedError: Error
+      const message = err instanceof Error ? err.message : String(err)
 
       if (message.includes('User rejected')) {
-        mappedError = new UserRejectedError();
-      } else if (
-        message.includes('switch Freighter to Mainnet') ||
-        message.includes('Network mismatch')
-      ) {
-        mappedError = new NetworkError(message);
+        mappedError = new UserRejectedError()
+      } else if (message.includes('switch Freighter to Mainnet') || message.includes('Network mismatch')) {
+        mappedError = new NetworkError(message)
       } else if (message.includes('not found') || message.includes('locked')) {
-        mappedError = new ConnectionError(message);
+        mappedError = new ConnectionError(message)
       } else {
-        mappedError = new UnknownWalletError(message);
+        mappedError = new UnknownWalletError(message)
       }
 
       setState((s) => ({
@@ -159,9 +174,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         isConnected: false,
         publicKey: null,
         error: mappedError.message,
-      }));
+      }))
     }
-  }, []);
+  }, [])
 
   const disconnect = useCallback(() => {
     setState({
@@ -170,22 +185,22 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       publicKey: null,
       network: null,
       error: null,
-    });
-  }, []);
+    })
+  }, [])
 
   const value = {
     ...state,
     connect,
     disconnect,
-  };
+  }
 
-  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
 }
 
 export function useWallet() {
-  const context = useContext(WalletContext);
+  const context = useContext(WalletContext)
   if (context === undefined) {
-    throw new Error('useWallet must be used within a WalletProvider');
+    throw new Error('useWallet must be used within a WalletProvider')
   }
-  return context;
+  return context
 }

--- a/hooks/useFreighter.ts
+++ b/hooks/useFreighter.ts
@@ -70,7 +70,6 @@ export function useFreighter() {
 
     async function init() {
       await detect()
-      if (cancelled) return
 
       try {
         const { WatchWalletChanges } = await import('@stellar/freighter-api')

--- a/hooks/useFreighter.ts
+++ b/hooks/useFreighter.ts
@@ -1,9 +1,9 @@
-'use client';
-import { useState, useEffect, useCallback, useRef } from 'react';
-import type { FreighterState } from '@/types';
+'use client'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { FreighterState } from '@/types'
 
-const STORAGE_KEY = 'freighter_connected';
-const POLL_MS = 300;
+const STORAGE_KEY = 'freighter_connected'
+const POLL_MS = 5000
 
 const INITIAL_STATE: FreighterState = {
   isInstalled: false,
@@ -11,52 +11,49 @@ const INITIAL_STATE: FreighterState = {
   publicKey: null,
   network: null,
   error: null,
-};
+}
 
 export function useFreighter() {
-  const [state, setState] = useState<FreighterState>(INITIAL_STATE);
-  const mountedRef = useRef(true);
+  const [state, setState] = useState<FreighterState>(INITIAL_STATE)
+  const mountedRef = useRef(true)
 
   useEffect(() => {
-    mountedRef.current = true;
+    mountedRef.current = true
     return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+      mountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    const watcherHandle = { current: null as { stop: () => void } | null }
 
     async function detect() {
       try {
-        const { isConnected, getAddress, getNetwork } = await import('@stellar/freighter-api');
-        const connResult = await isConnected();
+        const { isConnected, getAddress, getNetwork } = await import('@stellar/freighter-api')
+        const connResult = await isConnected()
 
-        if (cancelled || !mountedRef.current) return;
+        if (cancelled || !mountedRef.current) return
 
         if (connResult.error || !connResult.isConnected) {
           setState((s) => {
             if (s.isConnected) {
-              return {
-                ...s,
-                isInstalled: true,
-                isConnected: false,
-                publicKey: null,
-                network: null,
-              };
+              return { ...s, isInstalled: true, isConnected: false, publicKey: null, network: null }
             }
-            return s.isInstalled ? s : { ...s, isInstalled: true };
-          });
-          return;
+            return s.isInstalled ? s : { ...s, isInstalled: true }
+          })
+          return
         }
 
-        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
-        if (cancelled || !mountedRef.current) return;
+        const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
+        if (cancelled || !mountedRef.current) return
 
-        const networkName = netResult.network ?? null;
-        const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
-        const addr = addrResult as { address?: string; publicKey?: string };
-        const pk = addr.address ?? addr.publicKey ?? null;
+        const networkName = netResult.network ?? null
+        const networkError =
+          networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+        const addr = addrResult as { address?: string; publicKey?: string }
+        const pk = addr.address ?? addr.publicKey ?? null
 
         setState({
           isInstalled: true,
@@ -64,38 +61,76 @@ export function useFreighter() {
           publicKey: pk,
           network: networkName,
           error: networkError,
-        });
+        })
       } catch {
-        if (cancelled || !mountedRef.current) return;
-        setState((s) => (s.isInstalled ? { ...s, isInstalled: false } : s));
+        if (cancelled || !mountedRef.current) return
+        setState((s) => (s.isInstalled ? { ...s, isInstalled: false } : s))
       }
     }
 
-    detect();
-    const interval = setInterval(detect, POLL_MS);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
-
-  const connect = useCallback(async () => {
-    setState((s) => ({ ...s, error: null }));
-    try {
-      const { requestAccess, getAddress, getNetwork } = await import('@stellar/freighter-api');
-      const accessResult = await requestAccess();
-      if (accessResult.error) throw new Error(String(accessResult.error));
-
-      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()]);
-      if (!mountedRef.current) return;
-
-      const networkName = netResult.network ?? null;
-      const networkError = networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null;
-      const addr = addrResult as { address?: string; publicKey?: string };
+    async function init() {
+      await detect()
+      if (cancelled) return
 
       try {
-        localStorage.setItem(STORAGE_KEY, 'true');
+        const { WatchWalletChanges } = await import('@stellar/freighter-api')
+        if (cancelled) return
+
+        const watcher = new WatchWalletChanges(POLL_MS)
+        watcherHandle.current = watcher
+        watcher.watch((result: { address?: string; network?: string }) => {
+          if (cancelled || !mountedRef.current) return
+          const pk = result.address ?? null
+          const networkName = result.network ?? null
+          const networkError =
+            pk && networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+
+          setState((s) => {
+            if (s.publicKey === pk && s.network === networkName && s.error === networkError) return s
+            return {
+              ...s,
+              isInstalled: true,
+              isConnected: !!pk,
+              publicKey: pk,
+              network: networkName,
+              error: networkError,
+            }
+          })
+        })
+      } catch {
+        // WatchWalletChanges unavailable; fall back to 5s polling
+        if (!cancelled) {
+          intervalId = setInterval(detect, POLL_MS)
+        }
+      }
+    }
+
+    init()
+
+    return () => {
+      cancelled = true
+      watcherHandle.current?.stop()
+      if (intervalId) clearInterval(intervalId)
+    }
+  }, [])
+
+  const connect = useCallback(async () => {
+    setState((s) => ({ ...s, error: null }))
+    try {
+      const { requestAccess, getAddress, getNetwork } = await import('@stellar/freighter-api')
+      const accessResult = await requestAccess()
+      if (accessResult.error) throw new Error(String(accessResult.error))
+
+      const [addrResult, netResult] = await Promise.all([getAddress(), getNetwork()])
+      if (!mountedRef.current) return
+
+      const networkName = netResult.network ?? null
+      const networkError =
+        networkName !== 'PUBLIC' ? 'Please switch Freighter to Mainnet' : null
+      const addr = addrResult as { address?: string; publicKey?: string }
+
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true')
       } catch {
         // SSR / restricted environments
       }
@@ -106,17 +141,18 @@ export function useFreighter() {
         publicKey: addr.address ?? addr.publicKey ?? null,
         network: networkName,
         error: networkError,
-      });
+      })
     } catch (err) {
-      if (!mountedRef.current) return;
-      const message = err instanceof Error ? err.message : 'Freighter not detected';
-      setState((s) => ({ ...s, isConnected: false, publicKey: null, error: message }));
+      if (!mountedRef.current) return
+      const message =
+        err instanceof Error ? err.message : 'Freighter not detected'
+      setState((s) => ({ ...s, isConnected: false, publicKey: null, error: message }))
     }
-  }, []);
+  }, [])
 
   const disconnect = useCallback(() => {
     try {
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(STORAGE_KEY)
     } catch {
       // SSR / restricted environments
     }
@@ -126,8 +162,8 @@ export function useFreighter() {
       publicKey: null,
       network: null,
       error: null,
-    }));
-  }, []);
+    }))
+  }, [])
 
-  return { ...state, connect, disconnect };
+  return { ...state, connect, disconnect }
 }

--- a/tests/useFreighter.spec.tsx
+++ b/tests/useFreighter.spec.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
-import { useFreighter } from '@/hooks/useFreighter';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, renderHook, waitFor } from '@testing-library/react'
+import { useFreighter } from '@/hooks/useFreighter'
+import type { FreighterState } from '@/types'
 
 /**
  * Tests for useFreighter hook lifecycle.
@@ -14,25 +15,51 @@ import { useFreighter } from '@/hooks/useFreighter';
 
 // ─── Mock Freighter API ───────────────────────────────────────────────────────
 
-const mockFreighterApi = vi.hoisted(() => ({
-  isConnected: vi.fn(),
-  getAddress: vi.fn(),
-  getNetwork: vi.fn(),
-  requestAccess: vi.fn(),
-  signTransaction: vi.fn(),
-  WatchWalletChanges: class {
-    watch = vi.fn();
-    stop = vi.fn();
-  },
-}));
+const mockFreighterApi = vi.hoisted(() => {
+  const api = {
+    isConnected: vi.fn(),
+    getAddress: vi.fn(),
+    getNetwork: vi.fn(),
+    requestAccess: vi.fn(),
+    signTransaction: vi.fn(),
+    WatchWalletChanges: class {
+      private _cb: ((r: { address?: string; network?: string }) => void) | null = null
+      private _timer: ReturnType<typeof setInterval> | null = null
 
-vi.mock('@stellar/freighter-api', () => mockFreighterApi);
+      watch(cb: (r: { address?: string; network?: string }) => void) {
+        this._cb = cb
+        this._timer = setInterval(async () => {
+          if (!this._cb) return
+          try {
+            const conn = await api.isConnected()
+            if (conn?.isConnected) {
+              const [addr, net] = await Promise.all([api.getAddress(), api.getNetwork()])
+              this._cb({ address: addr?.publicKey ?? addr?.address, network: net?.network ?? undefined })
+            } else {
+              this._cb({})
+            }
+          } catch {
+            this._cb({})
+          }
+        }, 50)
+      }
 
-import { WalletProvider } from '@/contexts/WalletContext';
+      stop() {
+        if (this._timer) clearInterval(this._timer)
+        this._cb = null
+      }
+    }
+  }
+  return api
+})
+
+vi.mock('@stellar/freighter-api', () => mockFreighterApi)
+
+import { WalletProvider } from '@/contexts/WalletContext'
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <WalletProvider>{children}</WalletProvider>
-);
+)
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -40,297 +67,297 @@ function mockFreighterInstalled(isConnected: boolean, network?: string, publicKe
   mockFreighterApi.isConnected.mockResolvedValue({
     isConnected,
     error: null,
-  });
+  })
 
   if (isConnected) {
     mockFreighterApi.getAddress.mockResolvedValue({
       publicKey: publicKey ?? 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77',
       error: null,
-    });
+    })
 
     mockFreighterApi.getNetwork.mockResolvedValue({
       network: network ?? 'PUBLIC',
       error: null,
-    });
+    })
   } else {
     mockFreighterApi.getAddress.mockResolvedValue({
       error: 'Not connected',
-    });
+    })
     mockFreighterApi.getNetwork.mockResolvedValue({
       error: 'Not connected',
-    });
+    })
   }
 }
 
 function mockFreighterNotInstalled() {
-  mockFreighterApi.isConnected.mockRejectedValue(new Error('Freighter not found'));
+  mockFreighterApi.isConnected.mockRejectedValue(new Error('Freighter not found'))
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
-});
+  vi.clearAllMocks()
+})
 
 afterEach(() => {
-  vi.clearAllMocks();
-});
+  vi.clearAllMocks()
+})
 
 // ─── Lifecycle 1: Detect ──────────────────────────────────────────────────────
 
 describe('useFreighter — detect', () => {
   it('detects when Freighter extension is installed', async () => {
-    mockFreighterInstalled(false);
+    mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true);
-    });
-  });
+      expect(result.current.isInstalled).toBe(true)
+    })
+  })
 
   it('sets isInstalled to false when Freighter is not available', async () => {
-    mockFreighterNotInstalled();
+    mockFreighterNotInstalled()
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     // Even if API is unavailable, initial state should reflect that
-    expect(result.current.isInstalled).toBe(false);
-  });
+    expect(result.current.isInstalled).toBe(false)
+  })
 
   it('sets isConnected to false initially when detected but not connected', async () => {
-    mockFreighterInstalled(false);
+    mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true);
-      expect(result.current.isConnected).toBe(false);
-    });
-  });
+      expect(result.current.isInstalled).toBe(true)
+      expect(result.current.isConnected).toBe(false)
+    })
+  })
 
   it('sets publicKey to null when extension is detected but not connected', async () => {
-    mockFreighterInstalled(false);
+    mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBeNull();
-    });
-  });
-});
+      expect(result.current.publicKey).toBeNull()
+    })
+  })
+})
 
 // ─── Lifecycle 2: Connect ─────────────────────────────────────────────────────
 
 describe('useFreighter — connect', () => {
   it('retrieves publicKey when connected to mainnet', async () => {
-    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77';
-    mockFreighterInstalled(true, 'PUBLIC', testKey);
+    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
+    mockFreighterInstalled(true, 'PUBLIC', testKey)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true);
-      expect(result.current.publicKey).toBe(testKey);
-    });
-  });
+      expect(result.current.isConnected).toBe(true)
+      expect(result.current.publicKey).toBe(testKey)
+    })
+  })
 
   it('sets network to PUBLIC when connected on mainnet', async () => {
-    mockFreighterInstalled(true, 'PUBLIC');
+    mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC');
-    });
-  });
+      expect(result.current.network).toBe('PUBLIC')
+    })
+  })
 
   it('reflects connected state when extension API reports connected', async () => {
-    mockFreighterInstalled(true, 'PUBLIC');
+    mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isInstalled).toBe(true);
-      expect(result.current.isConnected).toBe(true);
-    });
-  });
+      expect(result.current.isInstalled).toBe(true)
+      expect(result.current.isConnected).toBe(true)
+    })
+  })
 
   it('clears error state on successful connection', async () => {
-    mockFreighterInstalled(true, 'PUBLIC');
+    mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.error).toBeNull();
-    });
-  });
-});
+      expect(result.current.error).toBeNull()
+    })
+  })
+})
 
 // ─── Lifecycle 3: Disconnect ──────────────────────────────────────────────────
 
 describe('useFreighter — disconnect', () => {
   it('clears publicKey when disconnected', async () => {
     // Start connected
-    mockFreighterInstalled(true, 'PUBLIC');
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
+    mockFreighterInstalled(true, 'PUBLIC')
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true);
-      expect(result.current.publicKey).not.toBeNull();
-    });
+      expect(result.current.isConnected).toBe(true)
+      expect(result.current.publicKey).not.toBeNull()
+    })
 
     // Simulate disconnect
-    mockFreighterInstalled(false);
-    rerender();
+    mockFreighterInstalled(false)
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(false);
-      expect(result.current.publicKey).toBeNull();
-    });
-  });
+      expect(result.current.isConnected).toBe(false)
+      expect(result.current.publicKey).toBeNull()
+    })
+  })
 
   it('sets isConnected to false when user disconnects', async () => {
-    mockFreighterInstalled(false);
+    mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(false);
-    });
-  });
+      expect(result.current.isConnected).toBe(false)
+    })
+  })
 
   it('clears network when disconnected', async () => {
     // Start connected
-    mockFreighterInstalled(true, 'PUBLIC');
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
+    mockFreighterInstalled(true, 'PUBLIC')
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC');
-    });
+      expect(result.current.network).toBe('PUBLIC')
+    })
 
     // Simulate disconnect
-    mockFreighterInstalled(false);
-    rerender();
+    mockFreighterInstalled(false)
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.network).toBeNull();
-    });
-  });
-});
+      expect(result.current.network).toBeNull()
+    })
+  })
+})
 
 // ─── Lifecycle 4: Network change ──────────────────────────────────────────────
 
 describe('useFreighter — network-change', () => {
   it('updates network when switched away from mainnet', async () => {
     // Start on PUBLIC (mainnet)
-    mockFreighterInstalled(true, 'PUBLIC');
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
+    mockFreighterInstalled(true, 'PUBLIC')
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC');
-    });
+      expect(result.current.network).toBe('PUBLIC')
+    })
 
     // Switch to TESTNET
-    mockFreighterInstalled(true, 'TESTNET');
-    rerender();
+    mockFreighterInstalled(true, 'TESTNET')
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.network).toBe('TESTNET');
-    });
-  });
+      expect(result.current.network).toBe('TESTNET')
+    })
+  })
 
   it('detects network mismatch (non-mainnet)', async () => {
-    mockFreighterInstalled(true, 'TESTNET');
+    mockFreighterInstalled(true, 'TESTNET')
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true);
-      expect(result.current.network).toBe('TESTNET');
-    });
-  });
+      expect(result.current.isConnected).toBe(true)
+      expect(result.current.network).toBe('TESTNET')
+    })
+  })
 
   it('maintains publicKey across network changes', async () => {
-    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77';
+    const testKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJEANS3D57CCOD5JIHVYXKOM77'
 
     // Start on PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC', testKey);
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
+    mockFreighterInstalled(true, 'PUBLIC', testKey)
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBe(testKey);
-    });
+      expect(result.current.publicKey).toBe(testKey)
+    })
 
     // Switch to TESTNET with same key
-    mockFreighterInstalled(true, 'TESTNET', testKey);
-    rerender();
+    mockFreighterInstalled(true, 'TESTNET', testKey)
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.publicKey).toBe(testKey);
-    });
-  });
+      expect(result.current.publicKey).toBe(testKey)
+    })
+  })
 
   it('restores mainnet-connected state when network switched back', async () => {
     // Start on PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC');
-    const { result, rerender } = renderHook(() => useFreighter(), { wrapper });
+    mockFreighterInstalled(true, 'PUBLIC')
+    const { result, rerender } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC');
-    });
+      expect(result.current.network).toBe('PUBLIC')
+    })
 
     // Switch to TESTNET
-    mockFreighterInstalled(true, 'TESTNET');
-    rerender();
+    mockFreighterInstalled(true, 'TESTNET')
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.network).toBe('TESTNET');
-    });
+      expect(result.current.network).toBe('TESTNET')
+    })
 
     // Switch back to PUBLIC
-    mockFreighterInstalled(true, 'PUBLIC');
-    rerender();
+    mockFreighterInstalled(true, 'PUBLIC')
+    rerender()
 
     await waitFor(() => {
-      expect(result.current.network).toBe('PUBLIC');
-    });
-  });
-});
+      expect(result.current.network).toBe('PUBLIC')
+    })
+  })
+})
 
 // ─── Error handling ───────────────────────────────────────────────────────────
 
 describe('useFreighter — error handling', () => {
   it('handles extension detection errors gracefully', async () => {
-    mockFreighterNotInstalled();
+    mockFreighterNotInstalled()
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     await waitFor(() => {
       // Should not throw, should set isInstalled to false
-      expect(result.current.isInstalled).toBe(false);
-    });
-  });
+      expect(result.current.isInstalled).toBe(false)
+    })
+  })
 
   it('does not update state after unmount', async () => {
-    mockFreighterInstalled(true, 'PUBLIC');
+    mockFreighterInstalled(true, 'PUBLIC')
 
-    const { result, unmount } = renderHook(() => useFreighter(), { wrapper });
+    const { result, unmount } = renderHook(() => useFreighter(), { wrapper })
 
-    unmount();
+    unmount()
 
     // Should not throw errors about state updates on unmounted component
-    expect(result.current).toBeDefined();
-  });
+    expect(result.current).toBeDefined()
+  })
 
   it('maintains initial state until API resolves', () => {
-    mockFreighterInstalled(false);
+    mockFreighterInstalled(false)
 
-    const { result } = renderHook(() => useFreighter(), { wrapper });
+    const { result } = renderHook(() => useFreighter(), { wrapper })
 
     // Initial state before resolution
-    expect(result.current.isInstalled).toBe(false);
-    expect(result.current.isConnected).toBe(false);
-    expect(result.current.publicKey).toBeNull();
-    expect(result.current.network).toBeNull();
-    expect(result.current.error).toBeNull();
-  });
-});
+    expect(result.current.isInstalled).toBe(false)
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.publicKey).toBeNull()
+    expect(result.current.network).toBeNull()
+    expect(result.current.error).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- `useFreighter`: replaced 300ms polling with `WatchWalletChanges` subscription (5s interval); falls back to 5s `setInterval` polling if the API is unavailable
- `WalletContext`: same subscription pattern via lazy dynamic import (avoids SSR failures from a static top-level import); single cleanup covers both paths
- `WalletButton`: consumes `useWallet` from context so the wrong-network badge re-renders reactively on network switch
- `RateTable`: accepts `executeDisabled` prop; Execute button is disabled whenever the app network is not `PUBLIC`

## Test plan
- [ ] Switch Freighter to Testnet — WalletButton shows "Wrong network / Mainnet required" within 5s
- [ ] Execute buttons in the rate table become disabled on wrong network
- [ ] Switch back to Mainnet — WalletButton returns to connected state and Execute re-enables
- [ ] With Freighter not installed, confirm no SSR crash and the "Install Freighter" link renders

Closes #42