### PR TITLE
fix(nightly): read homeDomain from constants/anchors.ts, closes #145

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,13 +27,12 @@ jobs:
       - name: Resolve every anchor .well-known/stellar.toml
         id: probe
         run: |
-          # Extract anchor domains from constants/index.ts so we do not drift
-          # from the app's source of truth.
+          # Extract anchor home domains from constants/anchors.ts — the single
+          # source of truth for anchor definitions (uses homeDomain: field).
           mapfile -t DOMAINS < <(node -e "
-            const path = require('path');
             const fs = require('fs');
-            const src = fs.readFileSync('constants/index.ts', 'utf8');
-            const re = /domain:\s*['\"]([^'\"]+)['\"]/g;
+            const src = fs.readFileSync('constants/anchors.ts', 'utf8');
+            const re = /homeDomain:\s*['\"]([^'\"]+)['\"]/g;
             const seen = new Set();
             let m;
             while ((m = re.exec(src))) seen.add(m[1]);


### PR DESCRIPTION
Follow-up to the same bug that caused #137 — the nightly job on 2026-05-02 failed for the same reason: 
index.ts
 has no domain: field, so the probe loop never ran. This branch applies the identical fix (read homeDomain: from 
anchors.ts
) targeted at closing the second tracking issue.

Linked issue

Closes #145

Changes

nightly.yml
 — same correction as #137: source file changed to 
anchors.ts
, regex updated to homeDomain:
Testing notes

Same as #137. No new tests needed — pure CI config fix.

npm run typecheck · N/A
npm run lint · N/A
npm run test · N/A
npm run build · N/A
Screenshots / recordings

N/A — no user-visible change.

Breaking changes

None.