### PR TITLE
feat: replace Execute CTA with Sign intent behind feature flag

### DIFF
--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -6,6 +6,7 @@ import { getResolvedAnchorById } from '@/lib/stellar/anchors';
 import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon';
 import type { AnchorRate, ExecuteDrawerStep } from '@/types';
 import { KycIframe } from './KycIframe';
+import { FLAGS } from '@/lib/flags';
 
 // ─── Step definitions ─────────────────────────────────────────────────────────
 
@@ -289,12 +290,19 @@ export function ExecuteDrawer({
           {step !== 'kyc' && (
             <div className="mt-5">
               {step === 'idle' && (
-                <button
-                  onClick={handleExecute}
-                  className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  Start Off-ramp
-                </button>
+                <div className="flex flex-col items-center">
+                  <button
+                    onClick={handleExecute}
+                    className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  >
+                    {FLAGS.INTENT_FLOW ? 'Sign intent' : 'Start Off-ramp'}
+                  </button>
+                  {FLAGS.INTENT_FLOW && (
+                    <p className="mt-2 text-center text-xs text-gray-500 dark:text-gray-400">
+                      One signature, any outcome.
+                    </p>
+                  )}
+                </div>
               )}
               {isRunning && (
                 <button

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,13 +1,9 @@
 import { z } from 'zod';
 
 export const envSchema = z.object({
-<<<<<<< HEAD
-  NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['mainnet', 'testnet', 'futurenet'] as const),
-=======
   NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['mainnet', 'testnet', 'futurenet'], {
     error: () => ({ message: 'Must be one of: mainnet, testnet, futurenet' }),
   }),
->>>>>>> origin/main
   NEXT_PUBLIC_HORIZON_URL: z.string().url({
     message: 'Must be a valid URL (e.g. https://horizon.stellar.org)',
   }),

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,3 @@
+export const FLAGS = {
+  INTENT_FLOW: process.env.NEXT_PUBLIC_INTENT_FLOW === 'true',
+};


### PR DESCRIPTION
## Description
This PR addresses issue #214  by replacing the primary Call to Action (CTA) in the `ExecuteDrawer` with "Sign intent" and adding the adjacent explanatory help text: "One signature, any outcome."

To ensure a smooth and safe rollout, the new flow is placed behind the `INTENT_FLOW` feature flag. When the flag is disabled, the original "Start Off-ramp" CTA is retained.

## Changes Made
- **`lib/flags.ts`**: Created a centralized feature flags module and added the `INTENT_FLOW` flag, which reads from the `NEXT_PUBLIC_INTENT_FLOW` environment variable.
- **`components/offramp/ExecuteDrawer.tsx`**: Updated the CTA rendering logic to check `FLAGS.INTENT_FLOW` and conditionally display the new copy and help text.
- **`lib/env.ts`**: Fixed a pre-existing merge conflict affecting environment variable validations to ensure a clean and unblocked build.

## Related Issues
- Closes #214 

## Verification
- Local Testing: Start the application with `NEXT_PUBLIC_INTENT_FLOW=true` in your `.env.local` file and verify that the "Sign intent" button appears along with its subtext.
- Fallback Verification: Ensure the flag is disabled/removed and confirm that the original "Start Off-ramp" button is shown.
