### PR TITLE
feat(anchors): implement public anchors leaderboard with sorting and …

### DIFF
--- a/app/anchors/page.tsx
+++ b/app/anchors/page.tsx
@@ -1,0 +1,111 @@
+import { Card } from '@/components/ui/Card';
+import { CORRIDORS } from '@/constants';
+import { Leaderboard } from '@/components/anchors/Leaderboard';
+import {
+  buildLeaderboardData,
+  getLeaderboardDirection,
+  getLeaderboardSortKey,
+} from '@/lib/reputation';
+
+interface AnchorsPageProps {
+  searchParams?: {
+    corridor?: string;
+    sort?: string;
+    direction?: string;
+  };
+}
+
+export default function AnchorsPage({ searchParams }: AnchorsPageProps) {
+  const selectedCorridor = CORRIDORS.some((corridor) => corridor.id === searchParams?.corridor)
+    ? searchParams?.corridor
+    : null;
+  const sortKey = getLeaderboardSortKey(searchParams?.sort);
+  const direction = getLeaderboardDirection(searchParams?.direction);
+  const leaderboard = buildLeaderboardData(selectedCorridor ?? undefined, sortKey, direction);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <div className="space-y-6">
+        <section className="rounded-3xl border border-gray-200 bg-white/80 p-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-gray-800 dark:bg-slate-950/80">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-blue-600 dark:text-blue-400">
+                Anchor leaderboard
+              </p>
+              <h1 className="mt-3 text-3xl font-semibold text-gray-900 dark:text-white md:text-4xl">
+                The best Stellar anchor reputation scores.
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-300">
+                Compare anchors by composite score, fill rate, settle latency, and slippage.
+                Filter by corridor and click any column header to sort the leaderboard.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Card className="rounded-3xl border border-gray-200 bg-slate-50 p-4 dark:border-gray-800 dark:bg-slate-900">
+                <p className="text-xs uppercase tracking-[0.24em] text-gray-500 dark:text-gray-400">
+                  Filtered corridor
+                </p>
+                <p className="mt-2 text-lg font-semibold text-gray-900 dark:text-white">
+                  {selectedCorridor ?? 'All corridors'}
+                </p>
+              </Card>
+              <Card className="rounded-3xl border border-gray-200 bg-slate-50 p-4 dark:border-gray-800 dark:bg-slate-900">
+                <p className="text-xs uppercase tracking-[0.24em] text-gray-500 dark:text-gray-400">
+                  Active sort
+                </p>
+                <p className="mt-2 text-lg font-semibold text-gray-900 dark:text-white">
+                  {sortKey} · {direction}
+                </p>
+              </Card>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[280px_1fr]">
+          <aside className="space-y-4">
+            <Card className="space-y-4 rounded-3xl border border-gray-200 bg-slate-50 p-6 dark:border-gray-800 dark:bg-slate-900">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Corridor filter</h2>
+              <form action="/anchors" method="get" className="space-y-4">
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="corridor">
+                    Corridor
+                  </label>
+                  <select
+                    id="corridor"
+                    name="corridor"
+                    defaultValue={selectedCorridor ?? ''}
+                    className="w-full rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-300 dark:border-gray-700 dark:bg-slate-950 dark:text-white"
+                  >
+                    <option value="">All corridors</option>
+                    {CORRIDORS.map((corridor) => (
+                      <option key={corridor.id} value={corridor.id}>
+                        {corridor.from} → {corridor.to} — {corridor.countryName}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <input type="hidden" name="sort" value={sortKey} />
+                <input type="hidden" name="direction" value={direction} />
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
+                >
+                  Apply filter
+                </button>
+              </form>
+            </Card>
+          </aside>
+
+          <section className="space-y-4">
+            <Leaderboard
+              entries={leaderboard.entries}
+              selectedCorridor={leaderboard.corridorId}
+              sortKey={leaderboard.sortKey}
+              direction={leaderboard.direction}
+            />
+          </section>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/api/reputation/leaderboard/route.ts
+++ b/app/api/reputation/leaderboard/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { buildLeaderboardData } from '@/lib/reputation';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const corridor = url.searchParams.get('corridor') ?? undefined;
+  const sort = url.searchParams.get('sort') ?? undefined;
+  const direction = url.searchParams.get('direction') ?? undefined;
+
+  const leaderboard = buildLeaderboardData(corridor, sort, direction);
+  return NextResponse.json(leaderboard);
+}

--- a/components/anchors/Leaderboard.tsx
+++ b/components/anchors/Leaderboard.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import { clsx } from 'clsx';
+import type {
+  AnchorLeaderboardEntry,
+  LeaderboardDirection,
+  LeaderboardSortKey,
+} from '@/lib/reputation';
+
+interface LeaderboardProps {
+  entries: AnchorLeaderboardEntry[];
+  selectedCorridor: string | null;
+  sortKey: LeaderboardSortKey;
+  direction: LeaderboardDirection;
+}
+
+const COLUMNS: Array<{
+  key: LeaderboardSortKey;
+  label: string;
+  align: 'left' | 'right';
+}> = [
+  { key: 'composite', label: 'Composite score', align: 'left' },
+  { key: 'fillRate', label: 'Fill rate', align: 'right' },
+  { key: 'settleP50', label: 'Settle p50', align: 'right' },
+  { key: 'slippage', label: 'Slippage', align: 'right' },
+];
+
+function formatMetric(entry: AnchorLeaderboardEntry, key: LeaderboardSortKey) {
+  switch (key) {
+    case 'composite':
+      return entry.composite.toFixed(1);
+    case 'fillRate':
+      return new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        maximumFractionDigits: 1,
+      }).format(entry.fillRate);
+    case 'settleP50':
+      return `${entry.settleP50}h`;
+    case 'slippage':
+      return new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        maximumFractionDigits: 1,
+      }).format(entry.slippage / 100);
+    default:
+      return String(entry[key]);
+  }
+}
+
+function buildSortLink(key: LeaderboardSortKey, selectedCorridor: string | null, currentSort: LeaderboardSortKey, currentDirection: LeaderboardDirection) {
+  const nextDirection: LeaderboardDirection =
+    currentSort === key ? (currentDirection === 'desc' ? 'asc' : 'desc') : 'desc';
+  const search = new URLSearchParams();
+  if (selectedCorridor) search.set('corridor', selectedCorridor);
+  search.set('sort', key);
+  search.set('direction', nextDirection);
+  return `/anchors?${search.toString()}`;
+}
+
+export function Leaderboard({ entries, selectedCorridor, sortKey, direction }: LeaderboardProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50">
+            <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-gray-400">Anchor</th>
+            {COLUMNS.map((column) => {
+              const active = column.key === sortKey;
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  className={clsx(
+                    'px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400',
+                    column.align === 'right' ? 'text-right' : 'text-left'
+                  )}
+                >
+                  <Link href={buildSortLink(column.key, selectedCorridor, sortKey, direction)}>
+                    <span className="inline-flex items-center gap-2">
+                      {column.label}
+                      {active ? (
+                        <span className="text-gray-500 dark:text-gray-400">
+                          {direction === 'asc' ? '↑' : '↓'}
+                        </span>
+                      ) : null}
+                    </span>
+                  </Link>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.anchorId} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="px-4 py-4 font-medium text-gray-900 dark:text-white">{entry.anchorName}</td>
+              <td className="px-4 py-4 text-right text-gray-700 dark:text-gray-300">
+                {formatMetric(entry, 'composite')}
+              </td>
+              <td className="px-4 py-4 text-right text-gray-700 dark:text-gray-300">
+                {formatMetric(entry, 'fillRate')}
+              </td>
+              <td className="px-4 py-4 text-right text-gray-700 dark:text-gray-300">
+                {formatMetric(entry, 'settleP50')}
+              </td>
+              <td className="px-4 py-4 text-right text-gray-700 dark:text-gray-300">
+                {formatMetric(entry, 'slippage')}
+              </td>
+            </tr>
+          ))}
+          {entries.length === 0 && (
+            <tr>
+              <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                No anchors available for this corridor.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,10 +1,13 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ArrowDownLeft } from 'lucide-react';
+import { ArrowDownLeft, BarChart3 } from 'lucide-react';
 import { clsx } from 'clsx';
 
-const TAB_LINKS = [{ href: '/offramp', label: 'Off-ramp', icon: ArrowDownLeft }];
+const TAB_LINKS = [
+  { href: '/offramp', label: 'Off-ramp', icon: ArrowDownLeft },
+  { href: '/anchors', label: 'Anchors', icon: BarChart3 },
+];
 
 export function BottomNav() {
   const pathname = usePathname();

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -6,7 +6,10 @@ import { Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { useTheme } from '@/hooks/useTheme';
 
-const NAV_LINKS = [{ href: '/offramp', label: 'Off-ramp' }];
+const NAV_LINKS = [
+  { href: '/offramp', label: 'Off-ramp' },
+  { href: '/anchors', label: 'Anchors' },
+];
 
 export function Navbar() {
   const pathname = usePathname();

--- a/lib/reputation.ts
+++ b/lib/reputation.ts
@@ -1,0 +1,130 @@
+import { CORRIDORS, KNOWN_ANCHORS } from '@/constants';
+
+export type LeaderboardSortKey = 'composite' | 'fillRate' | 'settleP50' | 'slippage';
+export type LeaderboardDirection = 'asc' | 'desc';
+
+export interface AnchorLeaderboardEntry {
+  anchorId: string;
+  anchorName: string;
+  corridorId: string | null;
+  composite: number;
+  fillRate: number;
+  settleP50: number;
+  slippage: number;
+}
+
+export interface AnchorLeaderboardData {
+  entries: AnchorLeaderboardEntry[];
+  corridorId: string | null;
+  sortKey: LeaderboardSortKey;
+  direction: LeaderboardDirection;
+}
+
+const DEFAULT_METRICS: Record<string, Omit<AnchorLeaderboardEntry, 'anchorId' | 'anchorName' | 'corridorId'>> = {
+  moneygram: { composite: 91.8, fillRate: 0.95, settleP50: 22, slippage: 1.1 },
+  cowrie: { composite: 92.4, fillRate: 0.96, settleP50: 16, slippage: 0.7 },
+  anclap: { composite: 87.8, fillRate: 0.90, settleP50: 25, slippage: 1.9 },
+};
+
+const CORRIDOR_METRICS: Record<
+  string,
+  Partial<Record<string, Omit<AnchorLeaderboardEntry, 'anchorId' | 'anchorName' | 'corridorId'>>>
+> = {
+  'usdc-ngn': {
+    moneygram: { composite: 95.3, fillRate: 0.97, settleP50: 18, slippage: 0.6 },
+    cowrie: { composite: 94.8, fillRate: 0.98, settleP50: 14, slippage: 0.5 },
+  },
+  'usdc-kes': {
+    moneygram: { composite: 93.1, fillRate: 0.95, settleP50: 20, slippage: 1.0 },
+  },
+  'usdc-ghs': {
+    moneygram: { composite: 91.7, fillRate: 0.94, settleP50: 24, slippage: 1.3 },
+  },
+  'usdc-mxn': {
+    moneygram: { composite: 90.3, fillRate: 0.93, settleP50: 26, slippage: 1.8 },
+  },
+  'usdc-brl': {
+    moneygram: { composite: 90.9, fillRate: 0.94, settleP50: 28, slippage: 1.6 },
+  },
+  'usdc-ars': {
+    anclap: { composite: 88.1, fillRate: 0.91, settleP50: 24, slippage: 2.0 },
+  },
+  'usdc-pen': {
+    anclap: { composite: 87.4, fillRate: 0.90, settleP50: 26, slippage: 2.2 },
+  },
+};
+
+function normalizeSortKey(value: string | undefined): LeaderboardSortKey {
+  switch (value) {
+    case 'fillRate':
+    case 'settleP50':
+    case 'slippage':
+      return value;
+    default:
+      return 'composite';
+  }
+}
+
+function normalizeDirection(value: string | undefined): LeaderboardDirection {
+  return value === 'asc' ? 'asc' : 'desc';
+}
+
+function getAnchorMetrics(anchorId: string, corridorId?: string): Omit<AnchorLeaderboardEntry, 'anchorId' | 'anchorName' | 'corridorId'> {
+  if (corridorId && CORRIDOR_METRICS[corridorId]?.[anchorId]) {
+    return CORRIDOR_METRICS[corridorId]![anchorId]!;
+  }
+
+  return DEFAULT_METRICS[anchorId] ?? { composite: 0, fillRate: 0, settleP50: 0, slippage: 0 };
+}
+
+function getAnchorEntries(corridorId?: string): AnchorLeaderboardEntry[] {
+  const selectedCorridor = CORRIDORS.find((corridor) => corridor.id === corridorId);
+
+  return KNOWN_ANCHORS.filter((anchor) => {
+    if (!selectedCorridor) return true;
+    return anchor.corridors.includes(selectedCorridor.id);
+  }).map((anchor) => ({
+    anchorId: anchor.id,
+    anchorName: anchor.name,
+    corridorId: selectedCorridor?.id ?? null,
+    ...getAnchorMetrics(anchor.id, selectedCorridor?.id),
+  }));
+}
+
+function sortLeaderboard(
+  entries: AnchorLeaderboardEntry[],
+  sortKey: LeaderboardSortKey,
+  direction: LeaderboardDirection
+): AnchorLeaderboardEntry[] {
+  const modifier = direction === 'asc' ? 1 : -1;
+  return [...entries].sort((a, b) => {
+    const diff = a[sortKey] - b[sortKey];
+    if (diff !== 0) return diff * modifier;
+    return a.anchorName.localeCompare(b.anchorName) * modifier;
+  });
+}
+
+export function buildLeaderboardData(
+  corridorId?: string,
+  sortKeyValue?: string,
+  directionValue?: string
+): AnchorLeaderboardData {
+  const sortKey = normalizeSortKey(sortKeyValue);
+  const direction = normalizeDirection(directionValue);
+  const entries = getAnchorEntries(corridorId);
+
+  return {
+    entries: sortLeaderboard(entries, sortKey, direction),
+    corridorId: CORRIDORS.some((corridor) => corridor.id === corridorId) ? corridorId ?? null : null,
+    sortKey,
+    direction,
+  };
+}
+
+export function getLeaderboardSortKey(value: string | undefined): LeaderboardSortKey {
+  return normalizeSortKey(value);
+}
+
+export function getLeaderboardDirection(value: string | undefined): LeaderboardDirection {
+  return normalizeDirection(value);
+}

--- a/tests/api/reputation-leaderboard.spec.ts
+++ b/tests/api/reputation-leaderboard.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { GET } from '@/app/api/reputation/leaderboard/route';
+
+describe('GET /api/reputation/leaderboard', () => {
+  test('returns all anchors ordered by composite descending by default', async () => {
+    const response = await GET(new Request('http://localhost/api/reputation/leaderboard'));
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.sortKey).toBe('composite');
+    expect(body.direction).toBe('desc');
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.entries).toHaveLength(3);
+    expect(body.entries[0].composite).toBeGreaterThanOrEqual(body.entries[1].composite);
+  });
+
+  test('filters anchors by corridor and sorts by fill rate ascending', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/reputation/leaderboard?corridor=usdc-ngn&sort=fillRate&direction=asc')
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.corridorId).toBe('usdc-ngn');
+    expect(body.sortKey).toBe('fillRate');
+    expect(body.direction).toBe('asc');
+    expect(body.entries.length).toBeGreaterThanOrEqual(1);
+    expect(body.entries[0].fillRate).toBeLessThanOrEqual(body.entries[1]?.fillRate ?? Infinity);
+    expect(body.entries.every((entry: any) => entry.anchorId === 'moneygram' || entry.anchorId === 'cowrie')).toBe(true);
+  });
+});

--- a/tests/e2e/anchors-leaderboard.spec.ts
+++ b/tests/e2e/anchors-leaderboard.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * Verifies the public /anchors leaderboard page renders and exposes sortable
+ * anchor metrics.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Anchor leaderboard page', () => {
+  test('renders the leaderboard with sort headers and corridor filter', async ({ page }) => {
+    await page.goto('/anchors');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('heading', { name: /The best Stellar anchor reputation scores/i })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: /corridor/i })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /Composite score/i })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /Fill rate/i })).toBeVisible();
+    await expect(page.locator('table tbody tr')).toHaveCount(3);
+  });
+});


### PR DESCRIPTION
#closes #310 

## Summary
Adds a public anchor leaderboard page at `/anchors` with sortable columns and corridor filtering, plus a backend API endpoint for leaderboard data.

## What changed

- `app/anchors/page.tsx`
  - Added the new `/anchors` page.
  - Supports corridor filtering and sortable columns.
- `components/anchors/Leaderboard.tsx`
  - Added reusable leaderboard table component.
- `lib/reputation.ts`
  - Added leaderboard score helper, sorting logic, and mock corridor-specific anchor metrics.
- `app/api/reputation/leaderboard/route.ts`
  - Added a new API endpoint at `GET /api/reputation/leaderboard`.
- `components/layout/Navbar.tsx`
  - Added `Anchors` to the main navbar.
- `components/layout/BottomNav.tsx`
  - Added `Anchors` to the mobile bottom navigation.

## Behavior

- Renders the leaderboard page under `/anchors`.
- Supports sorting by:
  - `composite`
  - `fillRate`
  - `settleP50`
  - `slippage`
- Supports corridor filtering via query parameter or the page filter form.
- Returns leaderboard JSON from `GET /api/reputation/leaderboard`.

## How to test

1. Start the app:
   - `npm run dev`
2. Open the page:
   - `http://localhost:3000/anchors`
3. Verify the page:
   - The page loads successfully.
   - The corridor filter dropdown renders.
   - Sortable table headers render for composite score, fill rate, settle p50, and slippage.
   - Anchor rows render correctly.
4. Run automated tests:
   - `npm run test -- tests/api/reputation-leaderboard.spec.ts`
   - `npx playwright test tests/e2e/anchors-leaderboard.spec.ts`

## Notes

- The leaderboard currently uses seeded mock reputation metrics for the available corridors.
- API query params supported:
  - `corridor`
  - `sort`
  - `direction`
#closes