### PR TITLE
feat(reputation): add get_score, composite formula, and dispute endpoint

### DIFF
--- a/app/api/reputation/dispute/route.ts
+++ b/app/api/reputation/dispute/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Keypair } from '@stellar/stellar-sdk';
+import type { ApiError } from '@/types';
+
+const DisputeBodySchema = z.object({
+  intentHash: z.string().regex(/^[0-9a-f]{64}$/, {
+    message: 'intentHash must be a lowercase hex-encoded SHA-256 (64 chars)',
+  }),
+  publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, {
+    message: 'publicKey must be a valid Stellar public key (G…, 56 chars)',
+  }),
+  signature: z.string().min(1, { message: 'signature is required' }),
+  anchorId: z.string().min(1, { message: 'anchorId is required' }),
+  reason: z.string().min(1, { message: 'reason is required' }),
+});
+
+export type DisputeBody = z.infer<typeof DisputeBodySchema>;
+
+export interface DisputeRecord {
+  id: string;
+  intentHash: string;
+  publicKey: string;
+  anchorId: string;
+  reason: string;
+  disputed: true;
+  createdAt: string;
+}
+
+// ─── In-memory stores (replace with DB for production) ───────────────────────
+
+const disputes = new Map<string, DisputeRecord>();
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+const DISPUTE_WINDOW_MS = 86_400_000; // 24 hours
+const DISPUTE_MAX = 10;
+
+function checkDisputeRateLimit(publicKey: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitStore.get(publicKey);
+
+  if (!entry || now - entry.windowStart >= DISPUTE_WINDOW_MS) {
+    rateLimitStore.set(publicKey, { count: 1, windowStart: now });
+    return true;
+  }
+  if (entry.count >= DISPUTE_MAX) return false;
+  entry.count += 1;
+  return true;
+}
+
+export function clearDisputeStores(): void {
+  disputes.clear();
+  rateLimitStore.clear();
+}
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json<ApiError>(
+      { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
+      { status: 400 }
+    );
+  }
+
+  const parsed = DisputeBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json<ApiError>(
+      { code: 'VALIDATION_ERROR', message: parsed.error.issues[0]?.message ?? 'Validation failed' },
+      { status: 422 }
+    );
+  }
+
+  const { intentHash, publicKey, signature, anchorId, reason } = parsed.data;
+
+  // Verify Ed25519 proof: signature over the raw intentHash bytes
+  let valid = false;
+  try {
+    const keypair = Keypair.fromPublicKey(publicKey);
+    const messageBytes = Buffer.from(intentHash, 'hex');
+    const sigBytes = Buffer.from(signature, 'base64');
+    valid = keypair.verify(messageBytes, sigBytes);
+  } catch {
+    valid = false;
+  }
+
+  if (!valid) {
+    return NextResponse.json<ApiError>(
+      { code: 'FORBIDDEN', message: 'Signature verification failed' },
+      { status: 403 }
+    );
+  }
+
+  if (!checkDisputeRateLimit(publicKey)) {
+    return NextResponse.json<ApiError>(
+      { code: 'RATE_LIMITED', message: 'Dispute limit of 10 per 24 h exceeded' },
+      { status: 429 }
+    );
+  }
+
+  const record: DisputeRecord = {
+    id: `${publicKey.slice(0, 8)}-${intentHash.slice(0, 8)}-${Date.now()}`,
+    intentHash,
+    publicKey,
+    anchorId,
+    reason,
+    disputed: true,
+    createdAt: new Date().toISOString(),
+  };
+  disputes.set(record.id, record);
+
+  return NextResponse.json(record, { status: 201 });
+}

--- a/lib/reputation/composite.ts
+++ b/lib/reputation/composite.ts
@@ -1,0 +1,31 @@
+/**
+ * Normalization reference: settlement time considered "baseline fast".
+ * A settle at or below this value yields a ratio ≥ 1 in the formula.
+ */
+export const NORM_SETTLE_SECONDS = 300;
+
+/**
+ * Guard against divide-by-zero for anchors with zero reported settle time.
+ */
+export const MIN_SETTLE_SECONDS = 1;
+
+export interface CompositeMetrics {
+  fillRate: number;      // fraction [0, 1]
+  slippage: number;      // fractional slippage [0, 1], e.g. 0.011 for 1.1 %
+  settleSeconds: number; // median settlement time in seconds (positive)
+}
+
+/**
+ * Composite score formula: fillRate × (1 − slippage) ÷ normalizedSettle
+ *
+ * normalizedSettle = settleSeconds / NORM_SETTLE_SECONDS
+ *
+ * A score of 1.0 means perfect fill, zero slippage, at exactly the reference
+ * settle time. Values > 1 indicate faster-than-reference settlement.
+ */
+export function composite(metrics: CompositeMetrics): number {
+  const { fillRate, slippage, settleSeconds } = metrics;
+  const safeSettle = Math.max(settleSeconds, MIN_SETTLE_SECONDS);
+  const normalizedSettle = safeSettle / NORM_SETTLE_SECONDS;
+  return (fillRate * (1 - slippage)) / normalizedSettle;
+}

--- a/lib/reputation/score.ts
+++ b/lib/reputation/score.ts
@@ -1,0 +1,26 @@
+import type { SettlementEvent } from './aggregate';
+
+export interface ScoreResult {
+  total: number;
+  success_rate: number;
+  last_settle_seconds: number;
+}
+
+export function getScore(anchorId: string, events: SettlementEvent[]): ScoreResult {
+  const relevant = events.filter((e) => e.anchorId === anchorId);
+
+  if (relevant.length === 0) {
+    return { total: 0, success_rate: 0, last_settle_seconds: 0 };
+  }
+
+  const total = relevant.length;
+  const successCount = relevant.filter((e) => e.success).length;
+  const success_rate = successCount / total;
+
+  const latest = relevant.reduce((a, b) =>
+    a.completedAt.getTime() > b.completedAt.getTime() ? a : b
+  );
+  const last_settle_seconds = latest.settlementMs / 1000;
+
+  return { total, success_rate, last_settle_seconds };
+}

--- a/tests/composite.spec.ts
+++ b/tests/composite.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { composite, NORM_SETTLE_SECONDS, MIN_SETTLE_SECONDS } from '@/lib/reputation/composite';
+
+describe('composite', () => {
+  it('exports NORM_SETTLE_SECONDS as a positive number', () => {
+    expect(NORM_SETTLE_SECONDS).toBeGreaterThan(0);
+  });
+
+  it('exports MIN_SETTLE_SECONDS as a positive number', () => {
+    expect(MIN_SETTLE_SECONDS).toBeGreaterThan(0);
+  });
+
+  it('returns 1.0 for perfect metrics at reference settle time', () => {
+    const score = composite({ fillRate: 1, slippage: 0, settleSeconds: NORM_SETTLE_SECONDS });
+    expect(score).toBeCloseTo(1.0);
+  });
+
+  it('returns 0 for fillRate of 0', () => {
+    const score = composite({ fillRate: 0, slippage: 0, settleSeconds: NORM_SETTLE_SECONDS });
+    expect(score).toBe(0);
+  });
+
+  it('returns 0 for slippage of 1 (100%)', () => {
+    const score = composite({ fillRate: 1, slippage: 1, settleSeconds: NORM_SETTLE_SECONDS });
+    expect(score).toBe(0);
+  });
+
+  it('increases as fillRate increases', () => {
+    const base = { slippage: 0.01, settleSeconds: NORM_SETTLE_SECONDS };
+    const low = composite({ fillRate: 0.7, ...base });
+    const high = composite({ fillRate: 0.9, ...base });
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('decreases as slippage increases', () => {
+    const base = { fillRate: 0.95, settleSeconds: NORM_SETTLE_SECONDS };
+    const low = composite({ slippage: 0.005, ...base });
+    const high = composite({ slippage: 0.02, ...base });
+    expect(low).toBeGreaterThan(high);
+  });
+
+  it('increases as settleSeconds decreases (faster is better)', () => {
+    const base = { fillRate: 0.95, slippage: 0.01 };
+    const fast = composite({ settleSeconds: NORM_SETTLE_SECONDS / 2, ...base });
+    const slow = composite({ settleSeconds: NORM_SETTLE_SECONDS * 2, ...base });
+    expect(fast).toBeGreaterThan(slow);
+  });
+
+  it('matches documented formula: fillRate × (1 - slippage) / (settleSeconds / NORM)', () => {
+    const metrics = { fillRate: 0.95, slippage: 0.011, settleSeconds: 1320 };
+    const expected = (0.95 * (1 - 0.011)) / (1320 / NORM_SETTLE_SECONDS);
+    expect(composite(metrics)).toBeCloseTo(expected, 10);
+  });
+
+  it('handles settleSeconds of 0 without throwing (clamped to MIN)', () => {
+    expect(() => composite({ fillRate: 0.9, slippage: 0.01, settleSeconds: 0 })).not.toThrow();
+    const score = composite({ fillRate: 0.9, slippage: 0.01, settleSeconds: 0 });
+    expect(Number.isFinite(score)).toBe(true);
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it('is deterministic — same inputs always produce the same output', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1, noNaN: true }),
+        fc.double({ min: 0, max: 1, noNaN: true }),
+        fc.double({ min: 1, max: 86400, noNaN: true }),
+        (fillRate, slippage, settleSeconds) => {
+          const a = composite({ fillRate, slippage, settleSeconds });
+          const b = composite({ fillRate, slippage, settleSeconds });
+          return a === b;
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('result is always finite for valid inputs', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1, noNaN: true }),
+        fc.double({ min: 0, max: 0.99, noNaN: true }),
+        fc.double({ min: 1, max: 86400, noNaN: true }),
+        (fillRate, slippage, settleSeconds) => {
+          return Number.isFinite(composite({ fillRate, slippage, settleSeconds }));
+        }
+      ),
+      { numRuns: 1000 }
+    );
+  });
+});

--- a/tests/dispute-api.spec.ts
+++ b/tests/dispute-api.spec.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { Keypair } from '@stellar/stellar-sdk';
+import { POST, clearDisputeStores } from '@/app/api/reputation/dispute/route';
+import { NextRequest } from 'next/server';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeIntentHash(): string {
+  return 'a'.repeat(64); // valid 64-char hex
+}
+
+function signHash(keypair: Keypair, intentHash: string): string {
+  const messageBytes = Buffer.from(intentHash, 'hex');
+  const sig = keypair.sign(messageBytes);
+  return Buffer.from(sig).toString('base64');
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/reputation/dispute', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/reputation/dispute', () => {
+  let keypair: Keypair;
+  const intentHash = makeIntentHash();
+
+  beforeAll(() => {
+    keypair = Keypair.random();
+  });
+
+  beforeEach(() => {
+    clearDisputeStores();
+  });
+
+  it('returns 201 and sets disputed:true for a valid signed request', async () => {
+    const signature = signHash(keypair, intentHash);
+    const res = await POST(
+      makeRequest({
+        intentHash,
+        publicKey: keypair.publicKey(),
+        signature,
+        anchorId: 'moneygram',
+        reason: 'transaction never settled',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.disputed).toBe(true);
+    expect(body.intentHash).toBe(intentHash);
+    expect(body.anchorId).toBe('moneygram');
+    expect(body.publicKey).toBe(keypair.publicKey());
+  });
+
+  it('returns 403 when signature is invalid', async () => {
+    const res = await POST(
+      makeRequest({
+        intentHash,
+        publicKey: keypair.publicKey(),
+        signature: Buffer.alloc(64).toString('base64'), // wrong signature
+        anchorId: 'moneygram',
+        reason: 'fraud',
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 403 when signature belongs to a different keypair', async () => {
+    const other = Keypair.random();
+    const signature = signHash(other, intentHash); // signed by wrong key
+    const res = await POST(
+      makeRequest({
+        intentHash,
+        publicKey: keypair.publicKey(),
+        signature,
+        anchorId: 'cowrie',
+        reason: 'wrong rate',
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 422 when intentHash has wrong format', async () => {
+    const res = await POST(
+      makeRequest({
+        intentHash: 'not-a-sha256',
+        publicKey: keypair.publicKey(),
+        signature: 'abc',
+        anchorId: 'moneygram',
+        reason: 'test',
+      })
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 422 when publicKey has wrong format', async () => {
+    const res = await POST(
+      makeRequest({
+        intentHash,
+        publicKey: 'not-a-stellar-key',
+        signature: 'abc',
+        anchorId: 'moneygram',
+        reason: 'test',
+      })
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 when required fields are missing', async () => {
+    const res = await POST(makeRequest({ intentHash, publicKey: keypair.publicKey() }));
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 400 for non-JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/reputation/dispute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('INVALID_JSON');
+  });
+
+  it('enforces 10-dispute-per-24h rate limit per publicKey', async () => {
+    const signature = signHash(keypair, intentHash);
+    const payload = {
+      intentHash,
+      publicKey: keypair.publicKey(),
+      signature,
+      anchorId: 'moneygram',
+      reason: 'test',
+    };
+
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(makeRequest(payload));
+      expect(res.status).toBe(201);
+    }
+
+    const limited = await POST(makeRequest(payload));
+    expect(limited.status).toBe(429);
+    const body = await limited.json();
+    expect(body.code).toBe('RATE_LIMITED');
+  });
+
+  it('allows a different publicKey after the first key is rate-limited', async () => {
+    const other = Keypair.random();
+    const sig1 = signHash(keypair, intentHash);
+    const sig2 = signHash(other, intentHash);
+    const base1 = { intentHash, publicKey: keypair.publicKey(), signature: sig1, anchorId: 'a', reason: 'r' };
+    const base2 = { intentHash, publicKey: other.publicKey(), signature: sig2, anchorId: 'a', reason: 'r' };
+
+    for (let i = 0; i < 10; i++) await POST(makeRequest(base1));
+    expect((await POST(makeRequest(base1))).status).toBe(429);
+    expect((await POST(makeRequest(base2))).status).toBe(201);
+  });
+});

--- a/tests/reputation-score.spec.ts
+++ b/tests/reputation-score.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { getScore } from '@/lib/reputation/score';
+import type { SettlementEvent } from '@/lib/reputation/aggregate';
+
+const base = new Date('2024-01-15T12:00:00Z');
+
+function makeEvent(
+  anchorId: string,
+  success: boolean,
+  settlementMs: number,
+  offsetMs = 0
+): SettlementEvent {
+  return {
+    anchorId,
+    corridor: 'usdc-ngn',
+    completedAt: new Date(base.getTime() + offsetMs),
+    settlementMs,
+    success,
+  };
+}
+
+describe('getScore', () => {
+  it('returns zeros for an anchor with no events', () => {
+    const result = getScore('unknown', []);
+    expect(result).toEqual({ total: 0, success_rate: 0, last_settle_seconds: 0 });
+  });
+
+  it('returns zeros when no events match the anchor', () => {
+    const events = [makeEvent('other-anchor', true, 30_000)];
+    expect(getScore('my-anchor', events)).toEqual({ total: 0, success_rate: 0, last_settle_seconds: 0 });
+  });
+
+  it('counts all events for the anchor', () => {
+    const events = [
+      makeEvent('alpha', true, 10_000),
+      makeEvent('alpha', false, 20_000),
+      makeEvent('alpha', true, 15_000),
+      makeEvent('beta', true, 5_000),
+    ];
+    const result = getScore('alpha', events);
+    expect(result.total).toBe(3);
+  });
+
+  it('computes correct success_rate', () => {
+    const events = [
+      makeEvent('anchor', true, 10_000),
+      makeEvent('anchor', true, 12_000),
+      makeEvent('anchor', false, 8_000),
+      makeEvent('anchor', false, 9_000),
+    ];
+    const result = getScore('anchor', events);
+    expect(result.success_rate).toBeCloseTo(0.5);
+  });
+
+  it('returns success_rate of 1 when all events succeed', () => {
+    const events = [
+      makeEvent('anchor', true, 5_000),
+      makeEvent('anchor', true, 7_000),
+    ];
+    expect(getScore('anchor', events).success_rate).toBe(1);
+  });
+
+  it('returns success_rate of 0 when all events fail', () => {
+    const events = [
+      makeEvent('anchor', false, 5_000),
+      makeEvent('anchor', false, 7_000),
+    ];
+    expect(getScore('anchor', events).success_rate).toBe(0);
+  });
+
+  it('reports last_settle_seconds from the most recent event', () => {
+    const events = [
+      makeEvent('anchor', true, 30_000, 0),       // oldest,  30s settle
+      makeEvent('anchor', true, 60_000, 5_000),    // middle,  60s settle
+      makeEvent('anchor', true, 45_000, 10_000),   // newest,  45s settle
+    ];
+    const result = getScore('anchor', events);
+    expect(result.last_settle_seconds).toBe(45);
+  });
+
+  it('converts settlementMs to seconds correctly', () => {
+    const events = [makeEvent('anchor', true, 90_000)];
+    expect(getScore('anchor', events).last_settle_seconds).toBe(90);
+  });
+
+  it('isolates events by anchorId', () => {
+    const events = [
+      makeEvent('anchor-a', true, 10_000),
+      makeEvent('anchor-b', false, 20_000),
+      makeEvent('anchor-a', false, 30_000),
+    ];
+    const a = getScore('anchor-a', events);
+    expect(a.total).toBe(2);
+    expect(a.success_rate).toBe(0.5);
+
+    const b = getScore('anchor-b', events);
+    expect(b.total).toBe(1);
+    expect(b.success_rate).toBe(0);
+  });
+
+  it('handles a single event correctly', () => {
+    const events = [makeEvent('anchor', true, 120_000)];
+    const result = getScore('anchor', events);
+    expect(result).toEqual({ total: 1, success_rate: 1, last_settle_seconds: 120 });
+  });
+});


### PR DESCRIPTION
## Summary

Implements three reputation features across the read, scoring, and dispute layers.

### get_score read entrypoint (closes #231)

`getScore(anchorId, events)` in `lib/reputation/score.ts` computes `{ total, success_rate, last_settle_seconds }` on-read from the existing `SettlementEvent[]` type. No caching or persistence — pure derivation per the v1 simplicity requirement. `last_settle_seconds` is taken from the most-recent event by `completedAt`.

### Composite score formula (closes #314)

`composite({ fillRate, slippage, settleSeconds })` in `lib/reputation/composite.ts` implements the documented formula:

  fillRate × (1 − slippage) ÷ (settleSeconds / NORM_SETTLE_SECONDS)

`NORM_SETTLE_SECONDS` (300) and `MIN_SETTLE_SECONDS` (1) are exported constants. The guard on `MIN_SETTLE_SECONDS` prevents divide-by-zero for zero-settle edge cases. A score of 1.0 means perfect fill, zero slippage, at exactly the reference settle time; values above 1 indicate faster-than-reference settlement.

### POST /api/reputation/dispute (closes #320)

`app/api/reputation/dispute/route.ts` accepts `{ intentHash, publicKey, signature, anchorId, reason }`. The handler:

- Validates the body with Zod (422 on schema failure)
- Verifies the Ed25519 proof via `Keypair.fromPublicKey(pk).verify(intentHashBytes, sigBytes)` — proving ownership of the intent without requiring the full intent payload (403 on failure)
- Enforces a per-`publicKey` sliding-window rate limit of 10 disputes per 24 h (429 on breach)
- Returns 201 with the dispute record and `disputed: true`

The in-memory store follows the same pattern as the existing admin disputes route and is structured for straightforward replacement with a database client.

## Test plan

- [ ] `npm test -- tests/reputation-score.spec.ts` — 10 tests: zero-event anchors, anchorId isolation, success_rate arithmetic, last_settle_seconds from most-recent event
- [ ] `npm test -- tests/composite.spec.ts` — 12 tests: exact fixture match against formula, monotonicity in all three axes, zero-divide guard, 1000-run finiteness property
- [ ] `npm test -- tests/dispute-api.spec.ts` — 9 tests: valid signed request, wrong signature, foreign keypair, malformed fields, missing fields, invalid JSON, rate limit exhaustion, per-key rate limit isolation
- [ ] All 31 tests pass: `npm test -- tests/reputation-score.spec.ts tests/composite.spec.ts tests/dispute-api.spec.ts`
