### PR TITLE
feat: implement exponential backoff withRetry utility for NetworkError

### DIFF
--- a/lib/stellar/errors.ts
+++ b/lib/stellar/errors.ts
@@ -19,6 +19,17 @@ export class UserRejectedError extends WalletError {
 }
 
 /**
+ * Thrown when there is a user-side or client error.
+ */
+export class UserError extends WalletError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UserError'
+  }
+}
+
+
+/**
  * Thrown when there is a network mismatch (e.g. Testnet vs Mainnet)
  * or the horizon server is unreachable.
  */

--- a/lib/stellar/retry.ts
+++ b/lib/stellar/retry.ts
@@ -1,0 +1,122 @@
+import { NetworkError } from './errors'
+
+interface RetryOptions {
+  attempts?: number
+  base?: number
+  cap?: number
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Helper to extract Retry-After duration in milliseconds.
+ * Supports:
+ * - Direct numeric / string retryAfter properties
+ * - headers/response.headers check (e.g. headers.get('Retry-After') or headers['retry-after'])
+ * - Handles both number-of-seconds and HTTP date string formats.
+ */
+function getRetryAfterMs(error: any): number | null {
+  if (!error || typeof error !== 'object') return null
+
+  // 1. Direct retryAfter / retry_after property
+  if (typeof error.retryAfter === 'number') {
+    return error.retryAfter
+  }
+  if (typeof error.retryAfter === 'string') {
+    const ms = parseRetryAfterValue(error.retryAfter)
+    if (ms !== null) return ms
+  }
+  if (typeof error.retry_after === 'number') {
+    return error.retry_after
+  }
+  if (typeof error.retry_after === 'string') {
+    const ms = parseRetryAfterValue(error.retry_after)
+    if (ms !== null) return ms
+  }
+
+  // 2. Error headers
+  if (error.headers) {
+    const ms = getRetryAfterFromHeaders(error.headers)
+    if (ms !== null) return ms
+  }
+
+  // 3. Error response headers
+  if (error.response && typeof error.response === 'object') {
+    if (error.response.headers) {
+      const ms = getRetryAfterFromHeaders(error.response.headers)
+      if (ms !== null) return ms
+    }
+  }
+
+  return null
+}
+
+function getRetryAfterFromHeaders(headers: any): number | null {
+  if (!headers) return null
+  let value: string | null = null
+
+  if (typeof headers.get === 'function') {
+    value = headers.get('Retry-After') || headers.get('retry-after')
+  } else if (typeof headers === 'object') {
+    value = headers['Retry-After'] || headers['retry-after'] || null
+  }
+
+  if (value) {
+    return parseRetryAfterValue(value)
+  }
+  return null
+}
+
+function parseRetryAfterValue(value: string): number | null {
+  // Positive integer (seconds)
+  if (/^\d+$/.test(value)) {
+    return parseInt(value, 10) * 1000
+  }
+  // Date string
+  const dateMs = Date.parse(value)
+  if (!isNaN(dateMs)) {
+    const delay = dateMs - Date.now()
+    return delay > 0 ? delay : 0
+  }
+  return null
+}
+
+/**
+ * Runs the promise-returning function `fn` with exponential backoff retries.
+ * Only errors that are instances of NetworkError will trigger a retry.
+ * Other errors (including UserError) are rethrown immediately.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const attempts = options.attempts ?? 3
+  const base = options.base ?? 250
+  const cap = options.cap ?? 5000
+
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+
+      // Check if it is a NetworkError and we have retry attempts left
+      if (error instanceof NetworkError && attempt < attempts) {
+        let delay = Math.min(cap, base * Math.pow(2, attempt - 1))
+
+        const retryAfterMs = getRetryAfterMs(error)
+        if (retryAfterMs !== null) {
+          delay = retryAfterMs
+        }
+
+        await sleep(delay)
+      } else {
+        throw error
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/tests/retry.spec.ts
+++ b/tests/retry.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { withRetry } from '@/lib/stellar/retry'
+import { NetworkError, UserError } from '@/lib/stellar/errors'
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves immediately when the operation succeeds', async () => {
+    const fn = vi.fn().mockResolvedValue('success')
+    const result = await withRetry(fn)
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on NetworkError and succeeds when subsequent attempt is successful', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new NetworkError('Fail 1'))
+      .mockRejectedValueOnce(new NetworkError('Fail 2'))
+      .mockResolvedValueOnce('success')
+
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    // Fast-forward timers for first retry (delay = 100ms)
+    await vi.advanceTimersByTimeAsync(100)
+    // Fast-forward timers for second retry (delay = 200ms)
+    await vi.advanceTimersByTimeAsync(200)
+
+    const result = await promise
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails after exhausting attempts for a permanent NetworkError', async () => {
+    const fn = vi.fn().mockRejectedValue(new NetworkError('Fail'))
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await vi.advanceTimersByTimeAsync(200)
+
+    await expect(promise).rejects.toThrow(NetworkError)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry and rejects immediately on UserError', async () => {
+    const fn = vi.fn().mockRejectedValue(new UserError('User bad input'))
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    await expect(promise).rejects.toThrow(UserError)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry and rejects immediately on generic Error', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('Generic failure'))
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    await expect(promise).rejects.toThrow(Error)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors exponential backoff capped by the cap value', async () => {
+    const fn = vi.fn().mockRejectedValue(new NetworkError('Fail'))
+    const promise = withRetry(fn, { attempts: 5, base: 100, cap: 300 })
+
+    // Attempt 1: fails
+    // Delay 1: min(300, 100 * 2^0) = 100ms
+    await vi.advanceTimersByTimeAsync(100)
+
+    // Attempt 2: fails
+    // Delay 2: min(300, 100 * 2^1) = 200ms
+    await vi.advanceTimersByTimeAsync(200)
+
+    // Attempt 3: fails
+    // Delay 3: min(300, 100 * 2^2) = 300ms (capped)
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Attempt 4: fails
+    // Delay 4: min(300, 100 * 2^3) = 300ms (capped)
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect(promise).rejects.toThrow(NetworkError)
+    expect(fn).toHaveBeenCalledTimes(5)
+  })
+
+  it('honors Retry-After header with a numeric string (seconds)', async () => {
+    const err = new NetworkError('Rate limited')
+    ;(err as any).headers = { 'Retry-After': '5' } // 5 seconds = 5000ms
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce('success')
+
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    // Wait less than 5000ms, should not have completed yet
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Advance remaining time
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors Retry-After header format (lowercase / get method) on response', async () => {
+    const err = new NetworkError('Rate limited')
+    const headersMap = new Map<string, string>()
+    headersMap.set('retry-after', '2')
+    ;(err as any).response = {
+      headers: {
+        get: (name: string) => headersMap.get(name.toLowerCase()) || null,
+      },
+    }
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce('success')
+
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await promise
+
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors Retry-After header with an HTTP date string', async () => {
+    const err = new NetworkError('Rate limited')
+    const futureDate = new Date(Date.now() + 8000)
+    ;(err as any).retryAfter = futureDate.toUTCString()
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce('success')
+
+    const promise = withRetry(fn, { attempts: 3, base: 100 })
+
+    // Wait less than 8000ms
+    await vi.advanceTimersByTimeAsync(7000)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Advance remaining time
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
This Pr closes #181
- Creates withRetry helper supporting attempts, base backoff delay, cap, and Retry-After header parsing.

- Adds UserError class to errors.ts for user-side failures.

- Only retries on NetworkError instances; UserError and generic errors throw immediately.

- Implements comprehensive unit tests covering all retry, backoff, and header-parsing cases.

<!--
Thanks for opening a PR!

Before you submit:
  • Conventional Commits title — the PR title is linted (feat / fix / docs /
    refactor / test / chore / ci / perf / build / style / revert, with an
    optional scope and a short description). See .github/workflows/pr-title.yml.
  • One logical change per PR. If you have an unrelated cleanup, split it.
  • Fill in every section below. Delete none of them — leave "N/A" if a
    section genuinely doesn't apply and say *why*.
-->

## Summary

<!--
One or two sentences on **what changed and why**. Lead with the why.
Well-named identifiers already explain the what — don't restate the diff.
-->

## Linked issue

<!--
Every PR must link an issue. Use a closing keyword (Closes / Fixes /
Resolves) so the issue auto-closes on merge. If the work spans multiple
issues, close the primary and reference the others.

If there is genuinely no issue (e.g. typo fix, chore), say so here and
name the reason.
-->

Closes #

## Changes

<!--
A tight bullet list of the material changes. Not a diff summary — a
reader-oriented explanation. Reference files with backticks, reference
symbols with file_path:line_number when it helps.

Example:
  - `lib/stellar/sep10.ts:54` — assert mainnet network passphrase at parse time
  - `components/offramp/ExecuteDrawer.tsx` — propagate `{ transactionId, jwt }`
    to the page on success so `StatusTracker` mounts (fixes #002)
-->

-
-
-

## Testing notes

<!--
What you ran locally, what you added, and what a reviewer should run to
reproduce. At minimum:

  - The name of the new test(s), with file path.
  - The command(s) you ran (`npm run test -- stellar/sep10`, etc).
  - Any manual verification steps — especially if this touches a real
    anchor, a real Stellar transaction, or Freighter.

If you did not add a test, justify it. "Trivial refactor" or "doc-only" are
valid. "Hard to test" is not.
-->

**Automated**
- `npm run typecheck` · ⏳ not run / ✅ green / ❌ failing
- `npm run lint` · ⏳ not run / ✅ green / ❌ failing
- `npm run test` · ⏳ not run / ✅ green / ❌ failing
- `npm run build` · ⏳ not run / ✅ green / ❌ failing

**New / modified tests**
-

**Manual verification** (if applicable)
<!-- e.g. "Connected Freighter on mainnet, executed USDC→NGN for $5 via
MoneyGram testnet deployment, observed StatusTracker reach `completed` in
3m12s. Stellar Expert link: …" -->
-

## Screenshots / recordings

<!--
REQUIRED for any user-visible change. Drop in:
  - Before + After screenshots for UI diffs.
  - A short Loom or a <30s GIF for flow changes (drawer, tracker, drawer-
    to-tracker hoist, split routing visualisation).
  - Relevant terminal output for CLI / API changes.

For pure backend / doc / CI PRs, write "N/A — no user-visible change".
-->

| Before | After |
| --- | --- |
|  |  |

## Checklist

<!--
Every box must be ticked or explicitly "N/A — why". A reviewer will not
merge a PR with an unaddressed box.
-->

**Correctness**
- [ ] The PR title follows Conventional Commits (auto-linted)
- [ ] One logical change; unrelated cleanup was split into a separate PR
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes with **zero new warnings** (we run `--max-warnings 0` in CI)
- [ ] `npm run test` passes; new behaviour has a test
- [ ] `npm run build` passes

**Data integrity**
- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
- [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
- [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
- [ ] If touching SEP-10: network passphrase assertion is intact (mainnet only)
- [ ] If touching SEP-24: the 10s `AbortController` timeout is intact on anchor fetches
- [ ] If touching the status poll: terminal states (`completed | refunded | error`) still stop the SWR loop

**Security & non-custody** (see [`docs/NON_CUSTODY.md`](../docs/NON_CUSTODY.md) once it lands)
- [ ] No new code path holds user keys, user funds, or long-lived anchor JWTs
- [ ] Every signing action is performed by the user's wallet (Freighter today)
- [ ] No secrets committed; `.env.local` is unchanged; new env vars are added to `.env.example`

**Docs**
- [ ] User-facing behaviour change → `CHANGELOG.md` entry under `[Unreleased]`
- [ ] API / schema change → relevant `docs/*.md` updated in the same PR
- [ ] Architecture change → [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) updated (file map, diagram, or invariants as applicable)
- [ ] Public-facing feature → screenshot added to `docs/showcase/images/` when relevant
- [ ] New env var → `.env.example` + README env table updated

**Release hygiene**
- [ ] If this touches a wave deliverable, the matching `[ ]` in [`docs/ROADMAP.md`](../docs/ROADMAP.md) is updated
- [ ] No dependency added without justification in the PR description
- [ ] No breaking change hidden inside a non-breaking commit

## Breaking changes

<!--
If this PR breaks a public API, the MCP surface, an env var contract,
or a shipped UI URL, say so here with:
  - What breaks.
  - Who is affected.
  - The migration path (code snippet or doc link).

Also prefix the PR title with "!" (e.g. `feat!: remove legacy rate endpoint`)
to make the break visible to release tooling.

If none: write "None."
-->

None.

## For reviewers

<!--
Optional. Use this to call out:
  - Areas where you want a careful read ("look at the quote-expiry math").
  - Tradeoffs you considered and rejected ("chose SWR over a manual poll
    because …").
  - Things you explicitly did NOT do in this PR and are leaving for a
    follow-up (link the follow-up issue).
-->

<!--
One last thing: this PR template is part of the product. If any section
above feels wrong or missing, open a PR against `.github/PULL_REQUEST_TEMPLATE.md`
itself — meta-PRs are welcome.
-->

