### PR TITLE
feat: add offline detection bar (#185)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Navbar } from '@/components/layout/Navbar';
 import { Footer } from '@/components/layout/Footer';
 import { ThemeProvider } from '@/contexts/theme';
 import { BottomNav } from '@/components/layout/BottomNav';
+import { OfflineBar } from '@/components/layout/OfflineBar';
 import { WalletProvider } from '@/contexts/WalletContext';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -38,6 +39,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${inter.className} min-h-screen bg-background`}>
         <ThemeProvider>
           <WalletProvider>
+            <OfflineBar />
             <Navbar />
             <main className="mx-auto max-w-7xl px-4 py-8">{children}</main>
             <Footer />

--- a/components/layout/OfflineBar.tsx
+++ b/components/layout/OfflineBar.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { WifiOff, X } from 'lucide-react';
+
+export function OfflineBar() {
+  const [offline, setOffline] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setOffline(!navigator.onLine);
+    const handleOffline = () => { setOffline(true); setDismissed(false); };
+    const handleOnline = () => { setOffline(false); setDismissed(false); };
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
+  if (!offline || dismissed) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-yellow-500/90 px-4 py-2 text-sm font-medium text-yellow-950 backdrop-blur-sm">
+      <WifiOff className="h-4 w-4 shrink-0" />
+      <span>You are offline</span>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        className="ml-auto rounded p-0.5 hover:bg-yellow-600/30"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Description:
  
  ## Summary
  
  Implements the offline detection bar from issue #185.
  
  ## Changes
  
  - `components/layout/OfflineBar.tsx` — new client component that listens to `window` `online`/`offline` events and renders a fixed top bar with "You are
  offline" when the network is unavailable
  - `app/layout.tsx` — mounts `<OfflineBar />` above `<Navbar />` so it appears on every page
  
  ## Behaviour
  
  - Bar appears immediately when the browser goes offline (devtools or real)
  - Bar disappears immediately when the browser comes back online
  - Bar is dismissible via the ✕ button, but reappears automatically on any subsequent status change
  - Page loaded while already offline correctly shows the bar on mount
  
  ## Testing
  
  Toggle offline in browser devtools (Network tab → Offline) to verify all acceptance criteria.
  
  Closes #185 
