### PR TITLE
feat: add lightweight toast portal with provider, UI component, and hook

### DIFF
--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import Toast from '@/components/ui/Toast';
+
+interface ToastItem {
+  id: string;
+  message: string;
+  type: 'info' | 'error';
+}
+
+interface ToastContextValue {
+  addToast: (message: string, type?: 'info' | 'error') => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const addToast = useCallback((message: string, type: 'info' | 'error' = 'info') => {
+    const id = `${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    // Auto‑dismiss after 5 seconds
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 5000);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <Toast toasts={toasts} onRemove={removeToast} />
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return ctx;
+};


### PR DESCRIPTION
This Pr closes #183


Implemented a reusable toast system:
- ToastContext provides `addToast` for info/error messages.
- Toast component displays a stack of toasts with auto‑dismiss (5 s) and click‑to‑dismiss.
- `useToast` hook for easy access.
- Styled with modern glass‑morphism gradients and subtle animations.
This fulfills the requirement for lightweight error/info notifications, auto‑dismissal, and correct stacking behavior.