### PR TITLE
fix(offramp): fix #091 drawer-level error boundary

### DIFF
--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -5,6 +5,7 @@ import { initiateWithdraw, getWithdrawTransactionRecord } from '@/lib/stellar/se
 import { getResolvedAnchorById } from '@/lib/stellar/anchors';
 import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon';
 import type { AnchorRate, ExecuteDrawerStep } from '@/types';
+import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { KycIframe } from './KycIframe';
 
 // ─── Step definitions ─────────────────────────────────────────────────────────
@@ -34,6 +35,41 @@ interface ExecuteDrawerProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ExecuteDrawer({
+  rate,
+  amount,
+  publicKey,
+  onClose,
+  onExecuteStarted,
+}: ExecuteDrawerProps) {
+  const resetKey = rate ? `${rate.anchorId}:${amount}:${publicKey}` : 'closed';
+
+  return (
+    <ErrorBoundary
+      resetKeys={[resetKey]}
+      fallback={({ resetErrorBoundary }) => (
+        <ExecuteDrawerErrorFallback
+          anchorName={rate?.anchorName}
+          isOpen={rate !== null}
+          onChooseDifferentAnchor={() => {
+            resetErrorBoundary();
+            onClose();
+          }}
+          onRetry={resetErrorBoundary}
+        />
+      )}
+    >
+      <ExecuteDrawerContent
+        rate={rate}
+        amount={amount}
+        publicKey={publicKey}
+        onClose={onClose}
+        onExecuteStarted={onExecuteStarted}
+      />
+    </ErrorBoundary>
+  );
+}
+
+function ExecuteDrawerContent({
   rate,
   amount,
   publicKey,
@@ -355,6 +391,57 @@ export function ExecuteDrawer({
           </div>
         </div>
       )}
+    </>
+  );
+}
+
+function ExecuteDrawerErrorFallback({
+  anchorName,
+  isOpen,
+  onChooseDifferentAnchor,
+  onRetry,
+}: {
+  anchorName: string | undefined;
+  isOpen: boolean;
+  onChooseDifferentAnchor: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <>
+      {isOpen && <div className="fixed inset-0 z-40 bg-black/40" aria-hidden="true" />}
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Off-ramp error"
+        className={`fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-2xl transition-transform duration-300 dark:bg-gray-900 sm:bottom-auto sm:left-auto sm:right-8 sm:top-1/2 sm:w-96 sm:-translate-y-1/2 sm:rounded-2xl ${
+          isOpen ? 'translate-y-0' : 'translate-y-full sm:translate-y-full'
+        }`}
+      >
+        <div className="p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Off-ramp unavailable
+          </h2>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            We could not render the {anchorName ? `${anchorName} ` : ''}off-ramp flow.
+          </p>
+
+          <div className="mt-5 space-y-3">
+            <button
+              onClick={onRetry}
+              className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Retry
+            </button>
+            <button
+              onClick={onChooseDifferentAnchor}
+              className="w-full rounded-xl bg-gray-100 py-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+            >
+              Choose different anchor
+            </button>
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryFallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode | ((props: ErrorBoundaryFallbackProps) => ReactNode);
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  resetKeys?: readonly unknown[];
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function resetKeysChanged(
+  previous: readonly unknown[] = [],
+  next: readonly unknown[] = []
+): boolean {
+  return (
+    previous.length !== next.length ||
+    previous.some((key, index) => !Object.is(key, next[index]))
+  );
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  componentDidUpdate(previousProps: ErrorBoundaryProps): void {
+    if (this.state.error && resetKeysChanged(previousProps.resetKeys, this.props.resetKeys)) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  resetErrorBoundary = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+
+    if (typeof this.props.fallback === 'function') {
+      return this.props.fallback({
+        error: this.state.error,
+        resetErrorBoundary: this.resetErrorBoundary,
+      });
+    }
+
+    return this.props.fallback;
+  }
+}


### PR DESCRIPTION
Closes #182 

# PR Description

Fixes #091 by adding a drawer-level React error boundary around the `ExecuteDrawer` content. Before this change, a render-time exception from any child inside the off-ramp drawer could bubble up through React and risk crashing the entire `/offramp` page. The drawer now contains those failures locally and renders a focused fallback state instead.

The updated flow keeps the exported `ExecuteDrawer` API unchanged. `ExecuteDrawer` now acts as the boundary wrapper, while the existing drawer implementation runs inside an internal content component. If a child render error occurs, the fallback preserves the drawer surface and gives the user two recovery paths: `Retry`, which resets the boundary and attempts to render the same selected drawer again, and `Choose different anchor`, which resets the boundary and closes the drawer so the user can select another quote.

This matters for #091 because the off-ramp flow includes multiple nested UI states, including KYC and transaction execution surfaces. A localized boundary prevents one drawer rendering failure from taking down the broader comparator experience, keeping the rate table and surrounding `/offramp` page available.

# Changed

- Added `components/ui/ErrorBoundary.tsx` as a reusable React class error boundary with reset support.
- Wrapped `ExecuteDrawer` content with the boundary while preserving the existing public component props.
- Added drawer-scoped fallback CTAs for `Retry` and `Choose different anchor`.