### PR TITLE
ci: add nightly workflow to monitor anchor domain integrity and creat…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Resolve every anchor .well-known/stellar.toml
         id: probe
         run: |
-          # Extract anchor domains from constants/index.ts so we do not drift
+          # Extract anchor domains from constants/anchors.ts so we do not drift
           # from the app's source of truth.
           mapfile -t DOMAINS < <(node -e "
             const path = require('path');
             const fs = require('fs');
-            const src = fs.readFileSync('constants/index.ts', 'utf8');
-            const re = /domain:\s*['\"]([^'\"]+)['\"]/g;
+            const src = fs.readFileSync('constants/anchors.ts', 'utf8');
+            const re = /homeDomain:\s*['\"]([^'\"]+)['\"]/g;
             const seen = new Set();
             let m;
             while ((m = re.exec(src))) seen.add(m[1]);
@@ -41,7 +41,7 @@ jobs:
           ")
 
           if [ ${#DOMAINS[@]} -eq 0 ]; then
-            echo "::warning::No anchor domains found in constants/index.ts; skipping"
+            echo "::warning::No anchor domains found in constants/anchors.ts; skipping"
             echo "summary=no-domains-detected" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
Root cause: The anchor-domains job was reading constants/index.ts (which only re-exports) and matching the key domain:, but anchor domains live in constants/anchors.ts under homeDomain:. The extractor always produced an empty array, triggering the no-domains-detected warning, which caused the open-issue-on-failure job to fire and open issue Closes #135 

Fix applied in [.github/workflows/nightly.yml](vscode-webview://1pfv0gu1r2g3aiop6umibm6308ad1k7tj501ohmp4dnpejr9iq8u/.github/workflows/nightly.yml):

Source file changed: constants/index.ts → constants/anchors.ts
Regex key changed: domain: → homeDomain:
Updated the stale comment and warning message to match
The three anchor domains (stellar.moneygram.com, cowrie.exchange, anclap.com) will now be correctly extracted and probed each night.
