### PR TITLE
ci(ops): remove cargo/contracts dependabot ecosystem until crate exists

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,15 +60,6 @@ updates:
     commit-message:
       prefix: 'ci(deps)'
 
-  # Placeholder for the Soroban contract crate set. Harmless if the directory
-  # does not yet exist; Dependabot skips missing manifests.
-  - package-ecosystem: 'cargo'
-    directory: '/contracts'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 3
-    labels:
-      - 'dependencies'
-      - 'module/oracle'
-    commit-message:
-      prefix: 'chore(deps-cargo)'
+  # NOTE: A 'cargo' ecosystem for '/contracts' (Soroban crates) was removed.
+  # Dependabot errors ("Cargo.toml not found"), not silently skips, when the
+  # manifest is absent. Re-add this block once /contracts/Cargo.toml exists.


### PR DESCRIPTION
## Problem
The scheduled **Dependabot Updates** job for the `cargo` ecosystem fails on every run:

```
ERROR Error during file fetching; aborting: /contracts/Cargo.toml not found
```

`.github/dependabot.yml` declares a `cargo` ecosystem rooted at `/contracts`, but the Soroban contract crate set doesn't exist yet. The prior inline comment assumed Dependabot *skips* a missing manifest — in practice the `cargo` updater **errors and fails the job**.

## Fix
Remove the `cargo` / `/contracts` ecosystem block. A note is left in its place explaining how to re-add it once `/contracts/Cargo.toml` lands (roadmap #111+ Soroban skeleton).

The `npm` and `github-actions` ecosystems are unchanged.

## Verification
- `dependabot.yml` parses as valid YAML; remaining ecosystems: `npm`, `github-actions`.
- No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)