### PR TITLE
feat(metrics): intent counters, per-anchor latency histogram, client timings

### DIFF
--- a/app/api/intent/offramp/route.ts
+++ b/app/api/intent/offramp/route.ts
@@ -4,6 +4,7 @@ import { Asset, Networks, TransactionBuilder, Operation, Memo, BASE_FEE, Account
 import { hashIntent } from '@/lib/intent/hash'
 import { USDC_ISSUER } from '@/lib/config'
 import { withRequestLogger } from '@/lib/logger'
+import { recordIntentError, recordIntentSuccess } from '@/lib/metrics'
 import type { Intent } from '@/lib/intent/hash'
 import type { ApiError } from '@/types'
 
@@ -102,6 +103,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       body = await request.json()
     } catch {
       logger.warn({ event: 'invalid_json', message: 'Request body must be valid JSON' })
+      recordIntentError('INVALID_JSON')
       return NextResponse.json<ApiError>(
         { code: 'INVALID_JSON', message: 'Request body must be valid JSON' },
         { status: 400 }
@@ -112,6 +114,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!parsed.success) {
       const first = parsed.error.issues[0]
       logger.warn({ event: 'validation_failed', issues: parsed.error.issues })
+      recordIntentError('VALIDATION_ERROR')
       return NextResponse.json<ApiError>(
         {
           code: 'VALIDATION_ERROR',
@@ -128,6 +131,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (!route) {
       logger.warn({ event: 'no_route', sourceAsset: intent.sourceAsset, destinationAsset: intent.destinationAsset })
+      recordIntentError('NO_ROUTE')
       return NextResponse.json<ApiError>(
         {
           code: 'NO_ROUTE',
@@ -142,6 +146,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (!anchorEntry) {
       logger.error({ event: 'anchor_config_missing', corridorId: route.corridorId })
+      recordIntentError('NO_ROUTE')
       return NextResponse.json<ApiError>(
         { code: 'NO_ROUTE', message: 'Anchor configuration missing' },
         { status: 400 }
@@ -160,6 +165,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       )
     } catch (err) {
       logger.error({ event: 'tx_build_failed', error: err instanceof Error ? err.message : 'Unknown error' })
+      recordIntentError('TX_BUILD_FAILED')
       return NextResponse.json<ApiError>(
         {
           code: 'TX_BUILD_FAILED',
@@ -170,6 +176,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     logger.info({ event: 'intent_response', corridorId: route.corridorId, quoteId })
+    recordIntentSuccess()
     return NextResponse.json<OfframpIntentResponse>({ route, unsignedTx, quoteId })
   })
 }

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRequestLogger } from '@/lib/logger';
+import {
+  getMetricsSnapshot,
+  ingestClientSample,
+  type ClientMetricName,
+  type ClientMetricSample,
+} from '@/lib/metrics';
+import type { ApiError } from '@/types';
+
+export const runtime = 'nodejs';
+
+const CLIENT_METRIC_NAMES: ReadonlySet<ClientMetricName> = new Set([
+  'quote_fetch_latency',
+  'tx_submit_latency',
+]);
+
+function parseSample(body: unknown): ClientMetricSample | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const { name, durationMs, anchorId } = body as Record<string, unknown>;
+  if (typeof name !== 'string' || !CLIENT_METRIC_NAMES.has(name as ClientMetricName)) return null;
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs) || durationMs < 0) return null;
+  return {
+    name: name as ClientMetricName,
+    durationMs,
+    ...(typeof anchorId === 'string' && anchorId ? { anchorId } : {}),
+  };
+}
+
+/** Exposes the in-process metrics snapshot (intent counters + per-anchor p50/p95). */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return withRequestLogger(request, 'api.metrics', async (logger) => {
+    const snapshot = getMetricsSnapshot();
+    logger.info({
+      event: 'metrics_snapshot',
+      intentSuccess: snapshot.intents.success,
+      intentErrors: snapshot.intents.errorTotal,
+      anchors: Object.keys(snapshot.anchorLatency).length,
+    });
+    return NextResponse.json(snapshot);
+  });
+}
+
+/** Ingests a client-side latency sample (quote fetch / tx submit). */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withRequestLogger(request, 'api.metrics', async (logger) => {
+    const body = await request.json().catch(() => null);
+    const sample = parseSample(body);
+
+    if (!sample) {
+      logger.warn({ event: 'metrics_sample_rejected' });
+      return NextResponse.json<ApiError>(
+        { code: 'VALIDATION_ERROR', message: 'Invalid metric sample' },
+        { status: 400 }
+      );
+    }
+
+    ingestClientSample(sample);
+    logger.info({ event: 'metrics_sample', name: sample.name, anchorId: sample.anchorId });
+    return NextResponse.json({ ok: true });
+  });
+}

--- a/components/offramp/ExecuteDrawer.tsx
+++ b/components/offramp/ExecuteDrawer.tsx
@@ -4,6 +4,7 @@ import { authenticate, NetworkMismatchError } from '@/lib/stellar/sep10';
 import { initiateWithdraw, getWithdrawTransactionRecord } from '@/lib/stellar/sep24';
 import { getResolvedAnchorById } from '@/lib/stellar/anchors';
 import { buildWithdrawPayment, signAndSubmitPayment } from '@/lib/stellar/horizon';
+import { measureClient } from '@/lib/metrics';
 import type { AnchorRate, ExecuteDrawerStep } from '@/types';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { KycIframe } from './KycIframe';
@@ -225,7 +226,9 @@ function ExecuteDrawerContent({
 
       // Step 6 — Sign and submit
       setStep('signing');
-      const result = await signAndSubmitPayment(tx);
+      const result = await measureClient('tx_submit_latency', () => signAndSubmitPayment(tx), {
+        anchorId: anchor.homeDomain,
+      });
       setTxHash(result.hash ?? null);
       setStep('done');
 

--- a/hooks/useAnchorRates.ts
+++ b/hooks/useAnchorRates.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import useSWR from 'swr';
+import { measureClient } from '@/lib/metrics';
 import type { ApiRatesResponse, AnchorRate, RateComparison } from '@/types';
 
 const RATES_REFRESH_INTERVAL_MS = 30_000;
@@ -42,19 +43,25 @@ async function fetcher(
   [, corridorId, amount]: [string, string, string],
   { signal }: { signal?: AbortSignal } = {}
 ): Promise<RateComparison> {
-  const url = new URL('/api/rates', window.location.origin);
-  url.searchParams.set('corridor', corridorId);
-  url.searchParams.set('amount', amount);
+  return measureClient(
+    'quote_fetch_latency',
+    async () => {
+      const url = new URL('/api/rates', window.location.origin);
+      url.searchParams.set('corridor', corridorId);
+      url.searchParams.set('amount', amount);
 
-  const res = await fetch(url.toString(), { signal });
+      const res = await fetch(url.toString(), { signal });
 
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`);
-  }
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`);
+      }
 
-  const data: ApiRatesResponse = await res.json();
-  return data.rates;
+      const data: ApiRatesResponse = await res.json();
+      return data.rates;
+    },
+    { anchorId: corridorId }
+  );
 }
 
 export interface UseAnchorRatesResult {

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,202 @@
+// ─── In-process metrics ───────────────────────────────────────────────────────
+//
+// Lightweight, dependency-free metrics that live in the Node process:
+//   • intent success / error-by-code counters over a configurable reset window
+//     (Issue #143 / #298)
+//   • per-anchor latency samples in a bounded ring buffer, queried as p50 / p95
+//     (Issue #144 / #299)
+//
+// Plus a tiny client-side timing helper (Issue #142 / #297) that wraps the
+// Performance API and flushes a sample to GET/POST /api/metrics. All state is
+// per-instance and intentionally ephemeral — this is observability, not a store.
+
+const DEFAULT_RESET_WINDOW_MS = Number(process.env.METRICS_RESET_WINDOW_MS) || 60 * 60 * 1000;
+
+/** Hold-open ring buffer size: the last N latency samples per anchor. */
+export const MAX_SAMPLES_PER_ANCHOR = 1000;
+
+interface CounterState {
+  windowStartedAt: number;
+  windowMs: number;
+  success: number;
+  errorByCode: Map<string, number>;
+}
+
+const counters: CounterState = {
+  windowStartedAt: Date.now(),
+  windowMs: DEFAULT_RESET_WINDOW_MS,
+  success: 0,
+  errorByCode: new Map(),
+};
+
+const anchorLatencies = new Map<string, number[]>();
+
+function maybeRollWindow(now: number): void {
+  if (now - counters.windowStartedAt >= counters.windowMs) {
+    counters.windowStartedAt = now;
+    counters.success = 0;
+    counters.errorByCode.clear();
+  }
+}
+
+/** Sets the counter reset window (ms) and starts a fresh window. */
+export function configureMetricsWindow(windowMs: number, now = Date.now()): void {
+  counters.windowMs = windowMs;
+  counters.windowStartedAt = now;
+  counters.success = 0;
+  counters.errorByCode.clear();
+}
+
+export function recordIntentSuccess(now = Date.now()): void {
+  maybeRollWindow(now);
+  counters.success += 1;
+}
+
+export function recordIntentError(code: string, now = Date.now()): void {
+  maybeRollWindow(now);
+  counters.errorByCode.set(code, (counters.errorByCode.get(code) ?? 0) + 1);
+}
+
+/** Appends a latency sample (ms) for an anchor, evicting the oldest past the cap. */
+export function recordAnchorLatency(anchorId: string, latencyMs: number): void {
+  if (!anchorId || !Number.isFinite(latencyMs) || latencyMs < 0) return;
+  const samples = anchorLatencies.get(anchorId) ?? [];
+  samples.push(latencyMs);
+  if (samples.length > MAX_SAMPLES_PER_ANCHOR) samples.shift();
+  anchorLatencies.set(anchorId, samples);
+}
+
+/** Linear-interpolated percentile over an ascending-sorted array. */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0]!;
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo]!;
+  const weight = rank - lo;
+  return sorted[lo]! * (1 - weight) + sorted[hi]! * weight;
+}
+
+export interface AnchorLatencySummary {
+  count: number;
+  p50: number;
+  p95: number;
+}
+
+export interface MetricsSnapshot {
+  window: { startedAt: string; windowMs: number };
+  intents: { success: number; errorByCode: Record<string, number>; errorTotal: number };
+  anchorLatency: Record<string, AnchorLatencySummary>;
+}
+
+export function getMetricsSnapshot(now = Date.now()): MetricsSnapshot {
+  maybeRollWindow(now);
+
+  const errorByCode = Object.fromEntries(counters.errorByCode);
+  const errorTotal = [...counters.errorByCode.values()].reduce((sum, n) => sum + n, 0);
+
+  const anchorLatency: Record<string, AnchorLatencySummary> = {};
+  for (const [anchorId, samples] of anchorLatencies) {
+    const sorted = [...samples].sort((a, b) => a - b);
+    anchorLatency[anchorId] = {
+      count: sorted.length,
+      p50: Math.round(percentile(sorted, 50)),
+      p95: Math.round(percentile(sorted, 95)),
+    };
+  }
+
+  return {
+    window: {
+      startedAt: new Date(counters.windowStartedAt).toISOString(),
+      windowMs: counters.windowMs,
+    },
+    intents: { success: counters.success, errorByCode, errorTotal },
+    anchorLatency,
+  };
+}
+
+/** Clears all counters and latency buffers — primarily for tests. */
+export function resetMetrics(): void {
+  counters.windowStartedAt = Date.now();
+  counters.success = 0;
+  counters.errorByCode.clear();
+  anchorLatencies.clear();
+}
+
+// ─── Client-side timing helper (Issue #142 / #297) ────────────────────────────
+
+export type ClientMetricName = 'quote_fetch_latency' | 'tx_submit_latency';
+
+export interface ClientMetricSample {
+  name: ClientMetricName;
+  durationMs: number;
+  anchorId?: string;
+}
+
+function perf(): Performance | undefined {
+  return typeof globalThis.performance !== 'undefined' ? globalThis.performance : undefined;
+}
+
+/**
+ * Starts a timer and returns a `stop()` that records the elapsed ms, emits a
+ * `performance.measure`, flushes the sample, and returns the duration.
+ */
+export function startClientTimer(
+  name: ClientMetricName,
+  meta: { anchorId?: string } = {}
+): () => number {
+  const p = perf();
+  const startMark = `${name}:start:${Math.random().toString(16).slice(2)}`;
+  const start = p?.now() ?? Date.now();
+  p?.mark?.(startMark);
+
+  return () => {
+    const durationMs = (p?.now() ?? Date.now()) - start;
+    if (p?.measure) {
+      try {
+        p.measure(name, startMark);
+      } catch {
+        /* measure is best-effort */
+      }
+    }
+    p?.clearMarks?.(startMark);
+    void flushClientMetric({ name, durationMs, ...meta });
+    return durationMs;
+  };
+}
+
+/** Times an async operation, flushes the sample, and returns its result. */
+export async function measureClient<T>(
+  name: ClientMetricName,
+  fn: () => Promise<T>,
+  meta: { anchorId?: string } = {}
+): Promise<T> {
+  const stop = startClientTimer(name, meta);
+  try {
+    return await fn();
+  } finally {
+    stop();
+  }
+}
+
+/** POSTs a client sample to /api/metrics. No-op outside a production browser. */
+export function flushClientMetric(sample: ClientMetricSample): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (process.env.NODE_ENV !== 'production') return Promise.resolve();
+  return fetch('/api/metrics', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(sample),
+    keepalive: true,
+  })
+    .then(() => undefined)
+    .catch(() => undefined);
+}
+
+/** Records a client sample into the in-process store (called by the API route). */
+export function ingestClientSample(sample: ClientMetricSample): void {
+  if (sample.anchorId) {
+    recordAnchorLatency(sample.anchorId, sample.durationMs);
+  }
+}

--- a/tests/metrics-api.spec.ts
+++ b/tests/metrics-api.spec.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from '@/app/api/metrics/route';
+import { recordIntentSuccess, resetMetrics } from '@/lib/metrics';
+
+beforeEach(() => {
+  resetMetrics();
+});
+
+function postSample(sample: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/metrics', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(sample),
+  });
+}
+
+describe('GET /api/metrics', () => {
+  it('exposes the in-process snapshot', async () => {
+    recordIntentSuccess();
+    const res = await GET(new NextRequest('http://localhost/api/metrics'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.intents.success).toBe(1);
+    expect(body).toHaveProperty('anchorLatency');
+    expect(res.headers.get('x-correlation-id')).toBeTruthy();
+  });
+});
+
+describe('POST /api/metrics', () => {
+  it('ingests a per-anchor client sample into the histogram', async () => {
+    for (let ms = 10; ms <= 30; ms += 10) {
+      const res = await POST(postSample({ name: 'quote_fetch_latency', durationMs: ms, anchorId: 'a1' }));
+      expect(res.status).toBe(200);
+    }
+
+    const snap = await (await GET(new NextRequest('http://localhost/api/metrics'))).json();
+    expect(snap.anchorLatency.a1.count).toBe(3);
+    expect(snap.anchorLatency.a1.p50).toBe(20);
+  });
+
+  it('rejects an invalid sample', async () => {
+    const res = await POST(postSample({ name: 'bogus', durationMs: 'nope' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/metrics.spec.ts
+++ b/tests/metrics.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureMetricsWindow,
+  getMetricsSnapshot,
+  measureClient,
+  recordAnchorLatency,
+  recordIntentError,
+  recordIntentSuccess,
+  resetMetrics,
+  startClientTimer,
+  MAX_SAMPLES_PER_ANCHOR,
+} from '@/lib/metrics';
+
+beforeEach(() => {
+  resetMetrics();
+});
+
+// ─── Intent counters (#298) ────────────────────────────────────────────────────
+
+describe('intent counters', () => {
+  it('reflects correct totals after a handful of intents', () => {
+    recordIntentSuccess();
+    recordIntentSuccess();
+    recordIntentSuccess();
+    recordIntentError('NO_ROUTE');
+    recordIntentError('VALIDATION_ERROR');
+    recordIntentError('NO_ROUTE');
+
+    const snap = getMetricsSnapshot();
+    expect(snap.intents.success).toBe(3);
+    expect(snap.intents.errorTotal).toBe(3);
+    expect(snap.intents.errorByCode).toEqual({ NO_ROUTE: 2, VALIDATION_ERROR: 1 });
+  });
+
+  it('resets counters when the configured window elapses', () => {
+    const base = 1_000_000;
+    configureMetricsWindow(60_000, base);
+
+    recordIntentSuccess(base);
+    recordIntentError('NO_ROUTE', base + 1_000);
+    expect(getMetricsSnapshot(base + 2_000).intents.success).toBe(1);
+
+    // Past the window: counters roll over to a fresh window.
+    const after = getMetricsSnapshot(base + 61_000);
+    expect(after.intents.success).toBe(0);
+    expect(after.intents.errorTotal).toBe(0);
+  });
+});
+
+// ─── Per-anchor latency histogram (#299) ───────────────────────────────────────
+
+describe('per-anchor latency', () => {
+  it('returns non-trivial p50/p95 after synthetic load', () => {
+    for (let ms = 1; ms <= 100; ms++) {
+      recordAnchorLatency('cowrie.exchange', ms);
+    }
+
+    const summary = getMetricsSnapshot().anchorLatency['cowrie.exchange'];
+    expect(summary?.count).toBe(100);
+    expect(summary?.p50).toBeGreaterThanOrEqual(49);
+    expect(summary?.p50).toBeLessThanOrEqual(51);
+    expect(summary?.p95).toBeGreaterThanOrEqual(94);
+    expect(summary?.p95).toBeLessThanOrEqual(96);
+    expect(summary!.p95).toBeGreaterThan(summary!.p50);
+  });
+
+  it('holds open only the last N samples per anchor (ring buffer)', () => {
+    for (let i = 0; i < MAX_SAMPLES_PER_ANCHOR + 250; i++) {
+      recordAnchorLatency('anchor-a', i);
+    }
+    expect(getMetricsSnapshot().anchorLatency['anchor-a']?.count).toBe(MAX_SAMPLES_PER_ANCHOR);
+  });
+
+  it('ignores invalid samples', () => {
+    recordAnchorLatency('anchor-b', -5);
+    recordAnchorLatency('anchor-b', Number.NaN);
+    expect(getMetricsSnapshot().anchorLatency['anchor-b']).toBeUndefined();
+  });
+});
+
+// ─── Client timing helper (#297) ───────────────────────────────────────────────
+
+describe('client timing helper', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('measures elapsed quote-fetch latency', () => {
+    let clock = 1_000;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+
+    const stop = startClientTimer('quote_fetch_latency', { anchorId: 'usdc-ngn' });
+    clock = 1_137;
+    expect(stop()).toBe(137);
+  });
+
+  it('measures tx submit latency around an async op and returns its result', async () => {
+    let clock = 5_000;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+
+    const result = await measureClient('tx_submit_latency', async () => {
+      clock = 5_420;
+      return 'tx-hash';
+    });
+
+    expect(result).toBe('tx-hash');
+  });
+});


### PR DESCRIPTION
Implements the v1.3 observability metrics that #381 claimed but did not deliver (that PR shipped only the structured logger, #296).

## Changes
- `lib/metrics.ts` — in-process intent success / error-by-code counters over a configurable reset window (#298); per-anchor latency ring buffer (last 1k samples) queried as p50/p95 (#299); a client timing helper wrapping the Performance API, flushing to `/api/metrics` and no-op outside a production browser (#297).
- `app/api/metrics/route.ts` — `GET` exposes the snapshot; `POST` ingests client samples (wrapped in `withRequestLogger`).
- `app/api/intent/offramp/route.ts` — records success / error-by-code on every terminal path.
- `hooks/useAnchorRates.ts`, `components/offramp/ExecuteDrawer.tsx` — measure quote-fetch and tx-submit latency.

## Tests
- `tests/metrics.spec.ts`, `tests/metrics-api.spec.ts` — counters/window reset, p50/p95 after synthetic load, ring-buffer cap, client timer, and GET/POST route contract. All green.

Closes #297
Closes #298
Closes #299