### PR TITLE
feat(logger): structured pino logger with correlation id

### DIFF
--- a/app/api/admin/disputes/route.ts
+++ b/app/api/admin/disputes/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isAdminRequest } from '@/lib/auth/admin';
+import { withRequestLogger } from '@/lib/logger';
 import type { ApiError } from '@/types';
 
 export type DisputeStatus = 'pending' | 'accepted' | 'rejected';
@@ -18,58 +19,69 @@ export interface Dispute {
 const store = new Map<string, Dispute>();
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  if (!isAdminRequest(request)) {
-    return NextResponse.json<ApiError>(
-      { code: 'UNAUTHORIZED', message: 'Admin access required' },
-      { status: 401 }
-    );
-  }
+  return withRequestLogger(request, 'api.admin.disputes', async (logger) => {
+    if (!isAdminRequest(request)) {
+      logger.warn({ event: 'unauthorized_access', path: request.nextUrl.pathname })
+      return NextResponse.json<ApiError>(
+        { code: 'UNAUTHORIZED', message: 'Admin access required' },
+        { status: 401 }
+      )
+    }
 
-  const disputes = Array.from(store.values()).sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+    const disputes = Array.from(store.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
 
-  return NextResponse.json(disputes);
+    logger.info({ event: 'admin_disputes_listed', count: disputes.length })
+    return NextResponse.json(disputes)
+  })
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (!isAdminRequest(request)) {
-    return NextResponse.json<ApiError>(
-      { code: 'UNAUTHORIZED', message: 'Admin access required' },
-      { status: 401 }
-    );
-  }
+  return withRequestLogger(request, 'api.admin.disputes', async (logger) => {
+    if (!isAdminRequest(request)) {
+      logger.warn({ event: 'unauthorized_access', path: request.nextUrl.pathname })
+      return NextResponse.json<ApiError>(
+        { code: 'UNAUTHORIZED', message: 'Admin access required' },
+        { status: 401 }
+      )
+    }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json<ApiError>(
-      { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
-      { status: 400 }
-    );
-  }
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      logger.warn({ event: 'invalid_json', message: 'Request body must be valid JSON' });
+      return NextResponse.json<ApiError>(
+        { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
+        { status: 400 }
+      )
+    }
 
-  const { id, action } = body as { id?: string; action?: string };
+    const { id, action } = body as { id?: string; action?: string };
 
-  if (!id || !['accept', 'reject'].includes(action ?? '')) {
-    return NextResponse.json<ApiError>(
-      { code: 'VALIDATION_ERROR', message: 'id and action (accept|reject) are required' },
-      { status: 400 }
-    );
-  }
+    if (!id || !['accept', 'reject'].includes(action ?? '')) {
+      logger.warn({ event: 'validation_failed', body })
+      return NextResponse.json<ApiError>(
+        { code: 'VALIDATION_ERROR', message: 'id and action (accept|reject) are required' },
+        { status: 400 }
+      )
+    }
 
-  const dispute = store.get(id);
-  if (!dispute) {
-    return NextResponse.json<ApiError>(
-      { code: 'NOT_FOUND', message: 'Dispute not found' },
-      { status: 404 }
-    );
-  }
+    const dispute = store.get(id);
+    if (!dispute) {
+      logger.warn({ event: 'dispute_not_found', disputeId: id })
+      return NextResponse.json<ApiError>(
+        { code: 'NOT_FOUND', message: 'Dispute not found' },
+        { status: 404 }
+      )
+    }
 
-  dispute.status = action === 'accept' ? 'accepted' : 'rejected';
-  dispute.resolvedAt = new Date().toISOString();
-  store.set(id, dispute);
+    dispute.status = action === 'accept' ? 'accepted' : 'rejected';
+    dispute.resolvedAt = new Date().toISOString();
+    store.set(id, dispute);
 
-  return NextResponse.json(dispute);
+    logger.info({ event: 'dispute_resolved', disputeId: id, action })
+    return NextResponse.json(dispute)
+  })
 }

--- a/app/api/admin/disputes/route.ts
+++ b/app/api/admin/disputes/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { id, action } = body as { id?: string; action?: string };
 
     if (!id || !['accept', 'reject'].includes(action ?? '')) {
-      logger.warn({ event: 'validation_failed', body })
+      logger.warn({ event: 'validation_failed', hasId: Boolean(id), action })
       return NextResponse.json<ApiError>(
         { code: 'VALIDATION_ERROR', message: 'id and action (accept|reject) are required' },
         { status: 400 }

--- a/app/api/intent/offramp/route.ts
+++ b/app/api/intent/offramp/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { Asset, Networks, TransactionBuilder, Operation, Memo, BASE_FEE, Account } from '@stellar/stellar-sdk'
 import { hashIntent } from '@/lib/intent/hash'
 import { USDC_ISSUER } from '@/lib/config'
+import { withRequestLogger } from '@/lib/logger'
 import type { Intent } from '@/lib/intent/hash'
 import type { ApiError } from '@/types'
 
@@ -95,70 +96,80 @@ function buildUnsignedOfframpTx(
 // ─── Route handler ────────────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json<ApiError>(
-      { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
-      { status: 400 }
-    )
-  }
+  return withRequestLogger(request, 'api.intent.offramp', async (logger) => {
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      logger.warn({ event: 'invalid_json', message: 'Request body must be valid JSON' })
+      return NextResponse.json<ApiError>(
+        { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
+        { status: 400 }
+      )
+    }
 
-  const parsed = IntentSchema.safeParse(body)
-  if (!parsed.success) {
-    const first = parsed.error.issues[0]
-    return NextResponse.json<ApiError>(
-      {
-        code: 'VALIDATION_ERROR',
-        message: first?.message ?? 'Invalid intent payload',
-      },
-      { status: 400 }
-    )
-  }
+    const parsed = IntentSchema.safeParse(body)
+    if (!parsed.success) {
+      const first = parsed.error.issues[0]
+      logger.warn({ event: 'validation_failed', issues: parsed.error.issues })
+      return NextResponse.json<ApiError>(
+        {
+          code: 'VALIDATION_ERROR',
+          message: first?.message ?? 'Invalid intent payload',
+        },
+        { status: 400 }
+      )
+    }
 
-  const intent = parsed.data as Intent
-  const route = resolveRoute(intent.sourceAsset, intent.destinationAsset)
+    const intent = parsed.data as Intent
+    const route = resolveRoute(intent.sourceAsset, intent.destinationAsset)
 
-  if (!route) {
-    return NextResponse.json<ApiError>(
-      {
-        code: 'NO_ROUTE',
-        message: `No route found for ${intent.sourceAsset} → ${intent.destinationAsset}`,
-      },
-      { status: 400 }
-    )
-  }
+    logger.info({ event: 'intent_parsed', sourceAsset: intent.sourceAsset, destinationAsset: intent.destinationAsset })
 
-  const quoteId = await hashIntent(intent)
-  const anchorEntry = ANCHOR_ROUTING[route.corridorId]
+    if (!route) {
+      logger.warn({ event: 'no_route', sourceAsset: intent.sourceAsset, destinationAsset: intent.destinationAsset })
+      return NextResponse.json<ApiError>(
+        {
+          code: 'NO_ROUTE',
+          message: `No route found for ${intent.sourceAsset} → ${intent.destinationAsset}`,
+        },
+        { status: 400 }
+      )
+    }
 
-  if (!anchorEntry) {
-    return NextResponse.json<ApiError>(
-      { code: 'NO_ROUTE', message: 'Anchor configuration missing' },
-      { status: 400 }
-    )
-  }
+    const quoteId = await hashIntent(intent)
+    const anchorEntry = ANCHOR_ROUTING[route.corridorId]
 
-  let unsignedTx: string
-  try {
-    unsignedTx = buildUnsignedOfframpTx(
-      intent.sender,
-      anchorEntry.anchorAccount,
-      intent.amount,
-      intent.sourceAsset,
-      USDC_ISSUER,
-      quoteId
-    )
-  } catch (err) {
-    return NextResponse.json<ApiError>(
-      {
-        code: 'TX_BUILD_FAILED',
-        message: err instanceof Error ? err.message : 'Failed to build transaction',
-      },
-      { status: 500 }
-    )
-  }
+    if (!anchorEntry) {
+      logger.error({ event: 'anchor_config_missing', corridorId: route.corridorId })
+      return NextResponse.json<ApiError>(
+        { code: 'NO_ROUTE', message: 'Anchor configuration missing' },
+        { status: 400 }
+      )
+    }
 
-  return NextResponse.json<OfframpIntentResponse>({ route, unsignedTx, quoteId })
+    let unsignedTx: string
+    try {
+      unsignedTx = buildUnsignedOfframpTx(
+        intent.sender,
+        anchorEntry.anchorAccount,
+        intent.amount,
+        intent.sourceAsset,
+        USDC_ISSUER,
+        quoteId
+      )
+    } catch (err) {
+      logger.error({ event: 'tx_build_failed', error: err instanceof Error ? err.message : 'Unknown error' })
+      return NextResponse.json<ApiError>(
+        {
+          code: 'TX_BUILD_FAILED',
+          message: err instanceof Error ? err.message : 'Failed to build transaction',
+        },
+        { status: 500 }
+      )
+    }
+
+    logger.info({ event: 'intent_response', corridorId: route.corridorId, quoteId })
+    return NextResponse.json<OfframpIntentResponse>({ route, unsignedTx, quoteId })
+  })
 }

--- a/app/api/mcp/ping/route.ts
+++ b/app/api/mcp/ping/route.ts
@@ -1,5 +1,9 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { withRequestLogger } from '@/lib/logger';
 
-export async function GET(): Promise<NextResponse> {
-  return NextResponse.json({ ok: true });
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return withRequestLogger(request, 'api.mcp.ping', async (logger) => {
+    logger.info({ event: 'ping' })
+    return NextResponse.json({ ok: true })
+  })
 }

--- a/app/api/reputation/[anchor]/route.ts
+++ b/app/api/reputation/[anchor]/route.ts
@@ -5,6 +5,7 @@ import {
   type SettlementEvent,
   type OutcomeRow,
 } from '@/lib/reputation/aggregate'
+import { withRequestLogger } from '@/lib/logger'
 
 // ─── In-memory stores (seed / replace with DB in a later iteration) ───────────
 
@@ -28,29 +29,33 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ anchor: string }> | { anchor: string } }
 ): Promise<NextResponse> {
-  const { anchor } = await params
+  return withRequestLogger(request, 'api.reputation.anchor', async (logger) => {
+    const { anchor } = await params
 
-  if (!anchor || typeof anchor !== 'string') {
-    return NextResponse.json({ error: 'anchor param is required' }, { status: 400 })
-  }
+    if (!anchor || typeof anchor !== 'string') {
+      logger.warn({ event: 'missing_anchor_param' })
+      return NextResponse.json({ error: 'anchor param is required' }, { status: 400 })
+    }
 
-  const corridor = new URL(request.url).searchParams.get('corridor')
+    const corridor = new URL(request.url).searchParams.get('corridor')
+    logger.info({ event: 'anchor_lookup', anchor, corridor })
 
-  if (corridor) {
-    const windows = ([7, 30, 90] as const).map((days) =>
-      computeCorridorAggregate(SAMPLE_EVENTS, anchor, corridor, days)
-    )
+    if (corridor) {
+      const windows = ([7, 30, 90] as const).map((days) =>
+        computeCorridorAggregate(SAMPLE_EVENTS, anchor, corridor, days)
+      )
+      return NextResponse.json({
+        anchorId: anchor,
+        corridor,
+        windows,
+        fetchedAt: new Date().toISOString(),
+      })
+    }
+
+    const anchorRows = outcomeStore.filter((r) => r.anchorId === anchor)
     return NextResponse.json({
       anchorId: anchor,
-      corridor,
-      windows,
-      fetchedAt: new Date().toISOString(),
+      scorecards: buildScorecards(anchorRows),
     })
-  }
-
-  const anchorRows = outcomeStore.filter((r) => r.anchorId === anchor)
-  return NextResponse.json({
-    anchorId: anchor,
-    scorecards: buildScorecards(anchorRows),
   })
 }

--- a/app/api/reputation/dispute/route.ts
+++ b/app/api/reputation/dispute/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { Keypair } from '@stellar/stellar-sdk';
+import { withRequestLogger } from '@/lib/logger';
 import type { ApiError } from '@/types';
 
 const DisputeBodySchema = z.object({
@@ -61,61 +62,70 @@ export function clearDisputeStores(): void {
 // ─── Route handler ────────────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json<ApiError>(
-      { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
-      { status: 400 }
-    );
-  }
+  return withRequestLogger(request, 'api.reputation.dispute', async (logger) => {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      logger.warn({ event: 'invalid_json', message: 'Request body must be valid JSON' });
+      return NextResponse.json<ApiError>(
+        { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
+        { status: 400 }
+      );
+    }
 
-  const parsed = DisputeBodySchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json<ApiError>(
-      { code: 'VALIDATION_ERROR', message: parsed.error.issues[0]?.message ?? 'Validation failed' },
-      { status: 422 }
-    );
-  }
+    const parsed = DisputeBodySchema.safeParse(body);
+    if (!parsed.success) {
+      logger.warn({ event: 'validation_failed', issues: parsed.error.issues });
+      return NextResponse.json<ApiError>(
+        { code: 'VALIDATION_ERROR', message: parsed.error.issues[0]?.message ?? 'Validation failed' },
+        { status: 422 }
+      );
+    }
 
-  const { intentHash, publicKey, signature, anchorId, reason } = parsed.data;
+    const { intentHash, publicKey, signature, anchorId, reason } = parsed.data;
 
-  // Verify Ed25519 proof: signature over the raw intentHash bytes
-  let valid = false;
-  try {
-    const keypair = Keypair.fromPublicKey(publicKey);
-    const messageBytes = Buffer.from(intentHash, 'hex');
-    const sigBytes = Buffer.from(signature, 'base64');
-    valid = keypair.verify(messageBytes, sigBytes);
-  } catch {
-    valid = false;
-  }
+    logger.info({ event: 'dispute_submission', anchorId, publicKey, intentHash });
 
-  if (!valid) {
-    return NextResponse.json<ApiError>(
-      { code: 'FORBIDDEN', message: 'Signature verification failed' },
-      { status: 403 }
-    );
-  }
+    // Verify Ed25519 proof: signature over the raw intentHash bytes
+    let valid = false;
+    try {
+      const keypair = Keypair.fromPublicKey(publicKey);
+      const messageBytes = Buffer.from(intentHash, 'hex');
+      const sigBytes = Buffer.from(signature, 'base64');
+      valid = keypair.verify(messageBytes, sigBytes);
+    } catch {
+      valid = false;
+    }
 
-  if (!checkDisputeRateLimit(publicKey)) {
-    return NextResponse.json<ApiError>(
-      { code: 'RATE_LIMITED', message: 'Dispute limit of 10 per 24 h exceeded' },
-      { status: 429 }
-    );
-  }
+    if (!valid) {
+      logger.warn({ event: 'signature_verification_failed', publicKey, intentHash });
+      return NextResponse.json<ApiError>(
+        { code: 'FORBIDDEN', message: 'Signature verification failed' },
+        { status: 403 }
+      );
+    }
 
-  const record: DisputeRecord = {
-    id: `${publicKey.slice(0, 8)}-${intentHash.slice(0, 8)}-${Date.now()}`,
-    intentHash,
-    publicKey,
-    anchorId,
-    reason,
-    disputed: true,
-    createdAt: new Date().toISOString(),
-  };
-  disputes.set(record.id, record);
+    if (!checkDisputeRateLimit(publicKey)) {
+      logger.warn({ event: 'rate_limited', publicKey });
+      return NextResponse.json<ApiError>(
+        { code: 'RATE_LIMITED', message: 'Dispute limit of 10 per 24 h exceeded' },
+        { status: 429 }
+      );
+    }
 
-  return NextResponse.json(record, { status: 201 });
+    const record: DisputeRecord = {
+      id: `${publicKey.slice(0, 8)}-${intentHash.slice(0, 8)}-${Date.now()}`,
+      intentHash,
+      publicKey,
+      anchorId,
+      reason,
+      disputed: true,
+      createdAt: new Date().toISOString(),
+    };
+    disputes.set(record.id, record);
+
+    logger.info({ event: 'dispute_created', disputeId: record.id });
+    return NextResponse.json(record, { status: 201 });
+  })
 }

--- a/app/api/reputation/leaderboard/route.ts
+++ b/app/api/reputation/leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { ANCHORS, CORRIDORS } from '@/constants';
+import { withRequestLogger } from '@/lib/logger';
 import type { ApiError } from '@/types';
 
 // ─── Query param schema ────────────────────────────────────────────────────────
@@ -106,46 +107,52 @@ function etagFor(corridor: string | undefined, generatedAt: string): string {
 // ─── Route handler ────────────────────────────────────────────────────────────
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const { searchParams } = request.nextUrl;
+  return withRequestLogger(request, 'api.reputation.leaderboard', async (logger) => {
+    const { searchParams } = request.nextUrl;
 
-  const rawParams = {
-    corridor: searchParams.get('corridor') ?? undefined,
-  };
+    const rawParams = {
+      corridor: searchParams.get('corridor') ?? undefined,
+    };
 
-  const parsed = LeaderboardQuerySchema.safeParse(rawParams);
-  if (!parsed.success) {
-    const first = parsed.error.issues[0];
-    return NextResponse.json<ApiError>(
-      {
-        code: 'VALIDATION_ERROR',
-        message: first?.message ?? 'Invalid query parameters',
+    const parsed = LeaderboardQuerySchema.safeParse(rawParams);
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      logger.warn({ event: 'validation_failed', issues: parsed.error.issues });
+      return NextResponse.json<ApiError>(
+        {
+          code: 'VALIDATION_ERROR',
+          message: first?.message ?? 'Invalid query parameters',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { corridor } = parsed.data;
+    logger.info({ event: 'leaderboard_requested', corridor });
+
+    const generatedAt = new Date().toISOString();
+    const leaderboard = buildLeaderboard(corridor);
+
+    const etag = etagFor(corridor, generatedAt);
+
+    // Honour conditional GET
+    if (request.headers.get('if-none-match') === etag) {
+      logger.info({ event: 'cache_hit', etag });
+      return new NextResponse(null, { status: 304, headers: { ETag: etag } });
+    }
+
+    const body: LeaderboardResponse = {
+      leaderboard,
+      corridor: corridor ?? null,
+      generatedAt,
+    };
+
+    return NextResponse.json<LeaderboardResponse>(body, {
+      status: 200,
+      headers: {
+        'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`,
+        ETag: etag,
       },
-      { status: 400 }
-    );
-  }
-
-  const { corridor } = parsed.data;
-  const generatedAt = new Date().toISOString();
-  const leaderboard = buildLeaderboard(corridor);
-
-  const etag = etagFor(corridor, generatedAt);
-
-  // Honour conditional GET
-  if (request.headers.get('if-none-match') === etag) {
-    return new NextResponse(null, { status: 304, headers: { ETag: etag } });
-  }
-
-  const body: LeaderboardResponse = {
-    leaderboard,
-    corridor: corridor ?? null,
-    generatedAt,
-  };
-
-  return NextResponse.json<LeaderboardResponse>(body, {
-    status: 200,
-    headers: {
-      'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`,
-      ETag: etag,
-    },
-  });
+    });
+  })
 }

--- a/app/api/reputation/refresh/route.ts
+++ b/app/api/reputation/refresh/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { acquireLock, releaseLock } from '@/lib/reputation/lock';
+import { withLoggerContext } from '@/lib/logger';
 
 const LOCK_KEY = 'reputation-refresh';
 const LOCK_TTL_MS = 5 * 60 * 1000;
@@ -7,25 +8,31 @@ const LOCK_TTL_MS = 5 * 60 * 1000;
 let lastRefreshAt: Date | null = null;
 
 export async function POST(): Promise<NextResponse> {
-  if (!acquireLock(LOCK_KEY, LOCK_TTL_MS)) {
-    return NextResponse.json({ error: 'Refresh already in progress' }, { status: 409 });
-  }
+  return withLoggerContext('api.reputation.refresh', async (logger) => {
+    if (!acquireLock(LOCK_KEY, LOCK_TTL_MS)) {
+      logger.warn({ event: 'refresh_conflict' })
+      return NextResponse.json({ error: 'Refresh already in progress' }, { status: 409 })
+    }
 
-  try {
-    lastRefreshAt = new Date();
-    console.info(`[reputation] aggregate refresh completed at ${lastRefreshAt.toISOString()}`); // eslint-disable-line no-console
+    try {
+      lastRefreshAt = new Date();
+      logger.info({ event: 'refresh_completed', refreshedAt: lastRefreshAt.toISOString() })
 
-    return NextResponse.json({
-      ok: true,
-      refreshedAt: lastRefreshAt.toISOString(),
-    });
-  } finally {
-    releaseLock(LOCK_KEY);
-  }
+      return NextResponse.json({
+        ok: true,
+        refreshedAt: lastRefreshAt.toISOString(),
+      })
+    } finally {
+      releaseLock(LOCK_KEY)
+    }
+  })
 }
 
 export async function GET(): Promise<NextResponse> {
-  return NextResponse.json({
-    lastRefreshAt: lastRefreshAt?.toISOString() ?? null,
-  });
+  return withLoggerContext('api.reputation.refresh', async (logger) => {
+    logger.info({ event: 'refresh_status_requested', lastRefreshAt: lastRefreshAt?.toISOString() ?? null })
+    return NextResponse.json({
+      lastRefreshAt: lastRefreshAt?.toISOString() ?? null,
+    })
+  })
 }

--- a/app/v1/public/scores/route.ts
+++ b/app/v1/public/scores/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkRateLimit } from '@/lib/api/rate-limit';
 import { computeCorridorAggregate, type SettlementEvent } from '@/lib/reputation/aggregate';
+import { withRequestLogger } from '@/lib/logger';
 
 const SAMPLE_EVENTS: SettlementEvent[] = [];
 
@@ -21,39 +22,44 @@ function buildScorePayload() {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
-    'unknown';
+  return withRequestLogger(request, 'api.public.scores', async (logger) => {
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+      request.headers.get('x-real-ip') ??
+      'unknown';
 
-  const rl = checkRateLimit(ip);
-  if (!rl.allowed) {
-    return NextResponse.json(
-      { error: 'Too many requests', retryAfter: rl.retryAfter },
-      {
-        status: 429,
-        headers: {
-          'Retry-After': String(rl.retryAfter),
-          'X-RateLimit-Remaining': '0',
-        },
-      }
-    );
-  }
+    const rl = checkRateLimit(ip);
+    if (!rl.allowed) {
+      logger.warn({ event: 'rate_limit_exceeded', ip, retryAfter: rl.retryAfter });
+      return NextResponse.json(
+        { error: 'Too many requests', retryAfter: rl.retryAfter },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rl.retryAfter),
+            'X-RateLimit-Remaining': '0',
+          },
+        }
+      );
+    }
 
-  const payload = buildScorePayload();
-  const etag = `"${Buffer.from(JSON.stringify(payload)).length}-${Date.now()}"`;
+    const payload = buildScorePayload();
+    const etag = `"${Buffer.from(JSON.stringify(payload)).length}-${Date.now()}"`;
 
-  const ifNoneMatch = request.headers.get('if-none-match');
-  if (ifNoneMatch && ifNoneMatch === lastEtag) {
-    return new NextResponse(null, { status: 304 });
-  }
-  lastEtag = etag;
+    const ifNoneMatch = request.headers.get('if-none-match');
+    if (ifNoneMatch && ifNoneMatch === lastEtag) {
+      logger.info({ event: 'cache_hit', etag });
+      return new NextResponse(null, { status: 304 });
+    }
+    lastEtag = etag;
 
-  return NextResponse.json(payload, {
-    headers: {
-      'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
-      ETag: etag,
-      'X-RateLimit-Remaining': String(rl.remaining),
-    },
-  });
+    logger.info({ event: 'scores_returned', anchorCount: payload.length });
+    return NextResponse.json(payload, {
+      headers: {
+        'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+        ETag: etag,
+        'X-RateLimit-Remaining': String(rl.remaining),
+      },
+    });
+  })
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,70 @@
+import pino from 'pino'
+import { AsyncLocalStorage } from 'async_hooks'
+import type { NextRequest, NextResponse } from 'next/server'
+
+type LoggerContext = { correlationId: string }
+
+const asyncLocalStorage = new AsyncLocalStorage<LoggerContext>()
+
+const baseLogger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  base: undefined,
+  timestamp: pino.stdTimeFunctions.isoTime,
+})
+
+function randomCorrelationId(): string {
+  if (typeof globalThis.crypto !== 'undefined' && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+export function getCorrelationId(): string | undefined {
+  return asyncLocalStorage.getStore()?.correlationId
+}
+
+export function runWithCorrelationId<T>(correlationId: string, fn: () => T): T {
+  return asyncLocalStorage.run({ correlationId }, fn)
+}
+
+export function getLogger(moduleName: string) {
+  const store = asyncLocalStorage.getStore()
+  return baseLogger.child({
+    module: moduleName,
+    ...(store?.correlationId ? { correlationId: store.correlationId } : {}),
+  })
+}
+
+export function getCorrelationIdFromRequest(request: NextRequest): string {
+  const provided = request.headers.get('x-correlation-id')?.trim()
+  return provided && provided.length > 0 ? provided : randomCorrelationId()
+}
+
+export async function withRequestLogger(
+  request: NextRequest,
+  moduleName: string,
+  fn: (logger: pino.Logger) => Promise<NextResponse>
+): Promise<NextResponse> {
+  const correlationId = getCorrelationIdFromRequest(request)
+  return runWithCorrelationId(correlationId, async () => {
+    const logger = getLogger(moduleName)
+    logger.info({ event: 'request.start', method: request.method, url: request.url })
+    const response = await fn(logger)
+    response.headers.set('x-correlation-id', correlationId)
+    return response
+  })
+}
+
+export async function withLoggerContext(
+  moduleName: string,
+  fn: (logger: pino.Logger) => Promise<NextResponse>
+): Promise<NextResponse> {
+  const correlationId = randomCorrelationId()
+  return runWithCorrelationId(correlationId, async () => {
+    const logger = getLogger(moduleName)
+    logger.info({ event: 'request.start' })
+    const response = await fn(logger)
+    response.headers.set('x-correlation-id', correlationId)
+    return response
+  })
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,6 +1,7 @@
 import pino from 'pino'
 import { AsyncLocalStorage } from 'async_hooks'
-import type { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 type LoggerContext = { correlationId: string }
 
@@ -8,7 +9,7 @@ const asyncLocalStorage = new AsyncLocalStorage<LoggerContext>()
 
 const baseLogger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
-  base: undefined,
+  base: null,
   timestamp: pino.stdTimeFunctions.isoTime,
 })
 
@@ -49,9 +50,23 @@ export async function withRequestLogger(
   return runWithCorrelationId(correlationId, async () => {
     const logger = getLogger(moduleName)
     logger.info({ event: 'request.start', method: request.method, url: request.url })
-    const response = await fn(logger)
-    response.headers.set('x-correlation-id', correlationId)
-    return response
+    try {
+      const response = await fn(logger)
+      response.headers.set('x-correlation-id', correlationId)
+      logger.info({ event: 'request.end', status: response.status })
+      return response
+    } catch (err) {
+      logger.error({
+        event: 'request.error',
+        error: err instanceof Error ? err.message : 'Unknown error',
+      })
+      const response = NextResponse.json(
+        { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+        { status: 500 }
+      )
+      response.headers.set('x-correlation-id', correlationId)
+      return response
+    }
   })
 }
 
@@ -63,8 +78,22 @@ export async function withLoggerContext(
   return runWithCorrelationId(correlationId, async () => {
     const logger = getLogger(moduleName)
     logger.info({ event: 'request.start' })
-    const response = await fn(logger)
-    response.headers.set('x-correlation-id', correlationId)
-    return response
+    try {
+      const response = await fn(logger)
+      response.headers.set('x-correlation-id', correlationId)
+      logger.info({ event: 'request.end', status: response.status })
+      return response
+    } catch (err) {
+      logger.error({
+        event: 'request.error',
+        error: err instanceof Error ? err.message : 'Unknown error',
+      })
+      const response = NextResponse.json(
+        { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+        { status: 500 }
+      )
+      response.headers.set('x-correlation-id', correlationId)
+      return response
+    }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.11.0",
         "next": "16.2.6",
+        "pino": "^9.14.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "swr": "^2.4.1",
@@ -2644,6 +2645,12 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
@@ -4864,6 +4871,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -9640,6 +9656,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9874,6 +9899,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -10059,6 +10121,22 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10167,6 +10245,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10264,6 +10348,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -10590,6 +10683,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -11042,6 +11144,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11049,6 +11160,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -11421,6 +11541,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tinybench": {
@@ -12569,6 +12698,12 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "19.2.6",
     "swr": "^2.4.1",
     "zod": "^4.3.6",
-    "pino": "^9.20.0"
+    "pino": "^9.14.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "swr": "^2.4.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "pino": "^9.20.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",

--- a/tests/logger.spec.ts
+++ b/tests/logger.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { getCorrelationId, withRequestLogger } from '@/lib/logger';
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/test', { method: 'POST', headers });
+}
+
+describe('withRequestLogger', () => {
+  it('echoes a provided x-correlation-id back on the response', async () => {
+    const res = await withRequestLogger(makeRequest({ 'x-correlation-id': 'abc-123' }), 'api.test', async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(res.headers.get('x-correlation-id')).toBe('abc-123');
+  });
+
+  it('generates a correlation id when the request omits one', async () => {
+    const res = await withRequestLogger(makeRequest(), 'api.test', async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    const id = res.headers.get('x-correlation-id');
+    expect(id).toBeTruthy();
+    expect(id?.length).toBeGreaterThan(0);
+  });
+
+  it('exposes the correlation id to the handler via AsyncLocalStorage', async () => {
+    let seen: string | undefined;
+    await withRequestLogger(makeRequest({ 'x-correlation-id': 'ctx-9' }), 'api.test', async () => {
+      seen = getCorrelationId();
+      return NextResponse.json({ ok: true });
+    });
+
+    expect(seen).toBe('ctx-9');
+  });
+
+  it('logs and returns a 500 (with correlation id) when the handler throws', async () => {
+    const res = await withRequestLogger(makeRequest({ 'x-correlation-id': 'boom-1' }), 'api.test', async () => {
+      throw new Error('handler exploded');
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('x-correlation-id')).toBe('boom-1');
+    await expect(res.json()).resolves.toMatchObject({ code: 'INTERNAL_ERROR' });
+  });
+
+  it('does not leak the correlation id outside the request scope', async () => {
+    await withRequestLogger(makeRequest({ 'x-correlation-id': 'scoped' }), 'api.test', async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(getCorrelationId()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a structured pino logger with request correlation IDs propagated via AsyncLocalStorage and echoed back on the `x-correlation-id` response header. API handlers emit structured JSON logs on validation/error/success paths.

Closes #296
Note: #297/#298/#299 (client metrics, success/error counters, per-anchor latency histogram) are NOT in this PR — they are follow-up work and were removed from the closing keywords.

Maintainer follow-up commit: corrected the pino version (`^9.20.0` → `^9.14.0`, which actually exists), added try/catch error capture in the logger wrappers, stopped logging raw request bodies, and added `tests/logger.spec.ts`.