### PR TITLE
feat: PII redaction at write for reputation outcome log

### DIFF
--- a/lib/reputation/redact.ts
+++ b/lib/reputation/redact.ts
@@ -1,0 +1,87 @@
+import { createHash } from 'crypto'
+
+// ─── Intent shape (with PII) ──────────────────────────────────────────────────
+
+/**
+ * A raw payment intent that may contain PII fields such as recipient details.
+ * These fields must never reach the outcome log.
+ */
+export interface RawIntent {
+  /** Stellar public key of the recipient — PII */
+  recipientAccount?: string
+  /** Full name of the recipient — PII */
+  recipientName?: string
+  /** Email address of the recipient — PII */
+  recipientEmail?: string
+  /** Phone number of the recipient — PII */
+  recipientPhone?: string
+  /** Bank account number — PII */
+  bankAccount?: string
+  /** Generic account field (e.g. from SEP-24 request) — PII */
+  account?: string
+  // ── Non-PII fields ──
+  amount: string
+  assetCode: string
+  assetIssuer?: string
+  corridorId: string
+  anchorId: string
+  [key: string]: unknown
+}
+
+// ─── Redacted row (safe to write) ────────────────────────────────────────────
+
+/**
+ * The shape written to the outcome log.
+ * Contains only the intent hash and non-PII routing metadata.
+ */
+export interface RedactedIntent {
+  intentHash: string
+  assetCode: string
+  corridorId: string
+  anchorId: string
+}
+
+// ─── PII field registry ───────────────────────────────────────────────────────
+
+/**
+ * Exhaustive list of field names considered PII.
+ * Used by the unit test to assert zero PII fields survive redaction.
+ */
+export const PII_FIELDS = [
+  'recipientAccount',
+  'recipientName',
+  'recipientEmail',
+  'recipientPhone',
+  'bankAccount',
+  'account',
+  'email',
+  'phone',
+  'name',
+  'address',
+] as const
+
+export type PiiField = (typeof PII_FIELDS)[number]
+
+// ─── Core functions ───────────────────────────────────────────────────────────
+
+/**
+ * Produces a stable SHA-256 hex digest of the full intent (including PII).
+ * The hash is the only representation of the recipient that enters the log.
+ */
+export function hashIntent(intent: RawIntent): string {
+  const stable = JSON.stringify(intent, Object.keys(intent).sort())
+  return createHash('sha256').update(stable).digest('hex')
+}
+
+/**
+ * Strips all PII from a raw intent and returns a row safe to write to the
+ * outcome log. Only the intent hash and non-PII routing fields are kept.
+ */
+export function redactIntent(intent: RawIntent): RedactedIntent {
+  return {
+    intentHash: hashIntent(intent),
+    assetCode: intent.assetCode,
+    corridorId: intent.corridorId,
+    anchorId: intent.anchorId,
+  }
+}

--- a/tests/reputation-redact.spec.ts
+++ b/tests/reputation-redact.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { redactIntent, hashIntent, PII_FIELDS, type RawIntent } from '@/lib/reputation/redact'
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+const nonEmptyString = fc.string({ minLength: 1, maxLength: 64 })
+
+const rawIntentArb = fc.record<RawIntent>({
+  recipientAccount: nonEmptyString,
+  recipientName: nonEmptyString,
+  recipientEmail: nonEmptyString,
+  recipientPhone: nonEmptyString,
+  bankAccount: nonEmptyString,
+  account: nonEmptyString,
+  amount: fc.double({ min: 1, max: 1_000_000, noNaN: true, noDefaultInfinity: true }).map(String),
+  assetCode: fc.constantFrom('USDC', 'EURC', 'XLM'),
+  assetIssuer: nonEmptyString,
+  corridorId: fc.constantFrom('usdc-ngn', 'usdc-kes', 'usdc-ghs', 'usdc-zar'),
+  anchorId: nonEmptyString,
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('redactIntent', () => {
+  it('produces zero PII fields in the written row', () => {
+    fc.assert(
+      fc.property(rawIntentArb, (intent) => {
+        const redacted = redactIntent(intent)
+
+        for (const field of PII_FIELDS) {
+          expect(redacted).not.toHaveProperty(field)
+        }
+      }),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('produces zero PII bytes in the serialised written row', () => {
+    fc.assert(
+      fc.property(rawIntentArb, (intent) => {
+        const redacted = redactIntent(intent)
+
+        // The redacted row must contain exactly these four keys and no others.
+        // Any extra key would be a PII leak.
+        const allowedKeys = new Set(['intentHash', 'assetCode', 'corridorId', 'anchorId'])
+        const actualKeys = Object.keys(redacted)
+
+        for (const key of actualKeys) {
+          expect(allowedKeys).toContain(key)
+        }
+
+        expect(actualKeys).toHaveLength(allowedKeys.size)
+      }),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('always stores the intent hash', () => {
+    fc.assert(
+      fc.property(rawIntentArb, (intent) => {
+        const redacted = redactIntent(intent)
+        expect(typeof redacted.intentHash).toBe('string')
+        expect(redacted.intentHash).toHaveLength(64) // SHA-256 hex = 64 chars
+      }),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('always preserves non-PII routing fields', () => {
+    fc.assert(
+      fc.property(rawIntentArb, (intent) => {
+        const redacted = redactIntent(intent)
+        expect(redacted.assetCode).toBe(intent.assetCode)
+        expect(redacted.corridorId).toBe(intent.corridorId)
+        expect(redacted.anchorId).toBe(intent.anchorId)
+      }),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('is deterministic — same intent always yields the same hash', () => {
+    fc.assert(
+      fc.property(rawIntentArb, (intent) => {
+        expect(redactIntent(intent).intentHash).toBe(redactIntent(intent).intentHash)
+      }),
+      { numRuns: 500 },
+    )
+  })
+
+  it('produces different hashes for different intents', () => {
+    fc.assert(
+      fc.property(rawIntentArb, rawIntentArb, (a, b) => {
+        // Stringify both to compare structural equality
+        if (JSON.stringify(a) !== JSON.stringify(b)) {
+          expect(hashIntent(a)).not.toBe(hashIntent(b))
+        }
+      }),
+      { numRuns: 500 },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `lib/reputation/redact.ts` with `redactIntent()` and `hashIntent()`
- Strips all recipient/PII fields before writing; stores only the SHA-256 intent hash
- Non-PII routing metadata (`assetCode`, `corridorId`, `anchorId`) is preserved
- Adds `tests/reputation-redact.spec.ts` with 6 property-based tests using fast-check

## Test plan

- [ ] `npm test` — all 6 tests pass (1000 runs each)
- [ ] Zero PII fields in written row (keys checked exhaustively)
- [ ] Zero PII bytes in serialised row (only allowed keys present)
- [ ] Intent hash is always a 64-char SHA-256 hex string
- [ ] Deterministic hashing for same intent
- [ ] Different intents produce different hashes

Closes #222