### PR TITLE
feat: bootstrap @stellarintel/mcp package with stdio transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+packages/*/node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "stellar-intel",
   "version": "0.1.0",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stellarintel/mcp",
+  "version": "0.1.0",
+  "description": "Stellar Intel MCP server — stdio transport",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "@stellarintel/mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "ts-node": "^10.9.2",
+    "@types/node": "^20"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,22 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+export function createServer(): Server {
+  const server = new Server(
+    {
+      name: "@stellarintel/mcp",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: [] };
+  });
+
+  return server;
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds `packages/mcp` as a new npm workspace package (`@stellarintel/mcp`)
- Uses `@modelcontextprotocol/sdk` with stdio transport only (v1 scope)
- Wires up `packages/*` workspaces in root `package.json`
- Entry point `src/index.ts` starts the MCP server and connects via `StdioServerTransport`
- Server responds to the MCP `initialize` handshake automatically via the SDK

## Test plan

- [ ] `cd packages/mcp && npm install && npm run build`
- [ ] `node dist/index.js` — server starts and listens on stdin/stdout
- [ ] Send an MCP `initialize` request over stdin; server responds with `serverInfo` and `capabilities`

Closes #225