### PR TITLE
feat: Add copy transaction ID button

### DIFF
--- a/components/offramp/StatusTracker.tsx
+++ b/components/offramp/StatusTracker.tsx
@@ -3,6 +3,7 @@ import type { WithdrawStatusValue, Sep24Transaction } from '@/types';
 import { formatDeliveredAmount } from '@/lib/format';
 import { Timeline } from './Timeline';
 import { STELLAR_EXPERT_URL } from '@/constants';
+import { CopyButton } from '@/components/ui/CopyButton';
 
 interface StatusTrackerProps {
   transactionId: string;
@@ -99,7 +100,10 @@ export function StatusTracker({
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
             Transaction Status
           </h3>
-          <p className="mt-0.5 font-mono text-xs text-gray-400">{transactionId}</p>
+          <div className="mt-0.5 flex items-center gap-2">
+            <p className="font-mono text-xs text-gray-400">{transactionId}</p>
+            <CopyButton text={transactionId} />
+          </div>
         </div>
         {!isTerminal && (
           <span className="flex items-center gap-1 text-xs text-gray-400">

--- a/components/ui/CopyButton.tsx
+++ b/components/ui/CopyButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState } from 'react';
+import { Button } from './Button';
+
+interface CopyButtonProps {
+  text: string;
+  className?: string;
+}
+
+export function CopyButton({ text, className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // Fallback for browsers without clipboard API
+        const textArea = document.createElement('textarea');
+        textArea.value = text;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        textArea.style.top = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+          document.execCommand('copy');
+        } catch (err) {
+          console.error('Fallback copy failed', err);
+          throw err;
+        }
+        document.body.removeChild(textArea);
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Copy failed', err);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className={className}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </Button>
+  );
+}


### PR DESCRIPTION

## Description

Implemented a copy-to-clipboard button for anchor transaction IDs to improve support and troubleshooting workflows.

Users can now quickly copy transaction IDs directly from the offramp status tracker for use in support tickets or transaction investigations.

The implementation includes:
- Clipboard API support using `navigator.clipboard.writeText`
- Temporary `"Copied"` toast/feedback state for 2 seconds
- Graceful fallback behavior for browsers without Clipboard API support

---

## Related Issue

Closes #48

---

## Type of Change

- [x] New feature  
- [x] UI / UX improvement  
- [ ] Bug fix  
- [ ] Refactor  
- [ ] Documentation  

---

## Changes Included

### Added
- `CopyButton` reusable UI component
- Clipboard copy support for transaction IDs
- Temporary copied state feedback

### Updated
- `components/offramp/StatusTracker.tsx`
- `components/ui/CopyButton.tsx`

---

## Features

- One-click transaction ID copy
- 2-second copied confirmation state
- Browser compatibility fallback handling
- Reusable copy button component pattern

---

## Security Impact

No security impact.

Only copies already-visible transaction identifiers to the local clipboard.

---

## Testing

- [x] Verified copy works in Chrome  
- [x] Verified copy works in Firefox  
- [x] Verified copy works in Safari  
- [x] Verified fallback behavior without Clipboard API  
- [x] Verified copied state resets after 2 seconds  
- [x] Existing UI behavior remains functional  

---

## Manual Testing Steps

- Opened offramp status tracker
- Clicked copy transaction ID button
- Verified transaction ID copied to clipboard
- Confirmed `"Copied"` state appears temporarily
- Waited 2 seconds and verified state resets
- Tested fallback behavior in unsupported environments

---

## Acceptance Criteria Coverage

- [x] Uses `navigator.clipboard.writeText`
- [x] Shows `"Copied"` toast/state for 2 seconds
- [x] Includes fallback for browsers without Clipboard API
- [x] Works in Chrome, Firefox, and Safari

---

## Breaking Changes

No breaking changes.

---

## Checklist

- [x] Code builds successfully  
- [x] Tests pass  
- [x] Follows project conventions  
- [x] No sensitive data exposed  
- [x] Existing functionality preserved  

---

## Additional Context

This improves user support workflows by making transaction references easy to copy and share without manual selection.

The reusable `CopyButton` component can also be leveraged in other parts of the application where copy-to-clipboard interactions are needed.

---

## Reviewer Notes

Please focus on:

- Clipboard API compatibility handling  
- Accessibility of copied-state feedback  
- Fallback behavior in unsupported browsers  
- Reusability of the `CopyButton` component  