### PR TITLE
chore(ci): drop example issue numbers from PR template + enforce one-issue-per-PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,12 @@ symbols with file_path:line_number when it helps.
 Example:
   - `lib/stellar/sep10.ts:54` — assert mainnet network passphrase at parse time
   - `components/offramp/ExecuteDrawer.tsx` — propagate `{ transactionId, jwt }`
-    to the page on success so `StatusTracker` mounts (fixes #002)
+    to the page on success so `StatusTracker` mounts (fixes the
+    StatusTracker-never-mounts bug)
+
+NOTE: never leave an example issue number here or in the "Closes #" line
+above. A closing keyword (Closes/Fixes/Resolves #N) auto-closes that exact
+issue on merge — only ever reference the one real issue your PR resolves.
 -->
 
 -
@@ -113,7 +118,7 @@ merge a PR with an unaddressed box.
 
 **Data integrity**
 
-- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see [`issue.md #005`](../issue.md))
+- [ ] No fabricated rates, stub prices, or placeholder exchange rates (see the no-fabricated-rates rule in [`issue.md`](../issue.md))
 - [ ] No `isMock`, `// MOCK`, `// TODO: replace with real data`, or commented-out real code
 - [ ] If touching an anchor: the anchor's `stellar.toml` is publicly resolvable at `https://{domain}/.well-known/stellar.toml` and contains `TRANSFER_SERVER_SEP0024`
 - [ ] If touching SEP-10: network passphrase assertion is intact (mainnet only)

--- a/.github/workflows/one-issue-per-pr.yml
+++ b/.github/workflows/one-issue-per-pr.yml
@@ -1,0 +1,40 @@
+name: one-issue-per-pr
+
+# Enforces "one PR per issue": a pull request may carry at most one closing
+# keyword (Closes / Fixes / Resolves #N). Closing keywords auto-close the
+# referenced issue on merge, so several of them in one PR silently closes
+# issues the PR never actually implemented.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  closing-keywords:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce a single closing keyword
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          mapfile -t issues < <(
+            printf '%s' "$BODY" \
+              | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+              | grep -oE '#[0-9]+' \
+              | sort -u
+          )
+          count=${#issues[@]}
+          echo "Closing-keyword issues: ${issues[*]:-none} (count=$count)"
+
+          if [ "$count" -gt 1 ]; then
+            echo "::error::This PR closes $count issues (${issues[*]}). Open one PR per issue and keep a single Closes/Fixes/Resolves #N keyword; reference the others without a closing keyword if needed."
+            exit 1
+          fi
+
+          if [ "$count" -eq 0 ]; then
+            echo "::warning::No closing keyword found. Link the issue this PR resolves with 'Closes #N' (or state in the body why none applies)."
+          fi


### PR DESCRIPTION
Two process fixes surfaced by the 23-PR review:

1. **PR template** — removed the live `fixes #002` closing keyword from the Changes example and the bare `#005` auto-link. These boilerplate numbers were being copied into PR bodies, auto-closing unrelated issues on merge. Added a note not to leave example issue numbers in `Closes #`.
2. **`one-issue-per-pr` workflow** — fails any PR whose body carries more than one closing keyword (Closes/Fixes/Resolves #N), which is exactly how PRs like #390 silently closed 4 issues while implementing 1.

No closing keyword (this is a chore).