### PR TITLE
feat(reputation): add GET /api/reputation/[anchor]/history?window end…

### DIFF
--- a/app/api/reputation/[anchor]/history/route.ts
+++ b/app/api/reputation/[anchor]/history/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { ANCHORS } from '@/constants'
+import type { ApiError } from '@/types'
+import type { OutcomeRow } from '@/lib/reputation/aggregate'
+import {
+  getHistoryBuckets,
+  HistoryResponseSchema,
+  WINDOW_VALUES,
+  type HistoryWindow,
+} from '@/lib/reputation/buckets'
+
+// ─── Shared in-memory store (mirrors [anchor]/route.ts outcomeStore) ──────────
+
+const outcomeStore: OutcomeRow[] = []
+
+/** Exposed for testing and seeding only. */
+export function _seedOutcomeStore(rows: OutcomeRow[]): void {
+  outcomeStore.length = 0
+  outcomeStore.push(...rows)
+}
+
+// ─── Query schema ─────────────────────────────────────────────────────────────
+
+const QuerySchema = z.object({
+  window: z.enum(WINDOW_VALUES).default('30d'),
+})
+
+// ─── GET /api/reputation/[anchor]/history ─────────────────────────────────────
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ anchor: string }> | { anchor: string } }
+): Promise<NextResponse> {
+  const { anchor } = await params
+
+  const knownAnchor = ANCHORS.find((a) => a.id === anchor)
+  if (!knownAnchor) {
+    return NextResponse.json<ApiError>(
+      { code: 'NOT_FOUND', message: `Unknown anchor: ${anchor}` },
+      { status: 404 }
+    )
+  }
+
+  const parsed = QuerySchema.safeParse({
+    window: request.nextUrl.searchParams.get('window') ?? undefined,
+  })
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return NextResponse.json<ApiError>(
+      { code: 'VALIDATION_ERROR', message: first?.message ?? 'Invalid window parameter' },
+      { status: 400 }
+    )
+  }
+
+  const result = getHistoryBuckets(anchor, parsed.data.window as HistoryWindow, outcomeStore)
+  return NextResponse.json(HistoryResponseSchema.parse(result))
+}

--- a/lib/reputation/buckets.ts
+++ b/lib/reputation/buckets.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { percentile, type OutcomeRow } from './aggregate'
+
+// ─── Window config ────────────────────────────────────────────────────────────
+
+export const WINDOW_VALUES = ['7d', '30d', '90d'] as const
+export type HistoryWindow = (typeof WINDOW_VALUES)[number]
+
+const BUCKET_HOURS: Record<HistoryWindow, number> = {
+  '7d': 6,
+  '30d': 24,
+  '90d': 168, // 7 * 24
+}
+
+const WINDOW_DAYS: Record<HistoryWindow, number> = { '7d': 7, '30d': 30, '90d': 90 }
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────────
+
+export const BucketSchema = z.object({
+  timestamp: z.string(), // ISO-8601 bucket start
+  fillRate: z.number(),
+  avgScore: z.number(),
+  settlementLatencyMs: z.number().nullable(),
+  sampleCount: z.number().int(),
+})
+
+export const HistoryResponseSchema = z.object({
+  anchorId: z.string(),
+  window: z.enum(WINDOW_VALUES),
+  buckets: z.array(BucketSchema),
+})
+
+export type Bucket = z.infer<typeof BucketSchema>
+export type HistoryResponse = z.infer<typeof HistoryResponseSchema>
+
+// ─── Bucket alignment ─────────────────────────────────────────────────────────
+
+function alignToBucket(tsMs: number, bucketHours: number): number {
+  const bucketMs = bucketHours * 3_600_000
+  return Math.floor(tsMs / bucketMs) * bucketMs
+}
+
+// ─── Core function ────────────────────────────────────────────────────────────
+
+export function getHistoryBuckets(
+  anchorId: string,
+  window: HistoryWindow,
+  rows: OutcomeRow[],
+  nowMs: number = Date.now(),
+): HistoryResponse {
+  const bucketHours = BUCKET_HOURS[window]
+  const bucketMs = bucketHours * 3_600_000
+  const cutoff = nowMs - WINDOW_DAYS[window] * 86_400_000
+
+  // Group rows into aligned buckets
+  const bucketMap = new Map<number, OutcomeRow[]>()
+  for (const row of rows) {
+    if (row.anchorId !== anchorId || row.recordedAt < cutoff) continue
+    const key = alignToBucket(row.recordedAt, bucketHours)
+    const list = bucketMap.get(key) ?? []
+    list.push(row)
+    bucketMap.set(key, list)
+  }
+
+  // Emit all bucket slots for the window, even empty ones
+  const startMs = alignToBucket(cutoff, bucketHours)
+  const buckets: Bucket[] = []
+
+  for (let ts = startMs; ts < nowMs; ts += bucketMs) {
+    const group = bucketMap.get(ts) ?? []
+    const sampleCount = group.length
+
+    if (sampleCount === 0) {
+      buckets.push({ timestamp: new Date(ts).toISOString(), fillRate: 0, avgScore: 0, settlementLatencyMs: null, sampleCount: 0 })
+      continue
+    }
+
+    const fillRate = group.filter((r) => r.filled).length / sampleCount
+    const settleTimes = group.map((r) => r.settleMs).filter((v): v is number => v !== null).sort((a, b) => a - b)
+    const settlementLatencyMs = settleTimes.length > 0 ? percentile(settleTimes, 50) : null
+    const slippages = group.map((r) => r.slippage).filter((v): v is number => v !== null).sort((a, b) => a - b)
+    const slippage = slippages.length > 0 ? percentile(slippages, 50) : 0
+    const speedScore = settlementLatencyMs !== null ? Math.max(0, 1 - settlementLatencyMs / 3_600_000) : 0
+    const avgScore = Math.round((fillRate * 0.7 + speedScore * 0.3 * (1 - slippage)) * 100) / 100
+
+    buckets.push({ timestamp: new Date(ts).toISOString(), fillRate, avgScore, settlementLatencyMs, sampleCount })
+  }
+
+  return { anchorId, window, buckets }
+}

--- a/tests/reputation-history.spec.ts
+++ b/tests/reputation-history.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, _seedOutcomeStore } from '@/app/api/reputation/[anchor]/history/route';
+import { getHistoryBuckets, HistoryResponseSchema } from '@/lib/reputation/buckets';
+import type { OutcomeRow } from '@/lib/reputation/aggregate';
+
+const NOW = Date.parse('2026-06-04T12:00:00.000Z');
+const hoursAgo = (h: number) => NOW - h * 3_600_000;
+
+function row(over: Partial<OutcomeRow> = {}): OutcomeRow {
+  return {
+    intentHash: Math.random().toString(16).slice(2),
+    anchorId: 'cowrie',
+    filled: true,
+    settleMs: 2_000,
+    slippage: 0.01,
+    recordedAt: hoursAgo(1),
+    ...over,
+  };
+}
+
+function historyRequest(anchor: string, window?: string): NextRequest {
+  const url = new URL(`http://localhost/api/reputation/${anchor}/history`);
+  if (window) url.searchParams.set('window', window);
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  _seedOutcomeStore([]);
+});
+
+describe('getHistoryBuckets', () => {
+  it('buckets rows within the window and reports non-trivial stats', () => {
+    const rows: OutcomeRow[] = [
+      row({ recordedAt: hoursAgo(1), filled: true, settleMs: 1_000 }),
+      row({ recordedAt: hoursAgo(2), filled: false, settleMs: null }),
+      row({ recordedAt: hoursAgo(30), filled: true, settleMs: 5_000 }),
+    ];
+
+    const result = getHistoryBuckets('cowrie', '7d', rows, NOW);
+
+    expect(result.anchorId).toBe('cowrie');
+    expect(result.window).toBe('7d');
+    expect(result.buckets.length).toBeGreaterThan(0);
+    const totalSamples = result.buckets.reduce((n, b) => n + b.sampleCount, 0);
+    expect(totalSamples).toBe(3);
+  });
+
+  it('excludes rows for other anchors and rows older than the window', () => {
+    const rows: OutcomeRow[] = [
+      row({ anchorId: 'moneygram', recordedAt: hoursAgo(1) }),
+      row({ recordedAt: hoursAgo(7 * 24 + 5) }), // older than 7d window
+    ];
+    const result = getHistoryBuckets('cowrie', '7d', rows, NOW);
+    expect(result.buckets.reduce((n, b) => n + b.sampleCount, 0)).toBe(0);
+  });
+});
+
+describe('GET /api/reputation/[anchor]/history', () => {
+  it('returns a schema-valid bucketed history for a known anchor', async () => {
+    _seedOutcomeStore([row({ recordedAt: hoursAgo(1) }), row({ recordedAt: hoursAgo(3) })]);
+
+    const res = await GET(historyRequest('cowrie', '7d'), { params: { anchor: 'cowrie' } });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(() => HistoryResponseSchema.parse(body)).not.toThrow();
+    expect(body.window).toBe('7d');
+    expect(body.buckets.reduce((n: number, b: { sampleCount: number }) => n + b.sampleCount, 0)).toBe(2);
+  });
+
+  it('defaults to the 30d window when none is supplied', async () => {
+    const res = await GET(historyRequest('cowrie'), { params: { anchor: 'cowrie' } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).window).toBe('30d');
+  });
+
+  it('404s for an unknown anchor', async () => {
+    const res = await GET(historyRequest('not-an-anchor', '7d'), {
+      params: { anchor: 'not-an-anchor' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('400s for an invalid window', async () => {
+    const res = await GET(historyRequest('cowrie', '5d'), { params: { anchor: 'cowrie' } });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
 PR Description:
  
  ## Summary
  
  Implements issue #313 — time-bucketed reputation history for an anchor.
  
  ## Changes
  
  - `lib/reputation/buckets.ts` — zod schemas (`BucketSchema`, `HistoryResponseSchema`) and `getHistoryBuckets()` function
  - `app/api/reputation/[anchor]/history/route.ts` — Next.js route handler for `GET /api/reputation/[anchor]/history?window`
  
  ## Behaviour
  
  | Window | Bucket size |
  |--------|-------------|
  | `7d`   | 6 hours     |
  | `30d`  | 24 hours    |
  | `90d`  | 7 days      |
  
  - Bucket timestamps are aligned to UTC bucket boundaries
  - Empty buckets are included (zeroed metrics, `sampleCount: 0`)
  - `?window` defaults to `30d`; invalid values return `400`
  - Unknown anchor returns `404`
  - Response is validated against `HistoryResponseSchema` before being returned
  
  ## Acceptance criteria
  
  - [x] Response parses against fixed zod schema
  - [x] Bucket alignment is stable (aligned to UTC boundaries)
  - [x] No new dependencies
  
  Closes #313