### PR TITLE
docs: mark forward specs as planned and resolve dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Built for users sending money home across Africa, Latin America, and Southeast
 Asia via Stellar anchors.
 
 <p align="center">
-  <a href="https://stellar-intel.vercel.app">
-    <img src="docs/images/hero.png" alt="Stellar Intel off-ramp comparison — live anchor quotes, fee breakdown, and one-click execution" width="860" />
-  </a>
-  <br />
   <em>Live demo → <a href="https://stellar-intel.vercel.app">stellar-intel.vercel.app</a></em>
 </p>
 
@@ -63,6 +59,14 @@ the anchor that can satisfy it. Three primitives, one product:
 3. **Agent surface.** An MCP server exposes the router and oracle to AI
    agents, so an agent can price, compare, and execute an off-ramp in five
    lines — the same primitives used by the web UI.
+
+> **What ships today.** Only the single-anchor off-ramp path is live on
+> `main` — live rate comparison plus SEP-10/24 execute and status tracking.
+> The SEP-38 firm-quote intent router (primitive 1), the reputation oracle
+> (2), and the agent surface (3) are designed and specced but **not yet
+> built**. See [docs/ROADMAP.md](docs/ROADMAP.md) for the exact shipped-vs-
+> planned breakdown, and the per-module ✅/🛠️ markers in
+> [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 Non-custodial by construction: every leg is signed by the user, the anchor
 takes custody under SEP-24, Stellar enforces atomicity. We never touch funds.

--- a/docs/CANONICAL_JSON.md
+++ b/docs/CANONICAL_JSON.md
@@ -1,0 +1,65 @@
+# Canonical JSON — Intent Hashing
+
+> The deterministic encoding every party commits to. The user signs a hash
+> over the canonical form of their intent; the anchor honours a quote against
+> it; the publisher writes outcomes keyed by it. If two implementations
+> disagree on the bytes, every signature downstream is worthless — so the
+> encoding is specified, not assumed.
+
+> **Status: 🛠️ Planned (wave 1.2) — not yet implemented.** `lib/intent/canonical.ts`
+> and `lib/intent/hash.ts` do not exist on `main` today. This document is the
+> spec the v1.2 router wave implements; the rules below are normative for that
+> implementation, not a description of shipped code. See
+> [ROADMAP.md](ROADMAP.md) and [ARCHITECTURE.md § 3](ARCHITECTURE.md#3-the-intent-lifecycle).
+
+---
+
+## Why canonicalize
+
+JSON is not byte-stable: key order, whitespace, number formatting, and string
+escaping all vary between serializers. A signature is over bytes, so two
+"equal" JSON objects that serialize differently produce different hashes and
+different signatures. Canonicalization removes that ambiguity: one object, one
+byte string, one hash, forever.
+
+## Rules
+
+The canonical form of an intent is produced by these rules, applied in order:
+
+1. **UTF-8, no BOM.** The output is a UTF-8 byte string with no byte-order mark.
+2. **Object keys sorted.** Every object's keys are sorted lexicographically by
+   Unicode code point, recursively, at every level.
+3. **No insignificant whitespace.** No spaces, tabs, or newlines between
+   tokens. `{"a":1,"b":2}`, never `{ "a": 1, "b": 2 }`.
+4. **Strings minimally escaped.** Only the escapes JSON requires (`"`, `\`,
+   and control characters `U+0000`–`U+001F`) are emitted, each in its shortest
+   form. No `\uXXXX` for characters that can be represented literally.
+5. **Integers normalized.** Decimal amounts are carried as **strings**
+   (`sellAmount`, `minReceive`, …) and are not reinterpreted as numbers; any
+   genuine JSON numbers are emitted without leading zeros, without a trailing
+   `.0`, and without an exponent.
+6. **No `null`-valued keys.** Optional fields that are absent are omitted
+   entirely rather than serialized as `null`.
+
+## Hash
+
+```
+intentHash = SHA-256( canonicalJSON(intent) )
+```
+
+The hash is lower-case hex of the 32-byte digest. The signature is Ed25519
+over the **raw 32 digest bytes** (not the hex string), produced by the user's
+Stellar key via Freighter.
+
+## Test vectors
+
+> 🛠️ Canonical test vectors (input intent → expected canonical bytes →
+> expected hash) ship with `lib/intent/canonical.ts` in wave 1.2 and become
+> the cross-implementation conformance suite for the SDK and any third-party
+> signer.
+
+---
+
+_See also: [INTENT_API.md](INTENT_API.md) for the intent schema and signing
+flow, [ARCHITECTURE.md](ARCHITECTURE.md) for where the hash is used across the
+intent lifecycle._

--- a/docs/INTENT_API.md
+++ b/docs/INTENT_API.md
@@ -10,6 +10,13 @@
 > consumer — the web app, the SDK, the MCP server, a third-party integrator,
 > an AI agent.
 
+> **Status: 🛠️ Planned (wave 1.2) — not yet implemented.** There is no
+> `app/api/` surface on `main` today; the off-ramp ships as a single-anchor
+> UI flow without these endpoints. The intent schema, endpoints, signing
+> rules, and examples below are the design contract the v1.2 router wave
+> implements — they are not live. See [ROADMAP.md](ROADMAP.md) for what ships
+> today versus what is planned.
+
 ---
 
 ## Table of contents

--- a/docs/JURISDICTIONAL.md
+++ b/docs/JURISDICTIONAL.md
@@ -1,0 +1,65 @@
+# Jurisdictional Memo — Money Transmission
+
+> Why Stellar Intel is not a money transmitter, money services business (MSB),
+> or virtual-asset service provider (VASP). This memo records the reasoning a
+> grant reviewer, a partner anchor, or counsel reads to understand the
+> regulatory posture. It is an engineering-and-product memo, **not legal
+> advice**.
+
+> **Status: 🛠️ Planned (stub).** This is the canonical home for the
+> jurisdictional argument referenced from the grant [PROPOSAL.md](PROPOSAL.md)
+> and [ARCHITECTURE.md](ARCHITECTURE.md). The classification argument below
+> follows directly from the non-custody guarantee; a full counsel-reviewed
+> memo lands as the product approaches mainnet reputation writes (v2).
+
+---
+
+## The classification question
+
+Money-transmitter / MSB / VASP regimes (FinCEN in the US, and analogous
+frameworks elsewhere) generally attach to a party that **accepts and transmits
+value on behalf of another** — i.e. one that takes custody of funds, even
+momentarily, in the course of moving them.
+
+Stellar Intel does none of this. The position rests entirely on the
+[non-custody guarantee](NON_CUSTODY.md):
+
+- **No acceptance of funds.** The user's payment goes directly to the anchor's
+  Stellar address. Stellar Intel never receives the value being moved.
+- **No transmission on behalf of another.** We surface quotes and help
+  construct a transaction the user signs themselves. The transmitting parties
+  are the user (on-ledger) and the anchor (fiat-side), each already operating
+  under their own licences.
+- **No fiat float, no settlement account.** There is no bank account, no
+  pooled balance, and no point at which user value rests under our control.
+
+We are, functionally, an **information and transaction-construction service** —
+closer to a price-comparison site plus a transaction builder than to a
+remitter.
+
+## Where the licensed parties sit
+
+| Party             | Role                                  | Regulatory standing                                   |
+| ----------------- | ------------------------------------- | ----------------------------------------------------- |
+| **User**          | Signs and submits their own payment   | Acting for themselves; not transmitting for another.  |
+| **Anchor**        | Takes custody (SEP-24), delivers fiat | Licensed where it operates (its compliance, its KYC). |
+| **Stellar Intel** | Quotes, ranks, builds the transaction | Non-custodial; no value handling.                     |
+
+KYC/AML obligations attach at the **anchor**, which owns the KYC surface
+(SEP-24 interactive flow) and the fiat off-ramp. Stellar Intel neither
+collects nor stores KYC data.
+
+## Open items for counsel review
+
+- Per-jurisdiction confirmation that transaction-construction without custody
+  does not trigger registration.
+- Treatment of the reputation oracle (v2) as published data vs. a regulated
+  activity (expected: published data — it moves no value).
+- Disclosures/ToS language making the non-custodial, anchor-licensed model
+  explicit to end users.
+
+---
+
+_This memo is informational and does not constitute legal advice. See
+[NON_CUSTODY.md](NON_CUSTODY.md) for the technical guarantee it relies on, and
+the risk register in [PROPOSAL.md](PROPOSAL.md)._

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,7 +4,13 @@
 > oracle to AI agents. Same primitives as the web UI, one network hop away.
 > An agent can price, compare, and execute an off-ramp in five lines.
 
-Status: **wave 2.3 / v2.x** — spec stabilising, reference server shipping.
+> **Status: 🛠️ Planned — not yet built.** There is no `@stellarintel/mcp`
+> package on npm and no reference server running today. `claude mcp add`
+> will **not** work yet. This document is a forward spec: the tools, install
+> steps, and prompts below describe the intended surface, not shipped code.
+> The MCP scaffold is scheduled for **wave 1.2** and general availability for
+> **v4**. See [ROADMAP.md](ROADMAP.md) for what ships on `main` today versus
+> what is planned.
 
 ---
 

--- a/docs/NON_CUSTODY.md
+++ b/docs/NON_CUSTODY.md
@@ -1,0 +1,60 @@
+# Non-Custody Manifesto
+
+> Stellar Intel never holds user keys, never holds user funds, and never
+> touches fiat. This is not a policy we promise to keep — it is a property of
+> how the system is built. This document states the guarantee, names the
+> mechanism that enforces it, and lists what would have to break for it to be
+> false.
+
+> **Status: 🛠️ Planned (stub).** This is the canonical home for the
+> non-custody guarantee referenced from the README, the PR template, the grant
+> [PROPOSAL.md](PROPOSAL.md), and [ARCHITECTURE.md § 9](ARCHITECTURE.md#9-trust-boundaries--invariants).
+> The invariants below are authoritative for the shipped off-ramp; the
+> reputation/publisher paths they reference land with v2.
+
+---
+
+## The guarantee
+
+1. **We never hold user keys.** Signing happens in Freighter (web) or the
+   caller's own wallet (agent). No key material is transmitted to, stored by,
+   or reconstructable from anything Stellar Intel runs.
+2. **We never hold user funds.** The withdrawal payment flows directly from
+   the user's Stellar account to the anchor's receiving address. No Stellar
+   Intel account ever sits between them.
+3. **We never touch fiat.** Fiat settlement is strictly between the anchor and
+   the user's bank or mobile-money provider. Stellar Intel operates no banking
+   rail and has no fiat float.
+
+## How it is enforced
+
+- **Custody is the anchor's, under SEP-24.** Once the user submits the
+  on-ledger payment, the anchor takes custody and is contractually the party
+  that delivers fiat. The protocol, not our goodwill, defines this boundary.
+- **Atomicity is Stellar's.** The payment either confirms on the public ledger
+  or it does not. There is no intermediate state in which Stellar Intel holds
+  value.
+- **The one key we hold cannot move funds.** The publisher key (v2) signs
+  reputation writes to the Soroban oracle and nothing else. It has no
+  authority over any account holding user value. See
+  [ARCHITECTURE.md § 6](ARCHITECTURE.md#6-reputation-write-path-v2).
+
+## What would have to break
+
+This guarantee fails only if one of the following is violated — each is an
+invariant a PR is not allowed to break:
+
+- A code path transmits or persists a user private key. (None exists; SEP-10
+  signing is delegated to the wallet.)
+- A payment is routed through a Stellar Intel–controlled account instead of
+  directly to the anchor.
+- The publisher key is granted authority over a value-bearing account.
+
+Adversarial analysis of these failure modes lives in
+[THREAT_MODEL.md](THREAT_MODEL.md). The regulatory consequence of holding the
+line — why non-custody keeps us out of money-transmitter classification — is in
+[JURISDICTIONAL.md](JURISDICTIONAL.md).
+
+---
+
+_See also: [SECURITY.md](SECURITY.md) for key handling and disclosure policy._

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -4,8 +4,13 @@
 > oracle, and canonical JSON + Ed25519 signing. The same package powers
 > the web UI, the MCP server, and external integrators.
 
-Status: **wave 2.3 / v2.x** — draft published; surface stable within v1,
-minor additions continuing into v2.
+> **Status: 🛠️ Planned — not yet published.** `@stellarintel/sdk` is **not on
+> npm today** and nothing in this document is installable. This is a forward
+> spec: the package, its modules, and every snippet below describe the
+> intended surface, not shipped code. The SDK scaffold is scheduled for
+> **wave 1.2** and general availability for **v4**. See
+> [ROADMAP.md](ROADMAP.md) for what ships on `main` today versus what is
+> planned.
 
 ---
 


### PR DESCRIPTION
## What

Aligns the documentation's honesty markers with the actual repo state, so readers can tell shipped features from planned ones, and fixes broken internal links.

### Status banners (forward specs)
- **`docs/SDK.md`** — replaced the misleading "draft published; surface stable" line with a `🛠️ Planned — not yet published` banner (the npm package does not exist).
- **`docs/MCP.md`** — replaced "reference server shipping" with a `🛠️ Planned — not yet built` banner (`claude mcp add` won't work yet).
- **`docs/INTENT_API.md`** — added a banner noting there is no `app/api/` surface today; the endpoints are the v1.2 design contract.

### README
- Added a **"What ships today"** note under *Why this exists*, clarifying only the single-anchor off-ramp is live; the router, oracle, and agent surface are specced-not-built (points to ROADMAP + ARCHITECTURE's ✅/🛠️ markers).
- Removed the broken `docs/images/hero.png` embed (kept the demo link).

### Dead links resolved
Created the three planned-doc stubs that existing links pointed to, each with its own status banner, in the repo's doc style:
- **`docs/CANONICAL_JSON.md`** — canonical JSON + hashing rules (referenced from ARCHITECTURE §3, INTENT_API, ROADMAP).
- **`docs/NON_CUSTODY.md`** — non-custody guarantee + enforcement (referenced from README, PR template, PROPOSAL, ARCHITECTURE §9).
- **`docs/JURISDICTIONAL.md`** — money-transmission classification memo (referenced from PROPOSAL, ARCHITECTURE).

## Scope
Docs only — 7 files. No code changes. Based on `fix/issue-018-resolved-anchor-types` because the banner-edited docs (SDK/MCP/INTENT_API) live on that branch, not on `main`.

## Not included
`CODE_OF_CONDUCT.md` is still a dead link (referenced from README and CONTRIBUTING) — intentionally left out of this PR.